### PR TITLE
Ensure that published versions cannot be deleted

### DIFF
--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -138,6 +138,10 @@ class WorkVersion < ApplicationRecord
 
   after_save :perform_update_index
 
+  before_destroy do
+    raise ArgumentError, 'cannot delete published versions' if published?
+  end
+
   aasm do
     state :draft, intial: true
     state :published, :withdrawn, :removed

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -379,6 +379,28 @@ RSpec.describe WorkVersion, type: :model do
     end
   end
 
+  describe '#destroy' do
+    context 'with a published version' do
+      let(:work_version) { create(:work_version, :published) }
+
+      it 'raises an error' do
+        expect {
+          work_version.destroy
+        }.to raise_error(ArgumentError, 'cannot delete published versions')
+      end
+    end
+
+    context 'with a draft version' do
+      let(:work_version) { create(:work_version, :draft) }
+
+      it 'deletes the version' do
+        expect {
+          work_version.destroy
+        }.to change(described_class, :count).by(1)
+      end
+    end
+  end
+
   describe WorkVersion::Licenses do
     let(:active_license) do
       {


### PR DESCRIPTION
This expressly forbids deleting published versions. In the future, they should be moved to a withdrawn state where calls to #destroy can proceed according to different policies.

Fixes #598 