### PR TITLE
Twitter and Google Scholar metadata meta tags

### DIFF
--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -7,6 +7,7 @@
 
     <!-- Internet Explorer use the highest version available -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <%= yield(:meta_tags) if content_for? :meta_tags %>
 
     <title><%= render_page_title %></title>
     <%= javascript_pack_tag 'frontend' %>

--- a/app/views/resources/_collection.html.erb
+++ b/app/views/resources/_collection.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%- content_for :meta_tags do %>
-  <%= render 'meta_tags', resource: collection, current_url: current_url %>
+  <%= render 'meta_tags', resource: collection, uuid: params[:id] %>
 <% end %>
 
 <div class="container-fluid">

--- a/app/views/resources/_collection.html.erb
+++ b/app/views/resources/_collection.html.erb
@@ -1,3 +1,11 @@
+<%- content_for :page_title do %>
+  <%= collection.title %>
+<% end %>
+
+<%- content_for :meta_tags do %>
+  <%= render 'meta_tags', resource: collection, current_url: current_url %>
+<% end %>
+
 <div class="container-fluid">
   <article class="row">
     <div class="col-lg-7">

--- a/app/views/resources/_meta_tags.html.erb
+++ b/app/views/resources/_meta_tags.html.erb
@@ -1,0 +1,16 @@
+<!-- Twitter card metadata -->
+<meta name="twitter:card" content="product">
+<meta name="twitter:site" content="@ScholarSphere">
+<meta name="twitter:creator" content="@ScholarSphere">
+<meta property="og:site_name" content="ScholarSphere">
+<meta property="og:type" content="object">
+<meta property="og:title" content="<%= resource.title %>">
+<meta property="og:description" content="<%= resource.description %>">
+<meta property="og:url" content="<%= current_url %>">
+
+<!-- Google Scholar metadata -->
+<meta name="citation_title" content="<%= resource.title %>">
+<%- resource.creator_aliases.each do |creator_alias| %>
+  <meta name="citation_author" content="<%= creator_alias.alias %>">
+<%- end %>
+<meta name="citation_publication_date" content="<%= resource.published_date %>">

--- a/app/views/resources/_meta_tags.html.erb
+++ b/app/views/resources/_meta_tags.html.erb
@@ -6,7 +6,7 @@
 <meta property="og:type" content="object">
 <meta property="og:title" content="<%= resource.title %>">
 <meta property="og:description" content="<%= resource.description %>">
-<meta property="og:url" content="<%= current_url %>">
+<meta property="og:url" content="<%= resource_url(uuid) %>">
 
 <!-- Google Scholar metadata -->
 <meta name="citation_title" content="<%= resource.title %>">

--- a/app/views/resources/_work.html.erb
+++ b/app/views/resources/_work.html.erb
@@ -1,4 +1,7 @@
 <% work_version = work.decorated_latest_published_version -%>
 <%= render partial: work_version.partial_name,
            object: work_version,
-           locals: { analytics_path: analytics_path } %>
+           locals: {
+             analytics_path: analytics_path,
+             current_url: current_url
+           } %>

--- a/app/views/resources/_work.html.erb
+++ b/app/views/resources/_work.html.erb
@@ -1,7 +1,4 @@
 <% work_version = work.decorated_latest_published_version -%>
 <%= render partial: work_version.partial_name,
            object: work_version,
-           locals: {
-             analytics_path: analytics_path,
-             current_url: current_url
-           } %>
+           locals: { analytics_path: analytics_path } %>

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -2,6 +2,10 @@
   <%= work_version.title %>
 <% end %>
 
