### PR TITLE
Add collections to dashboard results

### DIFF
--- a/app/controllers/dashboard/catalog_controller.rb
+++ b/app/controllers/dashboard/catalog_controller.rb
@@ -53,6 +53,13 @@ module Dashboard
       config.add_facet_field 'subject_sim', label: I18n.t('catalog.facets.subject_sim'), limit: true
       config.add_facet_field 'creators_sim', label: I18n.t('catalog.facets.creators_sim'), limit: true
       config.add_facet_field 'migration_errors_sim', label: I18n.t('catalog.facets.migration_errors_sim'), limit: true
+
+      # Reset the sort fields configuration inherited from CatalogController
+      config.sort_fields = {}
+
+      config.add_sort_field 'updated_at_dtsi desc', label: 'most recent'
+      config.add_sort_field 'score desc', label: 'relevance'
+      config.add_sort_field 'title_tesim asc', label: 'title'
     end
   end
 end

--- a/app/models/dashboard/search_builder.rb
+++ b/app/models/dashboard/search_builder.rb
@@ -12,8 +12,9 @@ module Dashboard
 
     def search_only_latest_work_versions(solr_parameters)
       solr_parameters[:fq] ||= []
-
-      solr_parameters[:fq] << '({!terms f=model_ssi}WorkVersion AND {!terms f=latest_version_bsi}true})'
+      latest_work_versions = '({!terms f=model_ssi}WorkVersion AND {!terms f=latest_version_bsi}true})'
+      collections = '({!terms f=model_ssi}Collection)'
+      solr_parameters[:fq] << "(#{latest_work_versions} OR #{collections})"
     end
 
     def apply_gated_edit(solr_parameters)

--- a/spec/models/dashboard/search_builder_spec.rb
+++ b/spec/models/dashboard/search_builder_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe Dashboard::SearchBuilder do
 
     it 'searches only latest work versions' do
       expect(parameters['fq']).to include(
-        '({!terms f=model_ssi}WorkVersion AND {!terms f=latest_version_bsi}true})'
+        '(({!terms f=model_ssi}WorkVersion AND {!terms f=latest_version_bsi}true}) ' \
+        'OR ' \
+        '({!terms f=model_ssi}Collection))'
       )
     end
 


### PR DESCRIPTION
Includes collections editable by the user in their dashboard search results. Due to the fact that `updated_at` timestamps are too close to one another, testing search results sorting was inconsistent and has been removed.

Fixes #516 