### PR TITLE
Add Edit button to collection resource page

### DIFF
--- a/app/views/resources/_collection.html.erb
+++ b/app/views/resources/_collection.html.erb
@@ -6,6 +6,16 @@
   <%= render 'meta_tags', resource: collection, uuid: params[:id] %>
 <% end %>
 
+<%= content_for :navbar_items do %>
+  <% if policy(collection).edit? %>
+    <li class="nav-item py-1">
+      <%= link_to t('resources.collection.edit_button'),
+                  dashboard_form_collection_details_path(collection.id),
+                  class: 'btn btn-outline-light btn--squish mr-lg-2' %>
+    </li>
+  <% end %>
+<% end %>
+
 <div class="container-fluid">
   <article class="row">
     <div class="col-lg-7">

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -16,9 +16,9 @@
     <li class="nav-item">
       <%= render LinkDisabledByTooltipComponent.new(
             enabled: policy(work_version).edit?,
-            text: I18n.t('resources.edit_button.text', version: work_version.display_version_short),
+            text: I18n.t('resources.work_version.edit_button.text', version: work_version.display_version_short),
             path: dashboard_form_work_version_details_path(work_version.id),
-            tooltip: I18n.t('resources.edit_button.tooltip'),
+            tooltip: I18n.t('resources.work_version.edit_button.tooltip'),
             class_list: 'btn btn-outline-light btn--squish mr-lg-2 qa-edit-version'
           ) %>
     </li>
@@ -26,10 +26,10 @@
     <li class="nav-item">
       <%= render LinkDisabledByTooltipComponent.new(
             enabled: policy(work_version).new?,
-            text: I18n.t('resources.create_button.text', version: work_version.display_version_short),
+            text: I18n.t('resources.work_version.create_button.text', version: work_version.display_version_short),
             path: dashboard_work_work_versions_path(work_version.work),
             method: :post,
-            tooltip: I18n.t('resources.create_button.tooltip'),
+            tooltip: I18n.t('resources.work_version.create_button.tooltip'),
             class_list: 'btn btn-outline-light btn--squish mr-lg-4 qa-create-draft'
           ) %>
     </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -435,12 +435,15 @@ en:
       create: 'Create a DOI for this work'
       confirm: 'Do you want to create a DOI? This DOI will always resolve to the most recently published version of this work.'
       disable_with: 'Creating...'
-    edit_button:
-      text: 'Edit %{version}'
-      tooltip: 'Only a draft can be edited. Create a new version to add changes to the published work.'
-    create_button:
-      text: 'Create New Version From %{version}'
-      tooltip: 'A new draft version can only be created from the latest published version. Only one draft version may exist at any time.'
+    work_version:
+      edit_button:
+        text: 'Edit %{version}'
+        tooltip: 'Only a draft can be edited. Create a new version to add changes to the published work.'
+      create_button:
+        text: 'Create New Version From %{version}'
+        tooltip: 'A new draft version can only be created from the latest published version. Only one draft version may exist at any time.'
+    collection:
+      edit_button: 'Edit'
     settings_button:
       text: 'Work Settings'
   shared:

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Public Resources', type: :feature do
 
         ## Does not have edit controls
         within('header') do
-          expect(page).not_to have_content(I18n.t('resources.edit_button.text', version: 'V2'))
+          expect(page).not_to have_content(I18n.t('resources.work_version.edit_button.text', version: 'V2'))
           expect(page).not_to have_content(I18n.t('resources.settings_button.text'))
         end
 
@@ -53,8 +53,8 @@ RSpec.describe 'Public Resources', type: :feature do
 
           within('header') do
             ## Edit controls are visible
-            expect(page).to have_content(I18n.t('resources.edit_button.text', version: 'V2'))
-              .and have_content(I18n.t('resources.create_button.text', version: 'V2'))
+            expect(page).to have_content(I18n.t('resources.work_version.edit_button.text', version: 'V2'))
+              .and have_content(I18n.t('resources.work_version.create_button.text', version: 'V2'))
               .and have_content(I18n.t('resources.settings_button.text'))
 
             ## Edit button is disabled, create draft button is enabled
@@ -111,50 +111,67 @@ RSpec.describe 'Public Resources', type: :feature do
     end
   end
 
