### PR TITLE
Migrate statistics via ImportStatisticsJob

### DIFF
--- a/app/jobs/import_statistics_job.rb
+++ b/app/jobs/import_statistics_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ImportStatisticsJob < ApplicationJob
+  ImportStatistic = Struct.new(:pid, :timestamp, :views)
+
+  queue_as :statistics
+
+  def perform(row)
+    import_stat = ImportStatistic.new(*row)
+    id = LegacyIdentifier.find_by(old_id: import_stat.pid)
+    return if id.nil?
+
+    resource = id.resource
+
+    if resource.is_a?(Work)
+      work_version = resource.latest_published_version
+      return if work_version.nil?
+
+      work_version.view_statistics.find_or_create_by(date: import_stat.timestamp, count: import_stat.views)
+    else
+      resource.view_statistics.find_or_create_by(date: import_stat.timestamp, count: import_stat.views)
+    end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,6 +2,7 @@
 :max_retries: <%= ENV.fetch("SIDEKIQ_MAX_RETRIES", 2) %>
 :queues:
   - doi
-  - shrine
-  - mailers
   - indexing
+  - mailers
+  - shrine
+  - statistics

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -3,26 +3,11 @@
 require 'csv'
 
 namespace :migration do
-  ImportStatistic = Struct.new(:pid, :timestamp, :views)
-
   desc 'Import statistics from Scholarsphere 3'
   task :statistics, [:file] => :environment do |_task, args|
     path = Rails.root.join(args[:file])
     CSV.foreach(path) do |row|
-      import_stat = ImportStatistic.new(*row)
-      id = LegacyIdentifier.find_by(old_id: import_stat.pid)
-      next if id.nil?
-
-      resource = id.resource
-
-      if resource.is_a?(Work)
-        work_version = resource.latest_published_version
-        next if work_version.nil?
-
-        work_version.view_statistics.find_or_create_by(date: import_stat.timestamp, count: import_stat.views)
-      else
-        resource.view_statistics.find_or_create_by(date: import_stat.timestamp, count: import_stat.views)
-      end
+      ImportStatisticsJob.perform_later(row)
     end
   end
 end

--- a/spec/jobs/import_statistics_job_spec.rb
+++ b/spec/jobs/import_statistics_job_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ImportStatisticsJob, type: :job do
+  describe '#perform' do
+    def import_from_csv
+      csv = Pathname.new(fixture_path).join('s3_export_stats.csv')
+
+      CSV.foreach(csv) do |row|
+        described_class.perform_now(row)
+      end
+    end
+
+    context 'when the work is published' do
+      before { create(:legacy_identifier, old_id: 'tb09j581r', resource: create(:work, has_draft: false)) }
+
+      it 'imports view statistics from Scholarsphere 3' do
+        expect {
+          import_from_csv
+        }.to change(ViewStatistic, :count).by(4)
+      end
+    end
+
+    context 'when the work is not published' do
+      before { create(:legacy_identifier, old_id: 'tb09j581r', resource: create(:work, has_draft: true)) }
+
+      it 'imports view statistics from Scholarsphere 3' do
+        expect {
+          import_from_csv
+        }.not_to change(ViewStatistic, :count)
+      end
+    end
+
+    context 'with files' do
+      before { create(:legacy_identifier, :with_file, old_id: 'rxw42n8719') }
+
+      it 'imports view statistics from Scholarsphere 3' do
+        expect {
+          import_from_csv
+        }.to change(ViewStatistic, :count).by(3)
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/migration_spec.rb
+++ b/spec/lib/tasks/migration_spec.rb
@@ -3,39 +3,14 @@
 require 'rails_helper'
 
 describe 'migration' do
-  after { Rake::Task['migration:statistics'].reenable }
-
   describe ':statistics' do
     let(:csv) { Pathname.new(fixture_path).join('s3_export_stats.csv') }
 
-    context 'when the work is published' do
-      before { create(:legacy_identifier, old_id: 'tb09j581r', resource: create(:work, has_draft: false)) }
+    before { allow(ImportStatisticsJob).to receive(:perform_later) }
 
-      it 'imports view statistics from Scholarsphere 3' do
-        expect {
-          Rake::Task['migration:statistics'].invoke(csv)
-        }.to change(ViewStatistic, :count).by(4)
-      end
-    end
-
-    context 'when the work is not published' do
-      before { create(:legacy_identifier, old_id: 'tb09j581r', resource: create(:work, has_draft: true)) }
-
-      it 'imports view statistics from Scholarsphere 3' do
-        expect {
-          Rake::Task['migration:statistics'].invoke(csv)
-        }.not_to change(ViewStatistic, :count)
-      end
-    end
-
-    context 'with files' do
-      before { create(:legacy_identifier, :with_file, old_id: 'rxw42n8719') }
-
-      it 'imports view statistics from Scholarsphere 3' do
-        expect {
-          Rake::Task['migration:statistics'].invoke(csv)
-        }.to change(ViewStatistic, :count).by(3)
-      end
+    it 'calls the ImportStatisticsJob' do
+      Rake::Task['migration:statistics'].invoke(csv)
+      expect(ImportStatisticsJob).to have_received(:perform_later).exactly(8).times
     end
   end
 end


### PR DESCRIPTION
Migrating statistics from Scholarsphere 3 is a time-intensive task and will need to be run repeatedly. This extracts our current rake task into multiple jobs which can be run asynchronously via Sidekiq.

Fixes #641 