### PR TITLE
Add editors via the work settings page

### DIFF
--- a/app/controllers/dashboard/works_controller.rb
+++ b/app/controllers/dashboard/works_controller.rb
@@ -42,11 +42,14 @@ module Dashboard
         @work.attributes = work_params
 
         @embargo_form = EmbargoForm.new(work: @undecorated_work, params: embargo_params)
+        @editors_form = EditorsForm.new(work: @undecorated_work, user: current_user, params: editors_params)
       end
 
       def select_form_model
         if params[:embargo_form].present?
           @embargo_form
+        elsif params[:editors_form].present?
+          @editors_form
         else
           @work
         end
@@ -67,6 +70,15 @@ module Dashboard
           .permit(
             :embargoed_until,
             :remove
+          )
+      end
+
+      def editors_params
+        params
+          .fetch(:editors_form, {})
+          .permit(
+            edit_users: [],
+            edit_groups: []
           )
       end
   end

--- a/app/forms/editors_form.rb
+++ b/app/forms/editors_form.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class EditorsForm
+  include ActiveModel::Model
+
+  attr_reader :work, :user
+
+  def initialize(work:, params:, user:)
+    @work = work
+    @user = user
+    super(params)
+  end
+
+  def edit_users
+    @edit_users || work.edit_users.map(&:access_id)
+  end
+
+  def edit_users=(access_ids)
+    @edit_users = access_ids.reject(&:blank?)
+  end
+
+  def edit_groups
+    @edit_groups || work.edit_groups.map(&:name)
+  end
+
+  def edit_groups=(names)
+    @edit_groups = names.reject(&:blank?)
+  end
+
+  def group_options
+    (user.groups - User.default_groups).map(&:name)
+  end
+
+  def save
+    user_list = build_users
+    return false if errors.present?
+
+    work.edit_users = user_list
+    work.edit_groups = group_list
+    work.save
+  end
+
+  private
+
+    def build_users
+      edit_users.map do |access_id|
+        UserRegistrationService.call(uid: access_id) ||
+          errors.add(:edit_users, "#{access_id} does not exist") && access_id
+      end
+    end
+
+    def group_list
+      edit_groups.map do |name|
+        Group.find_by(name: name)
+      end.compact
+    end
+end

--- a/app/views/dashboard/works/_editors.html.erb
+++ b/app/views/dashboard/works/_editors.html.erb
@@ -1,0 +1,24 @@
+<p><%= t('.explanation') %></p>
+
+<%- editors_form_id = "edit_editors_#{dom_id @work}" %>
+<%= form_for @editors_form,
+             url: dashboard_work_path(@work),
+             method: :patch,
+             remote: false,
+             html: { id: editors_form_id, class: 'edit-work-editors' } do |form| %>
+
+  <%= hidden_field_tag 'form_id', editors_form_id %>
+  <%= render FormErrorMessageComponent.new(form: form) %>
+
+  <%= render 'form_fields/multi_text', form: form, attribute: :edit_users %>
+  <%= render 'form_fields/select',
+             form: form,
+             attribute: :edit_groups,
+             options_for_select: form.object.group_options,
+             include_blank: true,
+             multiple: true %>
+
+  <div class="actions mt-1 mb-3">
+    <%= form.submit t('.submit_button'), class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/app/views/dashboard/works/edit.html.erb
+++ b/app/views/dashboard/works/edit.html.erb
@@ -22,6 +22,9 @@
           <li class="nav-item">
             <a class="nav-link" href="#<%= t('.doi.heading').parameterize %>"><%= t('.doi.heading') %></a>
           </li>
+          <li class="nav-item">
+            <%= link_to t('dashboard.works.editors.heading'), "##{t('dashboard.works.editors.heading').parameterize}", class: 'nav-link' %>
+          </li>
         </ul>
       </aside>
     </div>
@@ -78,12 +81,22 @@
         <h2 id="<%= t('.doi.heading').parameterize %>" class="h4"><%= t('.doi.heading') %></h2>
       </div>
 
