### PR TITLE
Maintain and re-order creators

### DIFF
--- a/app/controllers/dashboard/work_form/contributors_controller.rb
+++ b/app/controllers/dashboard/work_form/contributors_controller.rb
@@ -41,6 +41,7 @@ module Dashboard
                 :actor_id,
                 :_destroy,
                 :alias,
+                :position,
                 actor_attributes: [
                   :id,
                   :email,

--- a/app/javascript/controllers/contributors_controller.js
+++ b/app/javascript/controllers/contributors_controller.js
@@ -4,22 +4,17 @@ import { csrfToken } from './stimulus_modules'
 
 export default class extends Controller {
   connect () {
+    this.wrapperClass = this.data.get('wrapper-class')
+    this.badgeClass = this.data.get('badge-class')
+    this.positionClass = this.data.get('position-class')
+
     document.addEventListener('autocomplete:alternative', () => this.openModal(this.data.get('new')))
     document.addEventListener('autocomplete:after-selected', () => this.post(this.data.get('post')))
     document.addEventListener('actor:created', () => this.appendResponse(event.detail.response))
 
-    this.badgeClass = this.data.get('badge-class')
+    $(this.element).on('cocoon:after-remove', () => this.$updateChildren())
 
-    // @todo This uses jQuery. We might want to put these in a separate location for better organization
-    this.renumberBadges = () => {
-      $(this.element)
-        .find(`.${this.badgeClass}:visible`)
-        .each((index, item) => {
-          $(item).text(index + 1)
-        })
-    }
-
-    $(this.element).on('cocoon:after-remove', () => this.renumberBadges())
+    this.$updateChildren()
   }
 
   post (url) {
@@ -37,7 +32,7 @@ export default class extends Controller {
 
   appendResponse (response) {
     this.element.insertAdjacentHTML('beforeend', response.data)
-    this.renumberBadges()
+    this.$updateChildren()
   }
 
   // @todo Something nicer should go here.
@@ -53,5 +48,52 @@ export default class extends Controller {
       .catch(function (error) {
         console.log(error)
       })
+  }
+
+  moveUp (event) {
+    const $target = $(event.target)
+    const $parentWrapper = $target.closest(`.${this.wrapperClass}`)
+    const $previousSibling = $parentWrapper.prevAll(`.${this.wrapperClass}:visible`).first()
+
+    if ($previousSibling.length > 0) {
+      this._$swapElements($parentWrapper, $previousSibling)
+      this.$updateChildren()
+    }
+  }
+
+  moveDown (event) {
+    const $target = $(event.target)
+    const $parentWrapper = $target.closest(`.${this.wrapperClass}`)
+    const $nextSibling = $parentWrapper.nextAll(`.${this.wrapperClass}:visible`).first()
+
+    if ($nextSibling.length > 0) {
+      this._$swapElements($parentWrapper, $nextSibling)
+      this.$updateChildren()
+    }
+  }
+
+  // Uses jQuery
+  $updateChildren () {
+    const children = $(this.element)
+      .find(`.${this.wrapperClass}:visible`)
+
+    children
+      .each((index, wrapperElement) => {
+        $(wrapperElement).find(`.${this.badgeClass}`).text(index + 1)
+        $(wrapperElement).find(`.${this.positionClass}`).val((index + 1) * 10)
+        $(wrapperElement).find('.js-move-up').toggleClass('disabled', index === 0)
+        $(wrapperElement).find('.js-move-down').toggleClass('disabled', index === children.length - 1)
+      })
+  }
+
+  // Uses jQuery
+  _$swapElements ($el1, $el2) {
+    // create temporary placeholder
+    const $temp = $('<div>')
+
+    // 3-step swap
+    $el1.before($temp)
+    $el2.before($el1)
+    $temp.after($el2).remove()
   }
 }

--- a/app/javascript/frontend/styles/_contributors.scss
+++ b/app/javascript/frontend/styles/_contributors.scss
@@ -1,0 +1,25 @@
+.contributor-wrapper {
+  border-bottom: 1px solid $border-color;
+  margin-bottom: 2rem;
+  padding-bottom: 2rem;
+
+  &:last-of-type {
+    border-bottom: 0;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+
+
+  .move {
+    color: $blue;
+
+    &.disabled {
+      color: $gray-400;
+    }
+
+    i {
+      font-size: 40px;
+    }
+  }
+}
+

--- a/app/javascript/frontend/styles/index.scss
+++ b/app/javascript/frontend/styles/index.scss
@@ -35,6 +35,7 @@
 // Import our stuff
 @import 'autocomplete';
 @import 'common';
+@import 'contributors';
 @import 'diff';
 @import 'form_errors';
 @import 'uppy';

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -35,6 +35,7 @@ class WorkVersion < ApplicationRecord
            through: :file_version_memberships
 
   has_many :creator_aliases,
+           -> { order(position: :asc) },
            class_name: 'WorkVersionCreation',
            inverse_of: :work_version,
            dependent: :destroy

--- a/app/views/dashboard/work_form/contributors/_creator_alias_fields.html.erb
+++ b/app/views/dashboard/work_form/contributors/_creator_alias_fields.html.erb
@@ -2,11 +2,7 @@
 <%- form ||= ActionView::Helpers::FormBuilder.new("work_version[creator_aliases_attributes][#{Time.zone.now.to_i}]", creator_alias, self, {}) %>
 <%- index = form.try(:index) || 0 %>
 
-<div class="nested-fields">
-  <% if index > 0 || form.try(:index).blank? %>
-    <hr>
-  <% end %>
-
+<div class="nested-fields contributor-wrapper js-contributor-wrapper">
   <div class="row">
     <div class="col-2">
       <span class="badge badge-dark badge--outline">
@@ -17,6 +13,7 @@
 
     <div class="col-8 pr-2">
       <%= form.hidden_field :actor_id %>
+      <%= form.hidden_field :position, class: 'js-position-index' %>
       <div class="form-group has-float-label">
         <%= form.text_field :alias, class: 'form-control', placeholder: true, required: true %>
         <%= form.label :alias %>
@@ -24,9 +21,34 @@
     </div>
 
     <div class="col-2 pl-0">
-      <%= link_to_remove_association form, class: 'remove' do %>
+      <%= link_to_remove_association form,
+                                     class: 'remove',
+                                     title: t('dashboard.work_form.contributors.edit.remove', name: form.object.alias),
+                                     data: { toggle: 'tooltip', placement: 'top', offset: '0,100%' } do %>
         <span class="sr-only"><%= t('dashboard.work_form.contributors.edit.remove', name: form.object.alias) %></span>
         <i class="material-icons" aria-hidden="true">highlight_off</i>
+      <% end %>
+
+      <%= link_to '#',
+                  class: 'move js-move-up',
+                  title: t('dashboard.work_form.contributors.edit.move_up', name: form.object.alias),
+                  data: {
+                    action: 'contributors#moveUp',
+                    toggle: 'tooltip', placement: 'top', offset: '0,100%'
+                  } do %>
+        <span class="sr-only"><%= t('dashboard.work_form.contributors.edit.move_up', name: form.object.alias) %></span>
+        <i class="material-icons" aria-hidden="true">arrow_circle_up</i>
+      <% end %>
+
+      <%= link_to '#',
+                  class: 'move js-move-down',
+                  title: t('dashboard.work_form.contributors.edit.move_down', name: form.object.alias),
+                  data: {
+                    action: 'contributors#moveDown',
+                    toggle: 'tooltip', placement: 'top', offset: '0,100%'
+                  } do %>
+        <span class="sr-only"><%= t('dashboard.work_form.contributors.edit.move_down', name: form.object.alias) %></span>
+        <i class="material-icons" aria-hidden="true">arrow_circle_down</i>
       <% end %>
     </div>
   </div>

--- a/app/views/dashboard/work_form/contributors/_creators.html.erb
+++ b/app/views/dashboard/work_form/contributors/_creators.html.erb
@@ -8,7 +8,9 @@
      data-controller="contributors"
      data-contributors-new="<%= new_dashboard_actor_path %>"
      data-contributors-post="<%= dashboard_work_form_aliases_new_path %>"
-     data-contributors-badge-class="badge--index">
+     data-contributors-wrapper-class="js-contributor-wrapper"
+     data-contributors-badge-class="badge--index"
+     data-contributors-position-class="js-position-index">
   <%= form.fields_for :creator_aliases do |creator_alias| %>
     <%= render 'dashboard/work_form/contributors/creator_alias_fields', form: creator_alias %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -282,6 +282,8 @@ en:
             When autocomplete results are available use up and down arrows to review and enter to select.
             Touch device users, explore by touch or with swipe gestures.
           remove: "Remove creator %{name}"
+          move_up: "Move %{name} one position earlier"
+          move_down: "Move %{name} one position later"
           search: >
             You can search for creators using their Penn State Access Account, email, or name
           search_heading: Add another creator

--- a/db/migrate/20201111202158_add_position_to_work_version_creations.rb
+++ b/db/migrate/20201111202158_add_position_to_work_version_creations.rb
@@ -1,0 +1,5 @@
+class AddPositionToWorkVersionCreations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :work_version_creations, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_06_014837) do
+ActiveRecord::Schema.define(version: 2020_11_11_202158) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -212,6 +212,7 @@ ActiveRecord::Schema.define(version: 2020_11_06_014837) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "actor_id", null: false
+    t.integer "position"
     t.index ["actor_id"], name: "index_work_version_creations_on_actor_id"
     t.index ["work_version_id"], name: "index_work_version_creations_on_work_version_id"
   end

--- a/spec/models/work_version_creation_spec.rb
+++ b/spec/models/work_version_creation_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe WorkVersionCreation, type: :model do
     it { is_expected.to have_db_column(:work_version_id) }
     it { is_expected.to have_db_column(:actor_id) }
     it { is_expected.to have_db_column(:alias).of_type(:string) }
+    it { is_expected.to have_db_column(:position).of_type(:integer) }
     it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
   end

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -48,6 +48,25 @@ RSpec.describe WorkVersion, type: :model do
 
     it { is_expected.to accept_nested_attributes_for(:file_resources) }
     it { is_expected.to accept_nested_attributes_for(:creator_aliases).allow_destroy(true) }
+
+    describe '.creators' do
+      let(:work_version) { create(:work_version, :with_creators, creator_count: 2) }
+
+      it 'default orders them by #position asc' do
+        creator_a, creator_b = work_version.creator_aliases
+
+        creator_a.update!(alias: 'A', position: 1)
+        creator_b.update!(alias: 'B', position: 2)
+
+        work_version.reload
+        expect(work_version.creator_aliases.map(&:alias)).to eq %w(A B)
+
+        creator_a.update!(position: 100)
+
+        work_version.reload
+        expect(work_version.creator_aliases.map(&:alias)).to eq %w(B A)
+      end
+    end
   end
 
   describe 'states' do


### PR DESCRIPTION
Adds a position column to `work_version_creations` which is automatically ordered descending, i.e. `1` is first and `3` is third.

This position column is added to the creators section of the work form. There's javascript to enumerate it with the correct* value, using the same code as made the "Creator N" badges on the left. I used Stimulus actions to set up listeners to add up/down arrows that move the position of a creator up and down the list. I did refactor this code a little bit, renamed the `updateBadges` method to be a little more generic, and named methods that used jQuery to have a `$` in front of their name.

\* The javascript that sets the `position` value multiplies its index by 10. In other words, instead of enumerating them `1, 2, 3`, it enumerates them `10, 20, 30`. This is a pattern I like to do, because it makes life easier on the backend if one is required to manually go in and swap the order of something. Supposing they were enumerated `1, 2, 3`, and for some reason I needed to swap the position of the last two items manually, I would need to make two updates, one to change `2 -> 3` and another to change `3 -> 2`. If they're enumerated `10, 20, 30` then only one update is necessary, change `30 -> 15` (or any value less than 20, greater than 10)

Closes #531 


![Untitled](https://user-images.githubusercontent.com/14730/98978215-a2a99480-24e7-11eb-8853-3ddd214531b9.png)
