### PR TITLE
🐞 Resource page uses newly refactored WorkVersionPolicy#new? method

### DIFF
--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -17,7 +17,7 @@
 
     <li class="nav-item">
       <%= render LinkDisabledByTooltipComponent.new(
-            enabled: policy(work_version).new?(work_version.work.latest_version),
+            enabled: policy(work_version).new?,
             text: I18n.t('resources.create_button.text', version: work_version.display_version_short),
             path: dashboard_work_work_versions_path(work_version.work),
             method: :post,


### PR DESCRIPTION
We had a git branching/rebasing calamity with PR #634 and #633 which caused master to break CI. This fixes it