### PR TITLE
Re-query Actors using Penn State's identity results

### DIFF
--- a/lib/qa/authorities/persons.rb
+++ b/lib/qa/authorities/persons.rb
@@ -30,7 +30,9 @@ module Qa
         end
 
         def creators
-          @creators ||= Actor.where('surname ILIKE :q OR given_name ILIKE :q OR psu_id ILIKE :q', q: "%#{term}%")
+          @creators ||= Actor
+            .where('surname ILIKE :q OR given_name ILIKE :q OR psu_id ILIKE :q', q: "%#{term}%")
+            .or(Actor.where(psu_id: identities.map(&:user_id)))
         end
 
         # @note using Set enables faster searching for a given id instead of iterating over the entire array.

--- a/spec/lib/qa/authorities/persons_spec.rb
+++ b/spec/lib/qa/authorities/persons_spec.rb
@@ -95,8 +95,34 @@ RSpec.describe Qa::Authorities::Persons, type: :authority do
       it { is_expected.to include(formatted_result) }
     end
 
+    context "when Penn State's identity service contains existing Scholarsphere Actors" do
+      let!(:creator) { create(:actor) }
+
+      let(:formatted_result) do
+        {
+          given_name: creator.given_name,
+          surname: creator.surname,
+          psu_id: creator.psu_id,
+          default_alias: creator.default_alias,
+          email: creator.email,
+          orcid: creator.orcid,
+          source: 'scholarsphere',
+          actor_id: creator.id,
+          result_number: 1,
+          total_results: 1,
+          additional_metadata: "#{Actor.human_attribute_name(:psu_id)}: #{creator.psu_id}"
+        }
+      end
+
+      let(:mock_identity_response) { [person] }
+      let(:person) { build(:person, access_id: creator.psu_id) }
+      let(:search_term) { 'search query' }
+
+      it { is_expected.to include(formatted_result) }
+    end
+
     context 'with an unsupported person type' do
-      let(:bad_actor) { Struct.new('BadActor', :given_name).new('bad actor') }
+      let(:bad_actor) { Struct.new('BadActor', :given_name, :user_id).new('bad actor', 'bad123') }
       let(:mock_identity_response) { [bad_actor] }
 
       it 'raises an error' do


### PR DESCRIPTION
This avoids a problem whereby a user's query will return the correct results from Penn State's service, but not our local actors. The fix is to just re-query the actor's table using the results from the identity service. This way we will always have the preferred local records.

Fixes #659