### PR TITLE
Rename visibility to access, and other en.yml tweaks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
+    - 'app/controllers/dashboard/catalog_controller.rb'
     - 'app/views/catalog/index.json.jbuilder'
     - 'config/routes.rb'
     - 'config/environments/production.rb'

--- a/app/components/visibility_badge_component.rb
+++ b/app/components/visibility_badge_component.rb
@@ -33,20 +33,24 @@ class VisibilityBadgeComponent < ApplicationComponent
     def details
       {
         Permissions::Visibility::OPEN => {
-          label: 'Open Access',
+          label: i18n_label(Permissions::Visibility::OPEN),
           color: 'orange',
           icon: 'lock_open'
         },
         Permissions::Visibility::AUTHORIZED => {
-          label: 'Penn State',
+          label: i18n_label(Permissions::Visibility::AUTHORIZED),
           color: 'blue',
           icon: 'pets'
         },
         Permissions::Visibility::PRIVATE => {
-          label: 'Restricted',
+          label: i18n_label(Permissions::Visibility::PRIVATE),
           color: 'red',
           icon: 'lock'
         }
       }
+    end
+
+    def i18n_label(key)
+      I18n.t("visibility_badge_component.label.#{key}", raise: true)
     end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -85,10 +85,10 @@ class CatalogController < ApplicationController
     # prefixes that will be used to create the navigation (note: It is
     # case sensitive when searching values)
 
-    config.add_facet_field 'display_work_type_ssi', label: 'Work Type', limit: true
-    config.add_facet_field 'keyword_sim', label: 'Keywords', limit: true
-    config.add_facet_field 'subject_sim', label: 'Subject', limit: true
-    config.add_facet_field 'creators_sim', label: 'Creators', limit: true
+    config.add_facet_field 'display_work_type_ssi', label: I18n.t('catalog.facets.display_work_type_ssi'), limit: true
+    config.add_facet_field 'keyword_sim', label: I18n.t('catalog.facets.keyword_sim'), limit: true
+    config.add_facet_field 'subject_sim', label: I18n.t('catalog.facets.subject_sim'), limit: true
+    config.add_facet_field 'creators_sim', label: I18n.t('catalog.facets.creators_sim'), limit: true
 
     # Example pivot facet
     # config.add_facet_field 'example_pivot_field', label: 'Pivot Field', pivot: ['format', 'language_ssim']

--- a/app/controllers/dashboard/catalog_controller.rb
+++ b/app/controllers/dashboard/catalog_controller.rb
@@ -27,21 +27,33 @@ module Dashboard
       # Reset the facet configuration inherited from CatalogController
       config.facet_fields = {}
 
-      config.add_facet_field 'aasm_state_tesim', label: 'Status', collapse: false
-      config.add_facet_field 'visibility_ssi', label: 'Visibility', collapse: false
+      config.add_facet_field 'aasm_state_tesim', label: I18n.t('catalog.facets.aasm_state_tesim'), collapse: false
+      config.add_facet_field 'visibility_ssi', label: I18n.t('catalog.facets.visibility_ssi'), collapse: false
 