-      <p><%= t('.doi.explanation') %></p>
-      <% if policy(@work).mint_doi? %>
-        <%= render MintableDoiComponent.new(resource: @work) %>
-      <% else %>
-        <p><%= t('.doi.not_allowed') %></p>
-      <% end %>
+      <div class="actions mb-3">
+        <p><%= t('.doi.explanation') %></p>
+        <% if policy(@work).mint_doi? %>
+          <%= render MintableDoiComponent.new(resource: @work) %>
+        <% else %>
+          <p><%= t('.doi.not_allowed') %></p>
+        <% end %>
+      </div>
+
+      <div class="keyline keyline--left">
+        <h2 id="<%= t('dashboard.works.editors.heading').parameterize %>" class="h4"><%= t('dashboard.works.editors.heading') %></h2>
+      </div>
+
+      <div class="actions mb-3">
+        <%= render 'editors', work: @work %>
+      </div>
     </div>
   </article>
 </div>

--- a/app/views/form_fields/_select.html.erb
+++ b/app/views/form_fields/_select.html.erb
@@ -10,6 +10,7 @@
                   {
                     class: 'form-control custom-select',
                     required: local_assigns[:required].presence,
+                    multiple: local_assigns.fetch(:multiple, false),
                     aria: { describedby: (has_hint && hint_id).presence }
                   } %>
   <%= form.label attribute %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -247,6 +247,10 @@ en:
           heading: DOI
           explanation: A DOI is a persistent identifier that can be used in print or on the web.
           not_allowed: A DOI may only be created on published works. Since this work is a draft, you'll need to wait until it's published to create a DOI for it.
+      editors:
+        heading: Editors
+        explanation: Gives the ability for other users from Penn State to edit your work. This can be done on a per-user basis, or a group basis.
+        submit_button: Update Editors 
       update:
         success: "Work settings successfully updated."
     work_form:

--- a/spec/features/dashboard/work_settings_spec.rb
+++ b/spec/features/dashboard/work_settings_spec.rb
@@ -81,4 +81,68 @@ RSpec.describe 'Work Settings Page', with_user: :user do
       end
     end
   end
+
+  describe 'Updating Editors' do
+    context 'when adding a new editor' do
+      let(:work) { create :work, depositor: user.actor }
+
+      it 'adds a user as an editor' do
+        visit edit_dashboard_work_path(work)
+
+        expect(work.edit_users).to be_empty
+        fill_in('Edit users', with: 'agw13')
+        click_button('Update Editors')
+
+        work.reload
+        expect(work.edit_users.map(&:uid)).to contain_exactly('agw13')
+      end
+    end
+
+    context 'when removing an existing editor' do
+      let(:editor) { create(:user) }
+      let(:work) { create :work, depositor: user.actor, edit_users: [editor] }
+
+      it 'adds a user as an editor' do
+        visit edit_dashboard_work_path(work)
+
+        expect(work.edit_users).to contain_exactly(editor)
+        fill_in('Edit users', with: '')
+        click_button('Update Editors')
+
+        work.reload
+        expect(work.edit_users).to be_empty
+      end
+    end
+
+    context 'when the user does not exist' do
+      let(:work) { create :work, depositor: user.actor }
+
+      it 'adds a user as an editor' do
+        visit edit_dashboard_work_path(work)
+
+        fill_in('Edit users', with: 'iamnotpennstate')
+        click_button('Update Editors')
+
+        work.reload
+        expect(work.edit_users).to be_empty
+      end
+    end
+
+    context 'when selecting a group' do
+      let(:user) { create(:user, groups: User.default_groups + [group]) }
+      let(:group) { create(:group) }
+      let(:work) { create :work, depositor: user.actor }
+
+      it 'adds the group as an editor' do
+        visit edit_dashboard_work_path(work)
+
+        expect(work.edit_groups).to be_empty
+        select(group.name, from: 'Edit groups')
+        click_button('Update Editors')
+
+        work.reload
+        expect(work.edit_groups).to contain_exactly(group)
+      end
+    end
+  end
 end

