### PR TITLE
Display the visibility badge on the resource page

### DIFF
--- a/app/components/work_version_metadata_component.rb
+++ b/app/components/work_version_metadata_component.rb
@@ -9,6 +9,7 @@ class WorkVersionMetadataComponent < ApplicationComponent
   ATTRIBUTES = [
     :title,
     :subtitle,
+    :visibility_badge,
     :creator_aliases,
     :version_number,
     :keyword,

--- a/app/decorators/resource_decorator.rb
+++ b/app/decorators/resource_decorator.rb
@@ -29,4 +29,11 @@ class ResourceDecorator < SimpleDelegator
   def display_doi
     MintableDoiComponent.new(resource: resource_with_doi)
   end
+
+  # @note These are only displayed via the WorkVersion
+  def visibility_badge
+    return unless respond_to?(:work)
+
+    VisibilityBadgeComponent.new(work: work)
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
         display_work_type: Work Type
         display_doi: DOI
         file_resources: Files
+        visibility_badge: Access
       user:
         admin_enabled: Administrative privileges enabled
     errors:

--- a/spec/components/work_version_metadata_component_spec.rb
+++ b/spec/components/work_version_metadata_component_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
       # Titles
       expect(result.css('th.work-version-title')).to be_present
       expect(result.css('th.work-version-subtitle')).to be_present
+      expect(result.css('th.work-version-visibility-badge')).to be_present
       expect(result.css('th.work-version-version-number')).to be_present
       expect(result.css('th.work-version-keyword')).to be_present
       expect(result.css('th.work-version-rights')).to be_present

--- a/spec/decorators/resource_decorator_spec.rb
+++ b/spec/decorators/resource_decorator_spec.rb
@@ -117,4 +117,18 @@ RSpec.describe ResourceDecorator do
       expect(MintableDoiComponent).to have_received(:new).with(resource: resource)
     end
   end
+
+  describe '#visibility_badge' do
+    context 'with a WorkVersion' do
+      let(:resource) { build_stubbed :work_version }
+
+      its(:visibility_badge) { is_expected.to be_a(VisibilityBadgeComponent) }
+    end
+
+    context 'with a Work' do
+      let(:resource) { build_stubbed :work }
+
+      its(:visibility_badge) { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
Also renames the label to be "Access" because the term visibility is poorly understood.

Fixes #597 

![Screen Shot 2020-10-29 at 10 29 54 AM](https://user-images.githubusercontent.com/312085/97588028-71eb3a80-19d2-11eb-86ef-24c31af419cf.png)
