### PR TITLE
Remove "Version Comparison" tab from resource page

### DIFF
--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -85,22 +85,7 @@
       <div class="keyline keyline--left mb-3">
         <h2 class="h4"><%= t 'resources.work_history' %></h2>
       </div>
-      <nav>
-        <div class="nav nav-tabs" role="tablist">
-          <a class="nav-item nav-link active" id="nav-summary-tab" data-toggle="tab" href="#nav-summary" role="tab" aria-controls="nav-summary" aria-selected="true"><%= t('resources.work_history_summary') %></a>
-          <a class="nav-item nav-link" id="nav-version-tab" data-toggle="tab" href="#nav-version" role="tab" aria-controls="nav-version" aria-selected="false"><%= t('resources.work_history_diff') %></a>
-        </div>
-      </nav>
-      <div class="tab-content">
-        <div class="tab-pane fade active show" id="nav-summary" role="tabpanel" aria-labelledby="nav-summary-tab">
-          <div class="row">
-            <%= render WorkHistories::WorkHistoryComponent.new(work: work_version.work) %>
-          </div>
-        </div>
-        <div class="tab-pane fade" id="nav-version" role="tabpanel" aria-labelledby="nav-version-tab">
-          <p><%= t('resources.work_history_diff_content') %></p>
-        </div>
-      </div>
+      <%= render WorkHistories::WorkHistoryComponent.new(work: work_version.work) %>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -393,9 +393,6 @@ en:
       link: View the current version.
       message: This is an older version of the work.
     work_history: Work History
-    work_history_diff: Version Comparison
-    work_history_diff_content: 'TODO: coming soon'
-    work_history_summary: Summary
     works: Works
     doi:
       doi: 'doi:'


### PR DESCRIPTION
Version comparisons are not available and may be redesigned in future releases. The tab is removed, as well as the related tabbed navigation.

Fixes #649 

![Screen Shot 2020-11-10 at 1 54 11 PM](https://user-images.githubusercontent.com/312085/98719294-92fe4480-235d-11eb-9c45-923dbe5ba93b.png)
