### PR TITLE
Generate our sitemap automatically

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# @abstract Returns a auto-generated sitemap for a crawler. URLs are distributed across different pages depending on
+# which hexadecimal character(s) their UUID begins with.
+
+class SitemapController < ApplicationController
+  def index
+    @access_list = access_list
+  end
+
+  def show
+    (@response, _deprecated_document_list) = search_service.search_results
+  end
+
+  private
+
+    # @note This assumes all of our UUIDs are equally distributed so that there's at least one UUID that begins with
+    # each hexadecimal character. This may not be the case, and some characters may have none or more UUIDs than
+    # another.
+    def access_list
+      [*('a'..'f'), *('0'..'9')]
+    end
+
+    def search_service
+      @search_service ||= ::Blacklight::SearchService.new(
+        config: Blacklight::Configuration.new,
+        search_builder_class: SitemapSearchBuilder,
+        current_user: User.guest,
+        access_id: params.require(:id),
+        max_documents: max_documents
+      )
+    end
+
+    def max_documents
+      Rails.cache.fetch('index_max_docs', expires_in: 1.day) do
+        Blacklight.default_index.connection.select(params: { q: '*:*', rows: 0 })['response']['numFound']
+      end
+    end
+end

--- a/app/models/sitemap_search_builder.rb
+++ b/app/models/sitemap_search_builder.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class SitemapSearchBuilder < SearchBuilder
+  self.default_processor_chain += %i(
+    build_sitemap_query
+  )
+
+  # @note Builds a Solr query to return all the UUIDs that begin with #access_id
+  def build_sitemap_query(solr_parameters)
+    solr_parameters[:fl] = 'id, timestamp'
+    solr_parameters[:q] = "{!prefix f=uuid_ssi v=#{access_id}}"
+    solr_parameters[:rows] = max_documents
+    solr_parameters[:facet] = false
+    solr_parameters[:defType] = 'lucene'
+  end
+
+  private
+
+    def access_id
+      @scope.context[:access_id]
+    end
+
+    def max_documents
+      @scope.context[:max_documents]
+    end
+end

--- a/app/views/sitemap/index.xml.builder
+++ b/app/views/sitemap/index.xml.builder
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.sitemapindex(
+  'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+  'xsi:schemaLocation' => 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd',
+  'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9'
+) do
+  @access_list.each do |id|
+    xml.sitemap do
+      xml.loc(sitemap_url(id, format: :xml))
+    end
+  end
+end

--- a/app/views/sitemap/show.xml.builder
+++ b/app/views/sitemap/show.xml.builder
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.urlset(
+  'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+  'xsi:schemaLocation' => 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd',
+  'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9'
+) do
+  @response.documents.each do |doc|
+    xml.url do
+      xml.loc(resource_url(doc['id']))
+      xml.lastmod(doc['timestamp'])
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,8 @@ Rails.application.routes.draw do
     resource :doi, only: %i[create]
   end
 
+  resources :sitemap, defaults: { format: :xml }, only: [:index, :show]
+
   resources :bookmarks do
     concerns :exportable
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,3 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Crawl-delay: 10
+Sitemap: https://scholarsphere.psu.edu/sitemap.xml

--- a/spec/controllers/sitemap_controller_spec.rb
+++ b/spec/controllers/sitemap_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SitemapController, type: :controller do
+  let(:sitemap) { described_class.new }
+
+  describe 'GET #index' do
+    it 'returns a list of each hexadecimal character' do
+      expect(sitemap.index).to eq([*('a'..'f'), *('0'..'9')])
+    end
+  end
+
+  describe 'GET #show' do
+    let(:public_work) { build(:work, has_draft: false) }
+    let(:psu_work) { build(:work, :with_authorized_access, has_draft: false) }
+    let(:private_work) { build(:work, :with_private_access, has_draft: false) }
+    let(:collection) { build(:collection) }
+
+    let(:ids_0) { Array.new(4) { "0#{Faker::Number.number(digits: 7)}" } }
+    let(:ids_1) { Array.new(4) { "1#{Faker::Number.number(digits: 7)}" } }
+
+    let(:found_ids) { ids_0.take(3) }
+    let(:other_ids) { ids_1.push(ids_0.last) }
+
+    before do
+      # Index each resource into Solr with one of the random ids we've created, but note that order is important because
+      # we should *not* find the private_work.
+      [public_work, psu_work, collection, private_work].each_with_index do |resource, index|
+        document = resource.to_solr
+        Blacklight.default_index.connection.add(document.merge(id: ids_0[index], uuid_ssi: ids_0[index]))
+        Blacklight.default_index.connection.add(document.merge(id: ids_1[index], uuid_ssi: ids_1[index]))
+      end
+      Blacklight.default_index.connection.commit
+    end
+
+    render_views
+
+    it 'renders appropriate XML in the show view' do
+      get :show, params: { id: 0 }, format: 'xml'
+      found_ids.each do |id|
+        expect(response.body).to include "<loc>http://test.host/resources/#{id}</loc>"
+      end
+      other_ids.each do |id|
+        expect(response.body).not_to include "<loc>http://test.host/resources/#{id}</loc>"
+      end
+    end
+  end
+end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -55,4 +55,8 @@ FactoryBot.define do
   trait(:with_authorized_access) do
     visibility { Permissions::Visibility::AUTHORIZED }
   end
+
+  trait(:with_private_access) do
+    visibility { Permissions::Visibility::PRIVATE }
+  end
 end


### PR DESCRIPTION
Generates the sitemap each time it's requested. To keep the Solr response small, and page loading times short, each resource's uuid are distributed more-or-less evenly across 16 different sub-sections based on the starting hexadecimal character in the uuid.

This approach has been used in other, larger Blacklight instances, most notably our catalog: psu-libraries/psulib_blacklight@b536577

To ensure that nothing is indexed in the sitemap that shouldn't be, the Solr query to build the map is based off of the same query used in the search. Only resources that would be returned in a search will be included in the sitemap.

Fixes #697 