### PR TITLE
Respond with json for errors in non-html formats

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,10 +2,16 @@
 
 class ErrorsController < ApplicationController
   def not_found
-    render 'not_found', status: :not_found
+    respond_to do |format|
+      format.html { render 'not_found', status: :not_found }
+      format.any { render json: { message: 'Record not found' }, status: :not_found }
+    end
   end
 
   def server_error
-    render 'server_error', status: :internal_server_error
+    respond_to do |format|
+      format.html { render 'server_error', status: :internal_server_error }
+      format.any { render json: { message: 'Server error' }, status: :internal_server_error }
+    end
   end
 end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -5,15 +5,39 @@ require 'rails_helper'
 RSpec.describe ErrorsController, type: :controller do
   subject { response }
 
-  context 'with a 404 error' do
-    before { get :not_found }
+  let(:non_html_format) do
+    ext = Faker::File.extension
 
-    its(:status) { is_expected.to eq(404) }
+    ext == 'html' ? :xml : ext.to_sym
   end
 
-  context 'with a 500 error' do
-    before { get :server_error }
+  describe 'GET #not_found' do
+    context 'with the default html format' do
+      before { get :not_found }
 
-    its(:status) { is_expected.to eq(500) }
+      its(:status) { is_expected.to eq(404) }
+    end
+
+    context 'with any other specified format' do
+      before { get :not_found, format: :non_html_format }
+
+      its(:status) { is_expected.to eq(404) }
+      its(:body) { is_expected.to eq('{"message":"Record not found"}') }
+    end
+  end
+
+  describe 'GET #server_error' do
+    context 'with the default html format' do
+      before { get :server_error }
+
+      its(:status) { is_expected.to eq(500) }
+    end
+
+    context 'with any other specified format' do
+      before { get :server_error, format: :non_html_format }
+
+      its(:status) { is_expected.to eq(500) }
+      its(:body) { is_expected.to eq('{"message":"Server error"}') }
+    end
   end
 end


### PR DESCRIPTION
Custom error responses need to account for the format of the original request. If a user requests a resource in a format other than html, such as xml, rss, or other, the error response will attempt the respond using the requested format. This was causing missing template errors because the application was trying to honor the request with the requested format.

Since we don't want to attempt to match every kind of non-html response, we'll just respond with json for any non-html request that generates an error.

Fixes #745