### PR TITLE
Use ScholarSphere as default page title

### DIFF
--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = t('blacklight.search.page_title.title', constraints: render_search_to_page_title(params), application_name: application_name) %>
-
 <% content_for(:head) do -%>
   <%= render 'catalog/opensearch_response_metadata', response: @response %>
   <%= rss_feed_link_tag %>

--- a/app/views/dashboard/catalog/index.html.erb
+++ b/app/views/dashboard/catalog/index.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = t('blacklight.search.page_title.title', constraints: render_search_to_page_title(params), application_name: application_name) %>
-
 <% content_for(:skip_links) do -%>
   <%= link_to t('blacklight.skip_links.first_result'), '#documents',
               class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -1,3 +1,7 @@
+<%- content_for :page_title do %>
+  <%= work_version.title %>
+<% end %>
+
 <%= content_for :navbar_items do %>
   <%= render WorkVersions::VersionNavigationDropdownComponent.new(
         current_version: work_version,

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,3 +1,0 @@
-en:
-  blacklight:
-    application_name: 'Blacklight'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,8 @@ en:
   api:
     errors:
       not_authorized: "401: Request not authorized. Please provide a valid API key for access."
+  blacklight:
+    application_name: 'ScholarSphere'
   catalog:
     zero_results:
       info:

--- a/spec/features/catalog/catalog_spec.rb
+++ b/spec/features/catalog/catalog_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe 'Blacklight catalog page', :inline_jobs do
 
   it 'displays the search form and facets' do
     visit search_catalog_path
+    expect(page.title).to eq('ScholarSphere')
     click_link('100 per page')
 
     expect(page).to have_content("1 - #{indexed_resources.count} of #{indexed_resources.count}")

--- a/spec/features/dashboard/catalog_spec.rb
+++ b/spec/features/dashboard/catalog_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Dashboard catalog page', :inline_jobs do
   context 'when the user has NO deposited works' do
     it 'displays an informational page to the user', with_user: :user do
       visit(dashboard_root_path)
+      expect(page.title).to eq('ScholarSphere')
 
       expect(page).to have_link('Dashboard', class: 'disabled')
       expect(page).to have_selector('h4', text: 'What is my dashboard?')

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'Public Resources', type: :feature do
       it 'displays the public resource page for the work' do
         visit resource_path(work.uuid)
 
+        # @note There is some whitespace due to the :content_for block, but this is ultimately removed by the browser.
+        expect(page.title).to include(v2.title)
         expect(page).to have_content(v2.title)
 
         ## Does not have edit controls


### PR DESCRIPTION
Unless we're on a resource page, the title for all pages will be _ScholarSphere_. If it is a resource page, such as a work or collection, the resource's title will be used.

Fixes #617 