### PR TITLE
Display editable works in user's dashboard

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -3,8 +3,10 @@
 class ApplicationPolicy
   attr_reader :user, :record
 
+  # @param [User, UserDecorator] user
+  # @param [ActiveRecord::Base] record
   def initialize(user, record)
-    @user = user
+    @user = user.try(:__getobj__) || user
     @record = record
   end
 

--- a/app/schemas/permissions_schema.rb
+++ b/app/schemas/permissions_schema.rb
@@ -1,12 +1,19 @@
 # frozen_string_literal: true
 
 class PermissionsSchema < BaseSchema
-  delegate :discover_users, :discover_groups, :visibility, to: :resource
+  delegate :discover_users, :discover_groups,
+           :read_users, :read_groups,
+           :edit_users, :edit_groups,
+           :visibility, to: :resource
 
   def document
     {
       discover_users_ssim: discover_users.map(&:access_id).uniq,
       discover_groups_ssim: discover_groups.map(&:name).uniq,
+      read_users_ssim: read_users.map(&:access_id).uniq,
+      read_groups_ssim: read_groups.map(&:name).uniq,
+      edit_users_ssim: edit_users.map(&:access_id).uniq,
+      edit_groups_ssim: edit_groups.map(&:name).uniq,
       visibility_ssi: visibility
     }
   end

--- a/app/views/dashboard/catalog/index.html.erb
+++ b/app/views/dashboard/catalog/index.html.erb
@@ -16,7 +16,7 @@
 <div class="container-fluid">
   <h1 class="sr-only"><%= t('blacklight.search.header') %></h1>
 
-  <%- if current_user.works.empty? %>
+  <%- if current_user.works.empty? && @response.empty? %>
     <%= render 'home' %>
   <%- else %>
     <%= render 'search_results' %>

--- a/spec/features/dashboard/catalog_spec.rb
+++ b/spec/features/dashboard/catalog_spec.rb
@@ -55,6 +55,25 @@ RSpec.describe 'Dashboard catalog page', :inline_jobs do
     end
   end
 
+  context 'when the user has only editable works, and none that they own or have deposited' do
+    let!(:restricted_work) { create(:work, has_draft: true, depositor: outsider.actor) }
+    let!(:editable_work) { create(:work, has_draft: true, depositor: outsider.actor, edit_users: [user]) }
+
+    it "displays the user's editable works", with_user: :user do
+      visit(dashboard_root_path)
+
+      expect(user.actor.deposited_works).to be_empty
+      expect(page).to have_link('Dashboard', class: 'disabled')
+      expect(page).not_to have_text('What is my dashboard?')
+      expect(page).not_to have_text('Get Started')
+
+      expect(page.first('.card-title').text).to eq(editable_work.versions.first.title)
+      expect(page).not_to have_text(restricted_work.versions.first.title)
+      click_link(editable_work.versions.first.title)
+      expect(page).to have_link('Edit V1')
+    end
+  end
+
   context "when the user's search returns no results" do
     before { create(:work, depositor: user.actor, has_draft: true) }
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -205,6 +205,8 @@ RSpec.describe Collection, type: :model do
         discover_users_ssim
         display_work_type_ssi
         doi_tesim
+        edit_groups_ssim
+        edit_users_ssim
         id
         identifier_tesim
         keyword_sim
@@ -214,6 +216,8 @@ RSpec.describe Collection, type: :model do
         published_date_dtrsi
         published_date_tesim
         publisher_tesim
+        read_groups_ssim
+        read_users_ssim
         related_url_tesim
         source_tesim
         subject_sim

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -267,10 +267,14 @@ RSpec.describe Work, type: :model do
           discover_users_ssim
           display_work_type_ssi
           doi_tesim
+          edit_groups_ssim
+          edit_users_ssim
           embargoed_until_dtsi
           id
           model_ssi
           proxy_id_isi
+          read_groups_ssim
+          read_users_ssim
           updated_at_dtsi
           uuid_ssi
           visibility_ssi
@@ -301,6 +305,8 @@ RSpec.describe Work, type: :model do
           discover_users_ssim
           display_work_type_ssi
           doi_tesim
+          edit_groups_ssim
+          edit_users_ssim
           embargoed_until_dtsi
           id
           identifier_tesim
@@ -312,6 +318,8 @@ RSpec.describe Work, type: :model do
           published_date_dtrsi
           published_date_tesim
           publisher_tesim
+          read_groups_ssim
+          read_users_ssim
           related_url_tesim
           rights_tesim
           source_tesim

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -21,6 +21,22 @@ RSpec.describe ApplicationPolicy, type: :policy do
     end
   end
 
+  describe '::initialize' do
+    subject { described_class.new(user, record) }
+
+    context 'with a User' do
+      let(:user) { build(:user) }
+
+      its(:user) { is_expected.to be_a(User) }
+    end
+
+    context 'with a UserDecorator' do
+      let(:user) { UserDecorator.new(build(:user)) }
+
+      its(:user) { is_expected.to be_a(User) }
+    end
+  end
+
   describe ApplicationPolicy::Scope do
     it 'raises an error if #limit is not defined' do
       expect {


### PR DESCRIPTION
The user's dashboard was not displaying work versions that the user had edit access to via ACLs. This was because edit permissions were not correctly indexed into the Solr record.

This fixes the above issue by adding both edit and read permissions to the PermissionsSchema, which in turn indexes these permissions in works, work versions, and collections.

Additionally, another bug was discovered when trying to actually edit these resources. The ACLs cannot be matched against UserDecorator objects. The ApplicationPolicy was updated to cast any decorated user records to their ActiveRecord source.

Fixes #589 