### PR TITLE
I#658 no doi on drafts

### DIFF
--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -25,6 +25,12 @@ class WorkPolicy < ApplicationPolicy
     editable? && record.draft_version.blank?
   end
 
+  # @note we are temporarily disabling DOIs on draft works for launch. This
+  # method should probably go away when we re-enable them
+  def mint_doi?
+    published? && editable?
+  end
+
   private
 
     def editable?

--- a/app/views/dashboard/works/edit.html.erb
+++ b/app/views/dashboard/works/edit.html.erb
@@ -46,13 +46,16 @@
         </div>
       <% end %>
 
-        <p><%= t('.doi.explanation') %></p>
-        <%= render MintableDoiComponent.new(resource: @work) %>
       <div class="keyline keyline--left">
         <h2 id="<%= t('.doi.heading').parameterize %>" class="h4"><%= t('.doi.heading') %></h2>
       </div>
 
       <p><%= t('.doi.explanation') %></p>
+      <% if policy(@work).mint_doi? %>
+        <%= render MintableDoiComponent.new(resource: @work) %>
+      <% else %>
+        <p><%= t('.doi.not_allowed') %></p>
+      <% end %>
     </div>
   </article>
 </div>

--- a/app/views/dashboard/works/edit.html.erb
+++ b/app/views/dashboard/works/edit.html.erb
@@ -23,36 +23,36 @@
       </aside>
     </div>
     <div class="col-lg-9">
+      <h1 class="h2 mb-3"><%= t('.heading',
+                                work_title: (@work.latest_published_version || @work.latest_version).title) %></h1>
 
-        <h1 class="h2 mb-3"><%= t('.heading', work_title: @work.decorated_latest_published_version.title) %></h1>
+      <div class="keyline keyline--left">
+        <h2 id="<%= t('.visibility.heading').parameterize %>" class="h4"><%= t('.visibility.heading') %></h2>
+      </div>
 
-        <div class="keyline keyline--left">
-          <h2 id="<%= t('.visibility.heading').parameterize %>" class="h4"><%= t('.visibility.heading') %></h2>
-        </div>
+      <p><%= t('.visibility.explanation') %></p>
 
-        <p><%= t('.visibility.explanation') %></p>
-
-        <%- visibility_form_id = "edit_visibility_#{dom_id @work}" %>
-        <%= form_for [:dashboard, @work], remote: false, html: { id: visibility_form_id, class: 'edit-work-visibility' } do |visibility_form| %>
-          <%= hidden_field_tag 'form_id', visibility_form_id %>
-          <% if params['form_id'] == visibility_form_id %>
-            <%= render FormErrorMessageComponent.new(form: visibility_form) %>
-          <% end %>
-
-          <%= render 'dashboard/work_form/publish/visibility_field', form: visibility_form %>
-
-          <div class="actions mt-4 mb-3">
-            <%= visibility_form.submit t('.visibility.submit_button'), class: 'btn btn-primary' %>
-          </div>
+      <%- visibility_form_id = "edit_visibility_#{dom_id @work}" %>
+      <%= form_for [:dashboard, @work], remote: false, html: { id: visibility_form_id, class: 'edit-work-visibility' } do |visibility_form| %>
+        <%= hidden_field_tag 'form_id', visibility_form_id %>
+        <% if params['form_id'] == visibility_form_id %>
+          <%= render FormErrorMessageComponent.new(form: visibility_form) %>
         <% end %>
 
-        <div class="keyline keyline--left">
-          <h2 id="<%= t('.doi.heading').parameterize %>" class="h4"><%= t('.doi.heading') %></h2>
+        <%= render 'dashboard/work_form/publish/visibility_field', form: visibility_form %>
+
+        <div class="actions mt-4 mb-3">
+          <%= visibility_form.submit t('.visibility.submit_button'), class: 'btn btn-primary' %>
         </div>
