### PR TITLE
Return 404 for Pundit authorization errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,8 @@ class ApplicationController < ActionController::Base
   # Authorization
   include Pundit
 
+  ActionDispatch::ExceptionWrapper.rescue_responses['Pundit::NotAuthorizedError'] = :not_found
+
   def current_user
     UserDecorator.new(super || User.guest)
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+  describe ActionDispatch::ExceptionWrapper do
+    subject { described_class }
+
+    its(:rescue_responses) { is_expected.to include('Pundit::NotAuthorizedError' => :not_found) }
+  end
+end


### PR DESCRIPTION
Taps into ActionDispatch::ExceptionWrapper#rescue_responses and adds an additional directive to return :not_found responses for Pundit authorization errors. Previously, these were returning the default 500 error which was misleading.

Fixes #661 