### PR TITLE
Index migration errors as facets

### DIFF
--- a/app/controllers/dashboard/catalog_controller.rb
+++ b/app/controllers/dashboard/catalog_controller.rb
@@ -41,6 +41,7 @@ module Dashboard
       config.add_facet_field 'keyword_sim', label: 'Keywords', limit: true
       config.add_facet_field 'subject_sim', label: 'Subject', limit: true
       config.add_facet_field 'creators_sim', label: 'Creators', limit: true
+      config.add_facet_field 'migration_errors_sim', label: 'Migration Errors', limit: true
     end
 
     private

--- a/spec/schemas/work_version_schema_spec.rb
+++ b/spec/schemas/work_version_schema_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WorkVersionSchema, type: :schema do
+  let(:schema) { described_class.new(resource: resource) }
+
+  describe '#document' do
+    let(:errors) { schema.document[:migration_errors_sim] }
+
+    context 'when a work has migration errors' do
+      let(:resource) { create(:work).versions.first }
+
+      it { expect(errors).not_to include(
+        "Work versions file resources can't be blank",
+        "Work versions creator aliases can't be blank"
+      )}
+
+      it { expect(errors).to include(
+        "Files can't be blank",
+        "Creators can't be blank"
+      )}
+    end
+
+    context 'when the work is successfully published' do
+      let(:resource) { create(:work, has_draft: false).versions.first }
+
+      it { expect(errors).to be_empty }
+    end
+  end
+end


### PR DESCRIPTION
This will enable a reporting feature within the dashboard where we can see which works have what kinds of errors associated with them.

Fixes #664 