+      <% end %>
 
         <p><%= t('.doi.explanation') %></p>
         <%= render MintableDoiComponent.new(resource: @work) %>
+      <div class="keyline keyline--left">
+        <h2 id="<%= t('.doi.heading').parameterize %>" class="h4"><%= t('.doi.heading') %></h2>
+      </div>
 
+      <p><%= t('.doi.explanation') %></p>
     </div>
   </article>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,6 +206,7 @@ en:
         doi:
           heading: DOI
           explanation: A DOI is a persistent identifier that can be used in print or on the web.
+          not_allowed: A DOI may only be created on published works. Since this work is a draft, you'll need to wait until it's published to create a DOI for it.
       update:
         success: "Work settings successfully updated."
     work_form:

--- a/spec/features/dashboard/work_settings_spec.rb
+++ b/spec/features/dashboard/work_settings_spec.rb
@@ -39,11 +39,24 @@ RSpec.describe 'Work Settings Page', with_user: :user do
       visit edit_dashboard_work_path(work)
     end
 
-    it 'works from the Settings page' do
-      click_button I18n.t('resources.doi.create')
+    context 'when the work has been published' do
+      let(:work) { create :work, versions_count: 1, has_draft: false, depositor: user.actor }
 
-      expect(page).to have_current_path(edit_dashboard_work_path(work))
-      expect(page).not_to have_button I18n.t('resources.doi.create')
+      it 'works from the Settings page' do
+        click_button I18n.t('resources.doi.create')
+
+        expect(page).to have_current_path(edit_dashboard_work_path(work))
+        expect(page).not_to have_button I18n.t('resources.doi.create')
+      end
+    end
+
+    context 'when the work has not yet been published' do
+      let(:work) { create :work, versions_count: 1, has_draft: true, depositor: user.actor }
+
+      it 'is not allowed' do
+        expect(page).not_to have_content I18n.t('resources.doi.create')
+        expect(page).to have_content I18n.t('dashboard.works.edit.doi.not_allowed')
+      end
     end
   end
 end

--- a/spec/policies/work_policy_spec.rb
+++ b/spec/policies/work_policy_spec.rb
@@ -126,4 +126,44 @@ RSpec.describe WorkPolicy, type: :policy do
       it { is_expected.to permit(admin, work) }
     end
   end
+
+  permissions :mint_doi? do
+    context 'when a published version exists' do
+      let(:work) do
+        create :work, has_draft: false,
+                      versions_count: 1,
+                      depositor: depositor_actor,
+                      proxy_depositor: proxy_actor,
+                      discover_users: [discover_user],
+                      edit_users: [edit_user]
+      end
+
+      it { is_expected.to permit(depositor, work) }
+      it { is_expected.to permit(proxy, work) }
+      it { is_expected.to permit(edit_user, work) }
+      it { is_expected.not_to permit(discover_user, work) }
+      it { is_expected.not_to permit(other_user, work) }
+      it { is_expected.not_to permit(public, work) }
+      it { is_expected.to permit(admin, work) }
+    end
+
+    context 'when no published version exists' do
+      let(:work) do
+        create :work, has_draft: true,
+                      versions_count: 1,
+                      depositor: depositor_actor,
+                      proxy_depositor: proxy_actor,
+                      discover_users: [discover_user],
+                      edit_users: [edit_user]
+      end
+
+      it { is_expected.not_to permit(depositor, work) }
+      it { is_expected.not_to permit(proxy, work) }
+      it { is_expected.not_to permit(edit_user, work) }
+      it { is_expected.not_to permit(discover_user, work) }
+      it { is_expected.not_to permit(other_user, work) }
+      it { is_expected.not_to permit(public, work) }
+      it { is_expected.not_to permit(admin, work) }
+    end
+  end
 end


### PR DESCRIPTION
Closes #658 

In the first commit, I also fixed an issue where the `<h1>` tag freaked out of there was no published version. It now tries to grab the title of the page from the `latest_published_version` and if none exists, it tries `latest_version` instead