-      config.add_facet_field 'embargoed_until_dtsi', label: 'Embargoed Date', query: {
-        year_1: { label: 'this year', fq: 'embargoed_until_dtsi:[NOW TO NOW+1YEAR]' },
-        year_5: { label: 'in 5 years', fq: 'embargoed_until_dtsi:[NOW+1YEAR TO NOW+5YEAR]' },
-        year_10: { label: 'in 10 years', fq: 'embargoed_until_dtsi:[NOW+5YEAR TO NOW+10YEAR]' },
-        year_more: { label: 'beyond 10 years', fq: 'embargoed_until_dtsi:[NOW+10YEAR TO *]' }
+      config.add_facet_field 'embargoed_until_dtsi', label: I18n.t('catalog.facets.embargoed_until_dtsi'), query: {
+        year_1: {
+          label: I18n.t('catalog.facets.embargoed_until.year_1'),
+          fq: 'embargoed_until_dtsi:[NOW TO NOW+1YEAR]'
+        },
+        year_5: {
+          label: I18n.t('catalog.facets.embargoed_until.year_5'),
+          fq: 'embargoed_until_dtsi:[NOW+1YEAR TO NOW+5YEAR]'
+        },
+        year_10: {
+          label: I18n.t('catalog.facets.embargoed_until.year_10'),
+          fq: 'embargoed_until_dtsi:[NOW+5YEAR TO NOW+10YEAR]'
+        },
+        year_more: {
+          label: I18n.t('catalog.facets.embargoed_until.year_more'),
+          fq: 'embargoed_until_dtsi:[NOW+10YEAR TO *]'
+        }
       }, collapse: false
 
-      config.add_facet_field 'display_work_type_ssi', label: 'Work Type', limit: true
-      config.add_facet_field 'keyword_sim', label: 'Keywords', limit: true
-      config.add_facet_field 'subject_sim', label: 'Subject', limit: true
-      config.add_facet_field 'creators_sim', label: 'Creators', limit: true
-      config.add_facet_field 'migration_errors_sim', label: 'Migration Errors', limit: true
+      config.add_facet_field 'display_work_type_ssi', label: I18n.t('catalog.facets.display_work_type_ssi'), limit: true
+      config.add_facet_field 'keyword_sim', label: I18n.t('catalog.facets.keyword_sim'), limit: true
+      config.add_facet_field 'subject_sim', label: I18n.t('catalog.facets.subject_sim'), limit: true
+      config.add_facet_field 'creators_sim', label: I18n.t('catalog.facets.creators_sim'), limit: true
+      config.add_facet_field 'migration_errors_sim', label: I18n.t('catalog.facets.migration_errors_sim'), limit: true
     end
 
     private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,6 +83,20 @@ en:
       options:
         heading: 'Search Alternatives'
         browse: "Browse & Filter All Works"
+    facets:
+      aasm_state_tesim: Status
+      creators_sim: Creators
+      display_work_type_ssi: Work Type
+      embargoed_until_dtsi: Embargoed Date
+      embargoed_until:
+        year_1: this year
+        year_5: in 5 years
+        year_10: in 10 years
+        year_more: beyond 10 years
+      keyword_sim: Keywords
+      migration_errors_sim: Migration Errors
+      subject_sim: Subject
+      visibility_ssi: Access
   embargo:
     heading: "Embargoed until %{date}"
     public_message: "Files are not available during the embargo."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,9 +200,9 @@ en:
         heading: "Settings for %{work_title}"
         back: Back to Work
         visibility:
-          heading: Visibility
-          explanation: Visibility settings affect who can download files associated with the work.
-          submit_button: Update Visibility Settings
+          heading: Access
+          explanation: Access settings affect who can download files associated with the work.
+          submit_button: Update Access Settings
         doi:
           heading: DOI
           explanation: A DOI is a persistent identifier that can be used in print or on the web.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -412,3 +412,8 @@ en:
       submit: 'search'
       subheading: Or
       browse: 'Browse & Filter All Works'
+  visibility_badge_component:
+    label:
+      open: Open Access
+      authenticated: Penn State
+      restricted: Restricted

--- a/spec/components/visibility_badge_component_spec.rb
+++ b/spec/components/visibility_badge_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe VisibilityBadgeComponent, type: :component do
     let(:work) { build(:work) }
 
     specify do
-      expect(badge.text).to include('Open Access')
+      expect(badge.text).to include(I18n.t('visibility_badge_component.label.open'))
       expect(badge.attributes['data-before'].value).to eq('lock_open')
       expect(badge.classes).to contain_exactly('badge', 'badge--icon', 'badge--icon-orange')
     end
@@ -20,7 +20,7 @@ RSpec.describe VisibilityBadgeComponent, type: :component do
     let(:work) { build(:work, visibility: Permissions::Visibility::AUTHORIZED) }
 
     specify do
-      expect(badge.text).to include('Penn State')
+      expect(badge.text).to include(I18n.t('visibility_badge_component.label.authenticated'))
       expect(badge.attributes['data-before'].value).to eq('pets')
       expect(badge.classes).to contain_exactly('badge', 'badge--icon', 'badge--icon-blue')
     end
@@ -30,7 +30,7 @@ RSpec.describe VisibilityBadgeComponent, type: :component do
     let(:work) { build(:work, visibility: Permissions::Visibility::PRIVATE) }
 
     specify do
-      expect(badge.text).to include('Restricted')
+      expect(badge.text).to include(I18n.t('visibility_badge_component.label.restricted'))
       expect(badge.attributes['data-before'].value).to eq('lock')
       expect(badge.classes).to contain_exactly('badge', 'badge--icon', 'badge--icon-red')
     end


### PR DESCRIPTION
In an ideal world, this _should_ have been as simple as searching en.yml for "visibility" and renaming where necessary. And in some cases that was true. But in my travels I discovered a lot of user-facing strings that were not translated from en.yml, so I went ahead and refactored a lot of those where I could.

Closes #656 