### PR TITLE
List a work's collections in the resource page

### DIFF
--- a/app/javascript/frontend/styles/_common.scss
+++ b/app/javascript/frontend/styles/_common.scss
@@ -681,7 +681,8 @@ h4,
   }
 }
 
-.file-card {
+.file-card,
+.collection-card {
   margin: 0 auto;
   padding: 0;
   list-style-type: none;

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -66,7 +66,9 @@
       <div class="keyline keyline--left mb-3">
         <h2 class="h4"><%= t 'resources.collections' %></h2>
       </div>
-      <p><%= t 'resources.not_in_collections' %></p>
+
+      <%= render 'shared/work_version_collections', collections: work_version.work.collections %>
+
     </div>
   </article>
 

--- a/app/views/shared/_work_version_collections.html.erb
+++ b/app/views/shared/_work_version_collections.html.erb
@@ -1,0 +1,22 @@
+<% if collections.empty? %>
+
+  <p><%= t 'resources.not_in_collections' %></p>
+
+<% else %>
+
+  <ul class="collection-card">
+    <% collections.each do |collection| %>
+      <li class="collection-card__item">
+        <div class="file-card__content">
+          <h3>
+          <%= link_to collection.title, resource_path(collection.uuid) %>
+          </h3>
+          <p class="meta mb-0">
+            <span class="meta__date"><%= collection.deposited_at.to_s(:short_date) %></span>
+          </p>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -346,7 +346,7 @@ en:
     download: "Download %{name}"
     files: Files
     metadata: Metadata
-    not_in_collections: 'This Work is not currently in any collections. TODO: we need to make the collection functionality actually work.'
+    not_in_collections: 'This resource is currently not in any collection.'
     old_version:
       link: View the current version.
       message: This is an older version of the work.

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -83,6 +83,17 @@ RSpec.describe 'Public Resources', type: :feature do
         end
       end
     end
+
+    context 'when the work is present in a collection' do
+      let(:collection) { create(:collection) }
+      let(:work) { create(:work, has_draft: false, collections: [collection]) }
+
+      it 'displays information about the collection' do
+        visit resource_path(work.uuid)
+
+        expect(page).to have_link(collection.title)
+      end
+    end
   end
 
   describe 'given a collection without a DOI' do


### PR DESCRIPTION
Provides a very simple listing of the collections that contain a given work. This is only to provide basic feature parity between v. 3 and v. 4 and should be augmented/changed in future releases.

![Screen Shot 2020-10-29 at 11 36 53 AM](https://user-images.githubusercontent.com/312085/97596782-7831e480-19db-11eb-8751-23793689044d.png)