--- a/spec/forms/editors_form_spec.rb
+++ b/spec/forms/editors_form_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EditorsForm, type: :model do
+  subject(:form) { described_class.new(work: work, params: params, user: current_user) }
+
+  let(:work) { build(:work) }
+  let(:params) { {} }
+  let(:current_user) { build(:user) }
+
+  describe 'initialization' do
+    context 'with no params' do
+      its(:edit_users) { is_expected.to be_empty }
+      its(:edit_groups) { is_expected.to be_empty }
+    end
+
+    context 'with a list of values' do
+      let(:params) do
+        {
+          edit_users: ['abc123'],
+          edit_groups: ['groupName']
+        }
+      end
+
+      its(:edit_users) { is_expected.to eq(['abc123']) }
+      its(:edit_groups) { is_expected.to eq(['groupName']) }
+    end
+
+    context 'with blank values' do
+      let(:params) do
+        {
+          edit_users: ['abc123', ''],
+          edit_groups: ['groupName', '']
+        }
+      end
+
+      its(:edit_users) { is_expected.to eq(['abc123']) }
+      its(:edit_groups) { is_expected.to eq(['groupName']) }
+    end
+
+    context 'when the work has existing users and grous' do
+      let(:user) { build(:user) }
+      let(:group) { build(:group) }
+      let(:work) { build(:work, edit_users: [user], edit_groups: [group]) }
+
+      its(:edit_users) { is_expected.to contain_exactly(user.uid) }
+      its(:edit_groups) { is_expected.to contain_exactly(group.name) }
+    end
+  end
+
+  describe '#group_options' do
+    context 'when the user has NO additional groups' do
+      its(:group_options) { is_expected.to be_empty }
+    end
+
+    context 'when the user has additional groups' do
+      let(:current_user) { build(:user, groups: User.default_groups + [group]) }
+      let(:group) { build(:group) }
+
+      its(:group_options) { is_expected.to contain_exactly(group.name) }
+    end
+  end
+
+  describe '#save' do
+    context 'when the user exists' do
+      let(:params) { { 'edit_users' => [user.access_id] } }
+      let(:user) { create(:user) }
+
+      before { allow(UserRegistrationService).to receive(:call).with(uid: user.access_id).and_return(user) }
+
+      it 'adds the user as an editor' do
+        expect(work.edit_users).to be_empty
+        form.save
+        work.reload
+        expect(work.edit_users).to contain_exactly(user)
+      end
+    end
+
+    context 'when the user does NOT exist' do
+      let(:params) { { 'edit_users' => [access_id] } }
+      let(:access_id) { 'we-aint-penn-state' }
+
+      before { allow(UserRegistrationService).to receive(:call).with(uid: access_id).and_return(nil) }
+
+      it 'does not add the user and reports an error' do
+        expect(work.edit_users).to be_empty
+        form.save
+        expect(work.edit_users).to be_empty
+        expect(form.errors.full_messages).to contain_exactly("Edit users #{access_id} does not exist")
+      end
+    end
+
+    context 'when adding a group' do
+      let(:params) { { 'edit_groups' => [group.name] } }
+      let(:group) { create(:group) }
+
+      it 'adds the group as an editor' do
+        expect(work.edit_groups).to be_empty
+        form.save
+        work.reload
+        expect(work.edit_groups).to contain_exactly(group)
+      end
+    end
+
+    context 'when the group does NOT exist' do
+      let(:params) { { 'edit_groups' => ['missing-group'] } }
+
+      it 'adds the group as an editor' do
+        expect(work.edit_groups).to be_empty
+        form.save
+        work.reload
+        expect(work.edit_groups).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a new editors form to the work settings page where users can grant groups and users edit access to their works.

Fixes #277 