### PR TITLE
udpates for anticipated branch change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,13 +90,14 @@ workflows:
           filters:
             branches:
               only:
-                - /^((?!preview|master).)*$/
+                - /^((?!preview|master|main).)*$/
       - test:
           name: test-publish
           publish: true
           filters:
             branches:
               only:
+                - main
                 - master
                 - /preview\/.*/
       - deploy:
@@ -106,6 +107,7 @@ workflows:
           filters:
             branches:
               only:
+                - main
                 - master
       - deploy:
           config_env: dev


### PR DESCRIPTION
gets CI ready for switching default branch. this CI config treats master and main as equal. once default is changed we can remove references to master. 

related to #653 