-  describe 'given a collection without a DOI' do
-    let(:collection) { create :collection, :with_complete_metadata, works: [work] }
-    let(:work) { build :work, has_draft: false, versions_count: 1 }
+  describe 'a collection' do
+    context 'when it does NOT have a DOI' do
+      let(:collection) { create :collection, :with_complete_metadata, works: [work] }
+      let(:work) { build :work, has_draft: false, versions_count: 1 }
 
-    it 'displays the public resource page for the collection' do
-      visit resource_path(collection.uuid)
+      it 'displays the public resource page for the collection' do
+        visit resource_path(collection.uuid)
 
-      expect(page.title).to include(collection.title)
+        expect(page.title).to include(collection.title)
 
-      # Spot check meta tags
-      expect(page.find('meta[property="og:title"]', visible: false)[:content]).to eq collection.title
-      expect(page.find('meta[property="og:description"]', visible: false)[:content]).to eq collection.description
-      # Below was failing in CI due to hostnames getting weird
-      expect(page.find('meta[property="og:url"]', visible: false)[:content])
-        .to match(resource_path(collection.uuid)).and match(/^https?:/)
-      expect(page.find('meta[name="citation_title"]', visible: false)[:content]).to eq collection.title
-      expect(page.find('meta[name="citation_publication_date"]', visible: false)[:content])
-        .to eq collection.published_date
-      all_authors = page.all(:css, 'meta[name="citation_author"]', visible: false)
-      expect(all_authors.map { |a| a[:content] }).to match_array collection.creator_aliases.map(&:alias)
+        # Spot check meta tags
+        expect(page.find('meta[property="og:title"]', visible: false)[:content]).to eq collection.title
+        expect(page.find('meta[property="og:description"]', visible: false)[:content]).to eq collection.description
+        # Below was failing in CI due to hostnames getting weird
+        expect(page.find('meta[property="og:url"]', visible: false)[:content])
+          .to match(resource_path(collection.uuid)).and match(/^https?:/)
+        expect(page.find('meta[name="citation_title"]', visible: false)[:content]).to eq collection.title
+        expect(page.find('meta[name="citation_publication_date"]', visible: false)[:content])
+          .to eq collection.published_date
+        all_authors = page.all(:css, 'meta[name="citation_author"]', visible: false)
+        expect(all_authors.map { |a| a[:content] }).to match_array collection.creator_aliases.map(&:alias)
 
-      expect(page).to have_selector('h1', text: collection.title)
-      expect(page).to have_content collection.description
-      expect(page).to have_content work.latest_published_version.title
+        expect(page).to have_selector('h1', text: collection.title)
+        expect(page).to have_content collection.description
+        expect(page).to have_content work.latest_published_version.title
 
-      within('td.collection-title') do
-        expect(page).to have_content(collection.title)
+        within('td.collection-title') do
+          expect(page).to have_content(collection.title)
+        end
       end
     end
-  end
 
-  describe 'given a collection with a DOI' do
-    let(:collection) { create :collection, :with_complete_metadata, :with_a_doi, works: [work] }
-    let(:work) { build :work, has_draft: false, versions_count: 1 }
+    context 'when it has a DOI' do
+      let(:collection) { create :collection, :with_complete_metadata, :with_a_doi, works: [work] }
+      let(:work) { build :work, has_draft: false, versions_count: 1 }
 
-    it 'displays the public resource page for the collection' do
-      visit resource_path(collection.uuid)
+      it 'displays the public resource page for the collection' do
+        visit resource_path(collection.uuid)
 
-      expect(page).to have_selector('h1', text: collection.title)
-      expect(page).to have_content collection.description
-      expect(page).to have_content work.latest_published_version.title
+        expect(page).to have_selector('h1', text: collection.title)
+        expect(page).to have_content collection.description
+        expect(page).to have_content work.latest_published_version.title
 
-      within('td.collection-display-doi') do
-        expect(page).to have_content(collection.doi)
+        within('td.collection-display-doi') do
+          expect(page).to have_content(collection.doi)
+        end
+      end
+    end
+
+    context 'when logged in as the resource owner', with_user: :user do
+      let(:collection) { create :collection }
+      let(:user) { collection.depositor.user }
+
+      it 'displays edit controls on the resource page' do
+        visit resource_path(collection.uuid)
+
+        expect(page.title).to include(collection.title)
+
+        within('header') do
+          expect(page).to have_content(I18n.t('resources.collection.edit_button'))
+        end
       end
     end
   end


### PR DESCRIPTION
If the user has edit access, show a button that links to the collection edit form. This follows the same UI layout and styling as the resource page for works.

Fixes #741 