### PR TITLE
Preview/dast

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -19,6 +19,7 @@
     var _paq = window._paq || [];
     /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
     _paq.push(['trackPageView']);
+    _paq.push(['setSecureCookie', true]);
     _paq.push(['enableLinkTracking']);
     (function() {
       var u = "<%= ENV.fetch('MATOMO_URL', 'https://analytics.libraries.psu.edu/matomo/') %>";

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -19,6 +19,7 @@
       var _paq = window._paq || [];
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       _paq.push(['trackPageView']);
+      _paq.push(['setSecureCookie', true]);
       _paq.push(['enableLinkTracking']);
       (function() {
         var u = "<%= ENV.fetch('MATOMO_URL', 'https://analytics.libraries.psu.edu/matomo/') %>";

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,6 +3,8 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  config.session_store :cookie_store, httponly: true, secure: true
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-Rails.application.config.session_store :cookie_store,
-                                       key: '_scholarsphere',
-                                       secure: Rails.env.production?,
-                                       httponly: Rails.env.production?

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :cookie_store, key: '_scholarsphere', secure: Rails.env.production?, httponly: Rails.env.production?

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Rails.application.config.session_store :cookie_store,
+                                       key: '_scholarsphere',
+                                       secure: Rails.env.production?,
+                                       httponly: Rails.env.production?


### PR DESCRIPTION
OIS used a DAST (dynamic application security testing) tool against scholarsphere, and we discovered that, by default, rails does not use secure, httponly cookies, and the matomo cookie isn't secure by default. this PR addresses those issues.