### PR TITLE
Update Orcid validation to allow check characters

### DIFF
--- a/app/javascript/controllers/inputmask_controller.js
+++ b/app/javascript/controllers/inputmask_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from 'stimulus'
+import Inputmask from 'inputmask'
+
+export default class extends Controller {
+  // Presently, there is only one input mask: orcid. So there isn't the need (yet) to try to apply different types of
+  // masks based on the input type or id.
+  connect () {
+    const im = new Inputmask('9999-9999-9999-999X', {
+      definitions: {
+        X: {
+          validator: '[0-9xX]',
+          casing: 'upper'
+        }
+      },
+      removeMaskOnSubmit: true
+    })
+    im.mask(this.element)
+  }
+}

--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -67,8 +67,8 @@ class Actor < ApplicationRecord
               allow_nil: true
             },
             format: {
-              with: /\A\d{16,16}\z/,
-              message: 'must be 16 digits only',
+              with: /\A\d{15,15}[0-9X]{1,1}\z/,
+              message: 'must be valid',
               allow_nil: true
             }
 

--- a/app/views/dashboard/actors/_new.html.erb
+++ b/app/views/dashboard/actors/_new.html.erb
@@ -35,7 +35,11 @@
 
     <div class="form-wrapper">
       <%= render 'form_fields/text', form: form, attribute: :surname, required: true %>
-      <%= render 'form_fields/text', form: form, attribute: :orcid, required: true %>
+      <%= render 'form_fields/text',
+                 form: form,
+                 attribute: :orcid,
+                 data: { controller: 'inputmask' },
+                 required: true %>
     </div>
 
     <div class="form-wrapper form-wrapper--wide">

--- a/app/views/form_fields/_text.html.erb
+++ b/app/views/form_fields/_text.html.erb
@@ -8,6 +8,7 @@
                       class: 'form-control',
                       placeholder: true,
                       required: local_assigns[:required].presence,
+                      data: local_assigns[:data],
                       aria: { describedby: (has_hint && hint_id).presence } %>
   <%= form.label attribute %>
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "caniuse-lite": "^1.0.30001115",
     "cocoon-js": "^0.0.5",
     "d3": "^5.16.0",
+    "inputmask": "^5.0.5",
     "jquery": "^3.5.1",
     "mustache": "^4.0.1",
     "popper.js": "^1.16.1",

--- a/spec/features/publish_new_work_spec.rb
+++ b/spec/features/publish_new_work_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         end
 
         within('.modal-content') do
-          expect(page).to have_content('ORCiD must be 16 digits only')
+          expect(page).to have_content('ORCiD must be valid')
         end
       end
     end

--- a/spec/models/actor_spec.rb
+++ b/spec/models/actor_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Actor, type: :model do
 
       before { actor.validate }
 
-      it { is_expected.to include('ORCiD must be 16 digits only') }
+      it { is_expected.to include('ORCiD must be valid') }
     end
   end
 end

--- a/spec/support/factory_bot_helpers.rb
+++ b/spec/support/factory_bot_helpers.rb
@@ -14,7 +14,7 @@ module FactoryBotHelpers
   end
 
   def self.generate_orcid
-    Faker::Number.leading_zero_number(digits: 16)
+    Faker::Number.leading_zero_number(digits: 15) + ['X', *('0'..'9')].sample
   end
 
   def self.fancy_geo_location

--- a/yarn.lock
+++ b/yarn.lock
@@ -4503,6 +4503,11 @@ ini@^1.3.4, ini@^1.3.5:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
+inputmask@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/inputmask/-/inputmask-5.0.5.tgz#93af99c35fc108d590e9bbd3ec6cc9b9a2e7c2ed"
+  integrity sha512-9gqau4tb0oaxYiymLC43KU/aAXHVofya7ilGIxqKONbSh7LNKRHmpw6mhuH2D4yykRlcNhS9zI/FOsrAQmltQA==
+
 internal-ip@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907"


### PR DESCRIPTION
The last character of the orcid is a check digit, which can be an "X" so we need to allow for that in the regex.

Fixes #726 