### PR TITLE
i#748 license display

### DIFF
--- a/app/components/display_rights_component.html.erb
+++ b/app/components/display_rights_component.html.erb
@@ -1,0 +1,3 @@
+<span class="display-rights">
+    <%= link_to label, id, target: :_blank, rel: 'noopener' %>
+</span>

--- a/app/components/display_rights_component.rb
+++ b/app/components/display_rights_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class DisplayRightsComponent < ApplicationComponent
+  attr_reader :id,
+              :label
+
+  def initialize(id:)
+    @id = id
+    @label = WorkVersion::Licenses.label(id)
+  end
+
+  def render?
+    label.present?
+  end
+end

--- a/app/components/work_version_metadata_component.rb
+++ b/app/components/work_version_metadata_component.rb
@@ -13,7 +13,7 @@ class WorkVersionMetadataComponent < ApplicationComponent
     :creator_aliases,
     :version_number,
     :keyword,
-    :rights,
+    :display_rights,
     :display_work_type,
     :contributor,
     :publisher,
@@ -42,9 +42,9 @@ class WorkVersionMetadataComponent < ApplicationComponent
   private
 
     def decorate(work_ver)
-      return work_ver if work_ver.is_a? ResourceDecorator
+      return work_ver if work_ver.is_a? WorkVersionDecorator
 
-      ResourceDecorator.new(work_ver)
+      WorkVersionDecorator.new(work_ver)
     end
 
     def attributes_list

--- a/app/decorators/work_version_decorator.rb
+++ b/app/decorators/work_version_decorator.rb
@@ -13,6 +13,10 @@ class WorkVersionDecorator < ResourceDecorator
     WorkDecorator.new(work)
   end
 
+  def display_rights
+    DisplayRightsComponent.new(id: rights)
+  end
+
   private
 
     def version_name_or_number

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -78,7 +78,10 @@ class WorkVersion < ApplicationRecord
       end
 
       def label(id)
-        all.select { |license| license[:id] == id }.first[:label]
+        all
+          .select { |license| license[:id] == id }
+          .map { |license| license[:label] }
+          .first
       end
     end
   end

--- a/config/authorities/licenses.yml
+++ b/config/authorities/licenses.yml
@@ -41,9 +41,12 @@ terms:
   - id: http://creativecommons.org/publicdomain/zero/1.0/
     term: CC0 1.0 Universal
     active: true
-  - id: http://www.europeana.eu/portal/rights/rr-r.html
+  - id: https://rightsstatements.org/page/InC/1.0/
     term: All rights reserved
     active: true
+  - id: http://www.europeana.eu/portal/rights/rr-r.html
+    term: All rights reserved
+    active: false
   - id: http://www.apache.org/licenses/LICENSE-2.0
     term: Apache 2.0
     active: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,7 @@ en:
         subtitle: Subtitle
         keyword: Keyword
         rights: License
+        display_rights: License
         description: Description
         creator_aliases: Creators
         first_creators: Creators

--- a/spec/components/display_rights_component_spec.rb
+++ b/spec/components/display_rights_component_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DisplayRightsComponent, type: :component do
+  subject(:component) { described_class.new(id: id) }
+
+  let(:element) { render_inline(component).css('.display-rights') }
+
+  context 'when the id is nil' do
+    let(:id) { nil }
+
+    it { is_expected.not_to be_render }
+  end
+
+  context 'with a valid id' do
+    let(:license) { WorkVersion::Licenses.all.sample }
+    let(:id) { license['id'] }
+
+    specify { expect(element.search('a').first.attribute('href').text).to eq(id) }
+    specify { expect(element.text).to include(license['label']) }
+  end
+
+  context 'with an invalid id' do
+    let(:id) { 'bogus' }
+
+    it { is_expected.not_to be_render }
+  end
+end

--- a/spec/components/work_version_metadata_component_spec.rb
+++ b/spec/components/work_version_metadata_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe WorkVersionMetadataComponent, type: :component do
-  let(:decorated_work_version) { ResourceDecorator.new(work_version) }
+  let(:decorated_work_version) { WorkVersionDecorator.new(work_version) }
   let(:result) { render_inline(described_class.new(work_version: decorated_work_version)) }
 
   # MintableDoiComponent uses the `helpers` method to access a Pundit policy, to
@@ -70,7 +70,7 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
       expect(result.css('th.work-version-visibility-badge')).to be_present
       expect(result.css('th.work-version-version-number')).to be_present
       expect(result.css('th.work-version-keyword')).to be_present
-      expect(result.css('th.work-version-rights')).to be_present
+      expect(result.css('th.work-version-display-rights')).to be_present
       expect(result.css('th.work-version-resource-type')).not_to be_present
       expect(result.css('th.work-version-display-work-type')).to be_present
       expect(result.css('th.work-version-contributor')).to be_present
@@ -93,7 +93,7 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
       expect(result.css('td.work-version-creator-aliases').text).to include work_version.creator_aliases.map(&:alias).first
       expect(result.css('td.work-version-version-number').text).to eq work_version[:version_number].to_s
       expect(result.css('td.work-version-keyword').text).to include work_version[:keyword].first
-      expect(result.css('td.work-version-rights').text).to eq work_version[:rights]
+      expect(result.css('td.work-version-display-rights a').attr('href').text).to eq work_version[:rights]
       expect(result.css('td.work-version-display-work-type').text).to eq decorated_work_version.display_work_type
       expect(result.css('td.work-version-contributor').text).to include work_version[:contributor].first
       expect(result.css('td.work-version-publisher').text).to include work_version[:publisher].first

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -475,12 +475,28 @@ RSpec.describe WorkVersion, type: :model do
           ],
           ['Public Domain Mark 1.0', 'http://creativecommons.org/publicdomain/mark/1.0/'],
           ['CC0 1.0 Universal', 'http://creativecommons.org/publicdomain/zero/1.0/'],
-          ['All rights reserved', 'http://www.europeana.eu/portal/rights/rr-r.html'],
+          ['All rights reserved', 'https://rightsstatements.org/page/InC/1.0/'],
           ['Apache 2.0', 'http://www.apache.org/licenses/LICENSE-2.0'],
           ['GNU General Public License (GPLv3)', 'https://www.gnu.org/licenses/gpl.html'],
           ['MIT License', 'https://opensource.org/licenses/MIT'],
           ['BSD 3-Clause License', 'https://opensource.org/licenses/BSD-3-Clause']
         )
+      end
+    end
+
+    describe '::label' do
+      subject { described_class.label(license['id']) }
+
+      context 'with an existing id' do
+        let(:license) { described_class.all.sample }
+
+        it { is_expected.to eq(license['label']) }
+      end
+
+      context 'with an invalid id' do
+        let(:license) { { 'id' => 'bogus' } }
+
+        it { is_expected.to be_nil }
       end
     end
   end


### PR DESCRIPTION
Displays the rights as a link to it's corresponding URI.

Fixes #748 