### PR TITLE
"Back to work" button handles draft verisons

### DIFF
--- a/app/components/back_to_work_button_component.html.erb
+++ b/app/components/back_to_work_button_component.html.erb
@@ -1,0 +1,3 @@
+<%= link_to(t('dashboard.works.edit.back'),
+            path,
+            class: 'btn btn-outline-light btn--squish mr-lg-2 my-1') %>

--- a/app/components/back_to_work_button_component.rb
+++ b/app/components/back_to_work_button_component.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class BackToWorkButtonComponent < ApplicationComponent
+  attr_reader :work
+
+  def initialize(work:)
+    @work = work
+  end
+
+  # If the work has not been published, that is if it _only_ has a draft
+  # version, then we want to go to the resource page for that draft version.
+  # Otherwise, we want to to the resoure page of the work itself.
+  def path
+    resource = if work.latest_published_version.nil?
+                 work.draft_version
+               else
+                 work
+               end
+
+    resource_path(resource.uuid)
+  end
+end

--- a/app/views/dashboard/works/edit.html.erb
+++ b/app/views/dashboard/works/edit.html.erb
@@ -1,8 +1,6 @@
 <%= content_for :navbar_items do %>
   <li class="nav-item">
-    <%= link_to(t('.back'),
-                resource_path(@work.uuid),
-                class: 'btn btn-outline-light btn--squish mr-lg-2 my-1') %>
+    <%= render BackToWorkButtonComponent.new(work: @work) %>
   </li>
 <% end %>
 

--- a/spec/components/back_to_work_button_component_spec.rb
+++ b/spec/components/back_to_work_button_component_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BackToWorkButtonComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:component) { described_class.new(work: work) }
+  let(:result) { render_inline(component).css('a').first }
+
+  context 'when the Work has a latest published version' do
+    let(:work) { create :work, has_draft: false, versions_count: 1 }
+
+    it "renders a link back to the _Work's_ resource page" do
+      expect(result.text).to eq I18n.t('dashboard.works.edit.back', raise: true)
+      expect(result[:href]).to eq resource_path(work.uuid)
+    end
+  end
+
+  context 'when the has only a draft' do
+    let(:work) { create :work, has_draft: true, versions_count: 1 }
+
+    it "renders a link back to the _draft Version's_ resource page" do
+      expect(result[:href]).to eq resource_path(work.draft_version.uuid)
+    end
+  end
+end


### PR DESCRIPTION
#714 is caused by the way that the Dashboard and Work Settings pages interacted with draft-works (that is, a work with a single version in draft status). 

```
# The problem
Given I'm on the dashboard page
  And I click the title of a draft-work, 
      now I am on the *resource page for the draft WorkVersion*
  And I click the Work Settings button, 
      now I am in the settings for that work
When I click the Back to Work button
Then it sends me to the *resource page of the parent work*
  And I get a 500 panic because that pages assumes there's a published version

# The solution in this commit
Given I'm on the dashboard page
  And I click the title of a draft-work,
      now I am on the *resource page for the draft WorkVersion*
  And I click the Work Settings button,
      now I am in the settings for that work
When I click the Back to Work button
Then it sends me to the *resource page for the draft WorkVersion*
```

Note that I did not include an end-to-end feature spec for this, but I totally can if you think this is (a) a good solution (b) the feature spec is worthwhile.

Closes #714 

