### PR TITLE
Support html-only responses in catalog searches

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -9,6 +9,17 @@ class CatalogController < ApplicationController
     { current_user: current_user }
   end
 
+  def index
+    (@response, _document_list) = search_service.search_results
+
+    respond_to do |format|
+      format.html { store_preferred_view }
+      format.json do
+        @presenter = Blacklight::JsonPresenter.new(@response, blacklight_config)
+      end
+    end
+  end
+
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository

--- a/spec/request/catalog_spec.rb
+++ b/spec/request/catalog_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CatalogController, type: :request do
+  describe 'GET #index' do
+    # @note Atom and RSS feeds are supported by default in Blacklight, but we're removing it on purpose because the view
+    # partials provided in the gem are raising errors. Reinstating this feature would involve overriding the partials
+    # to display correctly, but that is currently out of scope.
+    context 'when requesting an rss feed' do
+      specify do
+        expect { get '/catalog.rss' }.to raise_error(ActionController::UnknownFormat)
+      end
+    end
+
+    context 'when requesting an atom feed' do
+      specify do
+        expect { get '/catalog.atom' }.to raise_error(ActionController::UnknownFormat)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This removes support for atom and rss feeds via catalog searches as well as exporting searches in different document formats. If we want to reenable these features, we can revert this commit at a later time.

Fixes #738 