+<%- content_for :meta_tags do %>
+  <%= render 'meta_tags', resource: work_version, current_url: current_url %>
+<% end %>
+
 <%= content_for :navbar_items do %>
   <%= render WorkVersions::VersionNavigationDropdownComponent.new(
         current_version: work_version,

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%- content_for :meta_tags do %>
-  <%= render 'meta_tags', resource: work_version, current_url: current_url %>
+  <%= render 'meta_tags', resource: work_version, uuid: params[:id] %>
 <% end %>
 
 <%= content_for :navbar_items do %>

--- a/app/views/resources/show.html.erb
+++ b/app/views/resources/show.html.erb
@@ -1,3 +1,6 @@
 <%= render partial: @resource.partial_name,
            object: @resource,
-           locals: { analytics_path: resource_analytics_path(@resource.uuid, format: :json) } %>
+           locals: {
+             analytics_path: resource_analytics_path(@resource.uuid, format: :json),
+             current_url: resource_url(@resource.uuid)
+           } %>

--- a/app/views/resources/show.html.erb
+++ b/app/views/resources/show.html.erb
@@ -1,6 +1,5 @@
 <%= render partial: @resource.partial_name,
            object: @resource,
            locals: {
-             analytics_path: resource_analytics_path(@resource.uuid, format: :json),
-             current_url: resource_url(@resource.uuid)
+             analytics_path: resource_analytics_path(@resource.uuid, format: :json)
            } %>

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe 'Public Resources', type: :feature do
         # Spot check meta tags
         expect(page.find('meta[property="og:title"]', visible: false)[:content]).to eq v2.title
         expect(page.find('meta[property="og:description"]', visible: false)[:content]).to eq v2.description
-        expect(page.find('meta[property="og:url"]', visible: false)[:content]).to eq resource_url(work.uuid)
+        # Below was failing in CI due to hostnames getting weird
+        expect(page.find('meta[property="og:url"]', visible: false)[:content])
+          .to match(resource_path(work.uuid)).and match(/^https?:/)
         expect(page.find('meta[name="citation_title"]', visible: false)[:content]).to eq v2.title
         expect(page.find('meta[name="citation_publication_date"]', visible: false)[:content]).to eq v2.published_date
         all_authors = page.all(:css, 'meta[name="citation_author"]', visible: false)
@@ -121,7 +123,9 @@ RSpec.describe 'Public Resources', type: :feature do
       # Spot check meta tags
       expect(page.find('meta[property="og:title"]', visible: false)[:content]).to eq collection.title
       expect(page.find('meta[property="og:description"]', visible: false)[:content]).to eq collection.description
-      expect(page.find('meta[property="og:url"]', visible: false)[:content]).to eq resource_url(collection.uuid)
+      # Below was failing in CI due to hostnames getting weird
+      expect(page.find('meta[property="og:url"]', visible: false)[:content])
+        .to match(resource_path(collection.uuid)).and match(/^https?:/)
       expect(page.find('meta[name="citation_title"]', visible: false)[:content]).to eq collection.title
       expect(page.find('meta[name="citation_publication_date"]', visible: false)[:content])
         .to eq collection.published_date

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe 'Public Resources', type: :feature do
         expect(page.title).to include(v2.title)
         expect(page).to have_content(v2.title)
 
+        # Spot check meta tags
+        expect(page.find('meta[property="og:title"]', visible: false)[:content]).to eq v2.title
+        expect(page.find('meta[property="og:description"]', visible: false)[:content]).to eq v2.description
+        expect(page.find('meta[property="og:url"]', visible: false)[:content]).to eq resource_url(work.uuid)
+        expect(page.find('meta[name="citation_title"]', visible: false)[:content]).to eq v2.title
+        expect(page.find('meta[name="citation_publication_date"]', visible: false)[:content]).to eq v2.published_date
+        all_authors = page.all(:css, 'meta[name="citation_author"]', visible: false)
+        expect(all_authors.map { |a| a[:content] }).to match_array v2.creator_aliases.map(&:alias)
+
         ## Does not have edit controls
         within('header') do
           expect(page).not_to have_content(I18n.t('resources.edit_button.text', version: 'V2'))
@@ -106,6 +115,18 @@ RSpec.describe 'Public Resources', type: :feature do
 
     it 'displays the public resource page for the collection' do
       visit resource_path(collection.uuid)
+
+      expect(page.title).to include(collection.title)
+
+      # Spot check meta tags
+      expect(page.find('meta[property="og:title"]', visible: false)[:content]).to eq collection.title
+      expect(page.find('meta[property="og:description"]', visible: false)[:content]).to eq collection.description
+      expect(page.find('meta[property="og:url"]', visible: false)[:content]).to eq resource_url(collection.uuid)
+      expect(page.find('meta[name="citation_title"]', visible: false)[:content]).to eq collection.title
+      expect(page.find('meta[name="citation_publication_date"]', visible: false)[:content])
+        .to eq collection.published_date
+      all_authors = page.all(:css, 'meta[name="citation_author"]', visible: false)
+      expect(all_authors.map { |a| a[:content] }).to match_array collection.creator_aliases.map(&:alias)
 
       expect(page).to have_selector('h1', text: collection.title)
       expect(page).to have_content collection.description


### PR DESCRIPTION
Closes #410 

The only WTF here is, I had to pass down the full URL from the ResourcesController#show view, down into the partials. This was necessary because, when looking at the "latest published version" we want to ensure we are rendering the URL for the parent Work and not the WorkVersion. 

I also added page titles to our sad, neglected Collection