### PR TITLE
Use a null indexer for selective indexing of work versions

### DIFF
--- a/app/controllers/dashboard/work_form/base_controller.rb
+++ b/app/controllers/dashboard/work_form/base_controller.rb
@@ -35,14 +35,22 @@ module Dashboard
           end
         end
 
-        def update_or_save_work_version(attributes: nil)
-          @work_version.indexing_source = SolrIndexingJob.public_method(:perform_now)
+        def update_or_save_work_version(attributes: nil, index: true)
+          @work_version.indexing_source = if index
+                                            SolrIndexingJob.public_method(:perform_now)
+                                          else
+                                            null_indexer
+                                          end
 
           if attributes
             @work_version.update(attributes)
           else
             @work_version.save
           end
+        end
+
+        def null_indexer
+          Proc.new { nil }
         end
     end
   end

--- a/app/controllers/dashboard/work_form/publish_controller.rb
+++ b/app/controllers/dashboard/work_form/publish_controller.rb
@@ -18,7 +18,6 @@ module Dashboard
         authorize(@work_version)
 
         @work_version.attributes = work_version_params
-
         # If the user clicks the "Publish" button, *and* there are validation
         # errors, we still want to persist any changes to the draft version's
         # db record, while at the same time showing the publish validation errors
@@ -26,9 +25,9 @@ module Dashboard
         # The easiest way to do this is to immediately save all the form changes
         # against the draft validations, then mark the record as published and
         # save again--this time using the published validations. That way the
-        # approriate error messages will appear on the form when it's re-rendered
+        # appropriate error messages will appear on the form when it's re-rendered
         if publish_work?
-          update_or_save_work_version
+          update_or_save_work_version(index: false)
           @work_version.publish
         end
 

--- a/spec/features/publish_new_work_spec.rb
+++ b/spec/features/publish_new_work_spec.rb
@@ -471,6 +471,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
       version = work.versions.first
 
       expect(page).to have_selector('h3', text: version.title)
+      expect(page).to have_selector('span.badge--content', text: 'PUBLISHED')
 
       expect(version).to be_published
       expect(version.version_number).to eq 1


### PR DESCRIPTION
In the publish step of the work form, we save the record twice to ensure any changes are persisted even if publishing fails. This was creating an indexing problem because, presumably owing to the quick succession in which the record was being saved and indexed each time, the *second* save process wasn't getting committed to the index. As a result, a work version that was published, wasn't getting correctly indexed as such in Solr.

The fix is to only index on the second call to #save, and not to index on the first call.