### PR TITLE
Administrator menu

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -3,6 +3,7 @@
 class UserDecorator < SimpleDelegator
   def display_name
     return I18n.t('navbar.guest_name') if guest?
+    return I18n.t('navbar.admin_name') if admin?
 
     "#{name} (#{access_id})"
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,11 +12,11 @@ module ApplicationHelper
       .to_formatted_s(:long)
   end
 
-  def link_to_dropdown_item(link, path)
+  def link_to_dropdown_item(link, path, options = {})
     if request.path == path
-      link_to link, path, class: 'dropdown-item disabled'
+      link_to link, path, options.merge(class: 'dropdown-item disabled')
     else
-      link_to link, path, class: 'dropdown-item'
+      link_to link, path, options.merge(class: 'dropdown-item')
     end
   end
 

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -20,6 +20,11 @@
       <%= link_to_dropdown_item('Profile', edit_dashboard_profile_path) %>
       <%= link_to_dropdown_item('Dashboard', dashboard_root_path) %>
       <%= link_to_dropdown_item('Create New Work', dashboard_work_form_new_path) %>
+      <% if current_user.admin? %>
+        <div class="dropdown-divider"></div>
+        <%= link_to_dropdown_item('Sidekiq', admin_sidekiq_web_path, target: :_blank) %>
+        <%= link_to_dropdown_item('Health Checks', '/health/all.json', target: :_blank) %>
+      <% end %>
       <div class="dropdown-divider"></div>
       <%= link_to_dropdown_item('Logout', destroy_user_session_path) %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -334,6 +334,7 @@ en:
       icon: "\u00D7"
   navbar:
     guest_name: 'Guest'
+    admin_name: 'Administrator'
     heading:
       about: 'About'
       dashboard: 'Your Dashboard'

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -21,11 +21,21 @@ RSpec.describe UserDecorator do
     context 'when user is not a guest' do
       before do
         allow(user).to receive(:guest?).and_return(false)
+        allow(user).to receive(:admin?).and_return(false)
         allow(user).to receive(:name).and_return('Pat Developer')
         allow(user).to receive(:access_id).and_return('pd123')
       end
 
       its(:display_name) { is_expected.to eq 'Pat Developer (pd123)' }
+    end
+
+    context 'when the user is an admin' do
+      before do
+        allow(user).to receive(:guest?).and_return(false)
+        allow(user).to receive(:admin?).and_return(true)
+      end
+
+      its(:display_name) { is_expected.to eq I18n.t('navbar.admin_name') }
     end
   end
 end

--- a/spec/features/dashboard/profile_spec.rb
+++ b/spec/features/dashboard/profile_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe 'Profile', type: :feature, with_user: :user do
 
     it 'offers the option to enable admin privileges' do
       visit edit_dashboard_profile_path
+      within('#topbar') do
+        expect(page).to have_content(I18n.t('navbar.admin_name'))
+        expect(page).to have_link('Sidekiq')
+        expect(page).to have_link('Health Checks')
+      end
       expect(page).to have_content('Edit Profile')
       expect(page).to have_field('Administrative privileges enabled', checked: true)
       uncheck('Administrative privileges enabled')
@@ -56,6 +61,11 @@ RSpec.describe 'Profile', type: :feature, with_user: :user do
       expect(user.admin_enabled).to be(false)
       expect(page).to have_content(I18n.t('navbar.heading.dashboard'))
       expect(page).to have_content(I18n.t('dashboard.profiles.update.success'))
+      within('#topbar') do
+        expect(page).to have_content(user.access_id)
+        expect(page).not_to have_link('Sidekiq')
+        expect(page).not_to have_link('Health Checks')
+      end
     end
   end
 end


### PR DESCRIPTION
When a user has engaged their admin privileges, we change up the user navbar to indicate that, and toss in a few helpful urls.

![Screen Shot 2020-10-29 at 1 59 12 PM](https://user-images.githubusercontent.com/312085/97614315-2b0c3d80-19f0-11eb-95c0-fd8ed83390b3.png)

Fixes #642 
