### PR TITLE
Required elements for publishing

### DIFF
--- a/app/controllers/dashboard/work_form/publish_controller.rb
+++ b/app/controllers/dashboard/work_form/publish_controller.rb
@@ -8,9 +8,7 @@ module Dashboard
           .includes(file_version_memberships: [:file_resource])
           .find(params[:work_version_id])
         authorize(@work_version)
-
-        @work_version.publish
-        @work_version.validate
+        prevalidate
       end
 
       def update
@@ -50,6 +48,15 @@ module Dashboard
       end
 
       private
+
+        # @note Validate the work like we're going to publish it, so we can inform the user ahead of time before they
+        # actually attempt it. However, we want to be nice and not yell at them for something they _haven't_ seen yet
+        # like rights.
+        def prevalidate
+          @work_version.publish
+          @work_version.validate
+          @work_version.errors.delete(:rights)
+        end
 
         def publish_work?
           !save_and_exit?

--- a/app/views/dashboard/work_form/publish/_fields.html.erb
+++ b/app/views/dashboard/work_form/publish/_fields.html.erb
@@ -2,6 +2,7 @@
   <%= render 'form_fields/select',
              form: form,
              attribute: :rights,
+             required: true,
              options_for_select: WorkVersion::Licenses.options_for_select_box,
              include_blank: true %>
 </div>
@@ -15,6 +16,7 @@
       <p class="font-weight-bold mt-5"><%= WorkVersion.human_attribute_name(:depositor_agreement) %></p>
       <div class="form-check">
         <%= form.check_box :depositor_agreement,
+                           required: true,
                            class: 'form-check-input' %>
 
         <%= form.label :depositor_agreement, class: 'form-check-label' do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,7 @@ en:
         display_work_type: Work Type
         display_doi: DOI
         file_resources: Files
+        visibility: Access
         visibility_badge: Access
         deposited_at: Deposited
       user:

--- a/spec/features/dashboard/visibility_spec.rb
+++ b/spec/features/dashboard/visibility_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Setting visibility in the dashboard', with_user: :user do
       FeatureHelpers::WorkForm.publish
 
       within('#error_explanation') do
-        expect(page).to have_content('Visibility cannot be private')
+        expect(page).to have_content('Access cannot be private')
       end
     end
   end

--- a/spec/features/publish_new_work_spec.rb
+++ b/spec/features/publish_new_work_spec.rb
@@ -458,6 +458,9 @@ RSpec.describe 'Publishing a work', with_user: :user do
       end
       FeatureHelpers::WorkForm.save_and_continue
 
+      # Don't yell at them for something they haven't seen yet
+      expect(page).not_to have_selector('div#error_explanation')
+
       # On the review page, change all the details metadata to ensure the params
       # are submitted correctly
       FeatureHelpers::WorkForm.fill_in_work_details(different_metadata)


### PR DESCRIPTION
License and deposit agreement are now marked required, which will inform users using HTML5 feature and will not longer display the error messages if they are navigating to the page for the first time.

We have also updated the visibility label to read _Access_, making it consistent throughout the application.

Fixes #700 
Fixes #707 