### PR TITLE
Guest users should not apply to audits

### DIFF
--- a/app/controllers/concerns/with_auditing.rb
+++ b/app/controllers/concerns/with_auditing.rb
@@ -12,7 +12,7 @@ module WithAuditing
   # @note Overrides PaperTrail::Rails::Controller to return a global id because our current users are either a User or
   # an ExternalApp.
   def user_for_paper_trail
-    return unless defined?(current_user)
+    return if current_user.guest?
 
     current_user.to_gid
   end

--- a/app/models/external_app.rb
+++ b/app/models/external_app.rb
@@ -37,4 +37,10 @@ class ExternalApp < ApplicationRecord
   def access_id
     name
   end
+
+  # @note ExternalApp and User need to behave in similar ways. This could be extracted into a decorator. See above note
+  # for #access_id.
+  def guest?
+    false
+  end
 end


### PR DESCRIPTION
There is always a current user, but not all current users can be audited. This avoids attempting to make a guest user a paper trail user.

Fixes #704 