### PR TITLE
Rake task for async reindexing of works

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,7 @@ Metrics/BlockLength:
     - 'config/environments/production.rb'
     - 'config/environments/development.rb'
     - 'spec/**/*'
+    - 'lib/tasks/**/*'
 
 Rails/FilePath:
   EnforcedStyle: arguments

--- a/app/jobs/solr_indexing_job.rb
+++ b/app/jobs/solr_indexing_job.rb
@@ -3,7 +3,7 @@
 class SolrIndexingJob < ApplicationJob
   queue_as :indexing
 
-  def perform(indexable_resource)
-    indexable_resource.update_index
+  def perform(indexable_resource, commit: true)
+    indexable_resource.update_index(commit: commit)
   end
 end

--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -93,9 +93,9 @@ class Actor < ApplicationRecord
   # by Works, Versions, and Collections via the `creators` metadata field.
   # Therefore, if a person updates their `default_alias`, we want to trigger a
   # reindex of those associated items so the updated alias shows up in the facet
-  def update_index
-    Work.reindex_all(created_works)
-    Collection.reindex_all(created_collections)
+  def update_index(_options = {})
+    Work.reindex_all(relation: created_works)
+    Collection.reindex_all(relation: created_collections)
   end
 
   # Fields that contain single values automatically remove blank values

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -98,7 +98,7 @@ class Collection < ApplicationRecord
     end
   end
 
-  def self.reindex_all(relation = all)
+  def self.reindex_all(relation: all)
     relation.find_each { |collection| CollectionIndexer.call(collection, commit: false) }
     IndexingService.commit
   end
@@ -129,10 +129,10 @@ class Collection < ApplicationRecord
   # this won't present a problem because we only index published versions, and at that point, the version will have
   # already been saved and reloaded from the database. However, there could be edge cases or other unforseen siutations
   # where the uuid is nil and the version needs to be indexed. Reloading it from Postgres will avoid those problems.
-  def update_index
+  def update_index(commit: true)
     reload if uuid.nil?
 
-    CollectionIndexer.call(self, commit: true)
+    CollectionIndexer.call(self, commit: commit)
   end
 
   def work_type

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -231,10 +231,10 @@ class WorkVersion < ApplicationRecord
   # this won't present a problem because we only index published versions, and at that point, the version will have
   # already been saved and reloaded from the database. However, there could be edge cases or other unforseen siutations
   # where the uuid is nil and the version needs to be indexed. Reloading it from Postgres will avoid those problems.
-  def update_index
+  def update_index(commit: true)
     reload if uuid.nil?
 
-    WorkIndexer.call(work, commit: true)
+    WorkIndexer.call(work, commit: commit)
   end
 
   def indexing_source

--- a/lib/tasks/solr.rake
+++ b/lib/tasks/solr.rake
@@ -19,7 +19,7 @@ namespace :solr do
 
   desc 'Reindexes all the works (as well as their versions) into Solr'
   task reindex_works: :environment do
-    Work.reindex_all
+    Work.reindex_all(async: true)
   end
 
   desc 'Reindexes all the collections into Solr'

--- a/spec/jobs/solr_indexing_job_spec.rb
+++ b/spec/jobs/solr_indexing_job_spec.rb
@@ -6,9 +6,18 @@ RSpec.describe SolrIndexingJob, type: :job do
   let(:indexable_resource) { instance_spy('WorkVerison') }
 
   describe '#perform' do
-    it 'delegates to the indexable_resource#update_index method' do
-      described_class.perform_now(indexable_resource)
-      expect(indexable_resource).to have_received(:update_index)
+    context 'without any arguments' do
+      it 'delegates to the indexable_resource#update_index method and commits to Solr' do
+        described_class.perform_now(indexable_resource)
+        expect(indexable_resource).to have_received(:update_index).with(commit: true)
+      end
+    end
+
+    context 'when delaying the commit' do
+      it 'delegates to the indexable_resource#update_index method and does NOT commit to Solr' do
+        described_class.perform_now(indexable_resource, commit: false)
+        expect(indexable_resource).to have_received(:update_index).with(commit: false)
+      end
     end
   end
 end

--- a/spec/models/actor_spec.rb
+++ b/spec/models/actor_spec.rb
@@ -128,8 +128,8 @@ RSpec.describe Actor, type: :model do
 
       actor.update_index
 
-      expect(Work).to have_received(:reindex_all).with(actor.created_works)
-      expect(Collection).to have_received(:reindex_all).with(actor.created_collections)
+      expect(Work).to have_received(:reindex_all).with(relation: actor.created_works)
+      expect(Collection).to have_received(:reindex_all).with(relation: actor.created_collections)
     end
   end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Collection, type: :model do
       let(:only_special_collections) { described_class.where(depositor: special_collection.depositor) }
 
       it 'only reindexes collections within that relation' do
-        described_class.reindex_all(only_special_collections)
+        described_class.reindex_all(relation: only_special_collections)
         expect(CollectionIndexer).to have_received(:call).once
         expect(CollectionIndexer).to have_received(:call).with(special_collection, anything)
       end


### PR DESCRIPTION
Updates our existing rake task for reindexing works to operate async, putting a job on the queue for each work. This requires refactoring our update_index methods so that committing can be specified at each point along the way.

For each *work* that is indexed, commits are not performed until the the job for the last work is put on the queue.

Fixes #706 