### PR TITLE
Support deleting collections

### DIFF
--- a/app/controllers/dashboard/form/collection_details_controller.rb
+++ b/app/controllers/dashboard/form/collection_details_controller.rb
@@ -28,6 +28,15 @@ module Dashboard
         process_response(on_error: :edit)
       end
 
+      def destroy
+        @resource = Collection.find(params[:id])
+        authorize(@resource)
+        @resource.destroy
+        respond_to do |format|
+          format.html { redirect_to dashboard_root_path, notice: 'Collection was successfully deleted.' }
+        end
+      end
+
       private
 
         def new_collection(attrs = {})

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -75,7 +75,7 @@ class Collection < ApplicationRecord
 
   after_save :perform_update_index
 
-  after_destroy { SolrDeleteJob.perform_later(uuid) }
+  after_destroy { SolrDeleteJob.perform_now(uuid) }
 
   # Fields that can contain multiple values automatically remove blank values
   %i[

--- a/app/views/resources/_collection.html.erb
+++ b/app/views/resources/_collection.html.erb
@@ -14,6 +14,14 @@
                   class: 'btn btn-outline-light btn--squish mr-lg-2' %>
     </li>
   <% end %>
+
+  <% if policy(collection).destroy? %>
+    <%= link_to t('resources.collection.delete_button'),
+                dashboard_form_collection_details_path(collection),
+                class: 'btn btn-danger btn--squish mr-lg-2',
+                method: :delete,
+                data: { confirm: t('resources.collection.delete_confirm') } %>
+  <% end %>
 <% end %>
 
 <div class="container-fluid">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -445,6 +445,8 @@ en:
         tooltip: 'A new draft version can only be created from the latest published version. Only one draft version may exist at any time.'
     collection:
       edit_button: 'Edit'
+      delete_button: 'Delete'
+      delete_confirm: "Are you sure you want to delete this collection? This cannot be undone."
     settings_button:
       text: 'Work Settings'
   shared:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,7 @@ Rails.application.routes.draw do
 
         get   ':id/details', to: 'collection_details#edit', as: 'collection_details'
         match ':id/details', to: 'collection_details#update', via: %i[patch put], as: nil
+        match ':id/details', to: 'collection_details#destroy', via: :delete, as: nil
 
         get   ':id/members', to: 'members#edit', as: 'members'
         match ':id/members', to: 'members#update', via: %i[patch put], as: nil

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -165,14 +165,18 @@ RSpec.describe 'Public Resources', type: :feature do
       let(:collection) { create :collection }
       let(:user) { collection.depositor.user }
 
-      it 'displays edit controls on the resource page' do
+      it 'displays edit controls on the resource page and allows the user to delete the collection' do
         visit resource_path(collection.uuid)
 
         expect(page.title).to include(collection.title)
 
         within('header') do
           expect(page).to have_content(I18n.t('resources.collection.edit_button'))
+          click_on I18n.t('resources.collection.delete_button')
         end
+
+        expect(page).to have_current_path(dashboard_root_path)
+        expect(page).to have_content('Collection was successfully deleted.')
       end
     end
   end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -289,11 +289,11 @@ RSpec.describe Collection, type: :model do
   describe 'after destroy' do
     let(:collection) { create(:collection) }
 
-    before { allow(SolrDeleteJob).to receive(:perform_later) }
+    before { allow(SolrDeleteJob).to receive(:perform_now) }
 
     it 'removes the collection from the index' do
       collection.destroy
-      expect(SolrDeleteJob).to have_received(:perform_later).with(collection.uuid)
+      expect(SolrDeleteJob).to have_received(:perform_now).with(collection.uuid)
     end
   end
 


### PR DESCRIPTION
Adds a delete button to the collection resource page which deletes the collection with a confirmation dialog. Collections are now deleted from Solr synchronously. We may want to revisit this later and adopt the pattern similar to updating indexes via a source method that can be either async or sync, but that is out of scope at this moment.

Fixes #774 