### PR TITLE
Removing coveralls and updating our gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'coveralls', require: false
   gem 'database_cleaner'
   gem 'launchy'
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
-    autoprefixer-rails (9.6.4)
+    autoprefixer-rails (9.6.5)
       execjs
     better_errors (2.5.1)
       coderay (>= 1.0.0)
@@ -108,13 +108,7 @@ GEM
     coderay (1.1.2)
     colorize (0.8.1)
     concurrent-ruby (1.1.5)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
-    crass (1.0.4)
+    crass (1.0.5)
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
     deprecation (1.0.0)
@@ -276,7 +270,7 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    rubocop (0.75.0)
+    rubocop (0.75.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
@@ -322,7 +316,7 @@ GEM
     sexp_processor (4.13.0)
     shoulda-matchers (3.1.3)
       activesupport (>= 4.0.0)
-    simplecov (0.16.1)
+    simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -344,12 +338,9 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tins (1.21.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
@@ -386,7 +377,6 @@ DEPENDENCIES
   bootstrap (~> 4.0)
   byebug
   capybara
-  coveralls
   database_cleaner
   figaro
   flog


### PR DESCRIPTION
Coveralls is no longer needed since we're using Code Climate's service instead of Coveralls to check test coverage.