### PR TITLE
Define /authorities/search/users endpoint

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,7 @@ module Scholarsphere
     require 'scholarsphere/solr_config'
     require 'json_log_formatter'
     require 'qa/authorities/persons'
+    require 'qa/authorities/users'
 
     config.generators { |generator| generator.test_framework :rspec }
     # Initialize configuration defaults for originally generated Rails version.

--- a/lib/qa/authorities/users.rb
+++ b/lib/qa/authorities/users.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# @abstract This duplicates Qa::Authorities::Persons with the only difference being only Penn State users are returned
+# in a search. An alternative implementation would be to define this as a subauthority of Persons, but this just seems
+# easier.
+module Qa
+  module Authorities
+    class Users < Persons
+      private
+
+        # @return Array<PennState::SearchService::Person>
+        def persons
+          identities
+        end
+    end
+  end
+end

--- a/spec/lib/qa/authorities/users_spec.rb
+++ b/spec/lib/qa/authorities/users_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Qa::Authorities::Users, type: :authority do
+  let(:authority) { described_class.new }
+  let(:mock_client) { instance_spy('PennState::SearchService::Client') }
+
+  describe '#search' do
+    subject(:results) { authority.search(search_term) }
+
+    before do
+      allow(PennState::SearchService::Client).to receive(:new).and_return(mock_client)
+      allow(mock_client).to receive(:search).and_return(mock_identity_response)
+    end
+
+    let(:formatted_result) do
+      {
+        given_name: person.given_name,
+        surname: person.surname,
+        psu_id: person.user_id,
+        default_alias: person.display_name,
+        email: person.university_email,
+        orcid: '',
+        source: 'penn state',
+        result_number: 1,
+        total_results: 1,
+        additional_metadata: "#{Actor.human_attribute_name(:psu_id)}: #{person.user_id}"
+      }
+    end
+
+    let(:mock_identity_response) { [person] }
+    let(:person) { build(:person) }
+    let(:search_term) { 'search query' }
+
+    it { is_expected.to include(formatted_result) }
+  end
+end


### PR DESCRIPTION
Uses Penn State's identity service to search for users that can be granted edit access.

Related to #277  