### PR TITLE
Bug: Collections with no works

### DIFF
--- a/app/controllers/dashboard/form/members_controller.rb
+++ b/app/controllers/dashboard/form/members_controller.rb
@@ -19,6 +19,8 @@ module Dashboard
       private
 
         def collection_params
+          return {} unless params.key?(:collection)
+
           params
             .require(:collection)
             .permit(

--- a/spec/features/dashboard/collection_form_spec.rb
+++ b/spec/features/dashboard/collection_form_spec.rb
@@ -162,4 +162,19 @@ RSpec.describe 'Creating and editing collections', :inline_jobs, with_user: :use
       expect(collection.works).to be_empty
     end
   end
+
+  context 'when a collection has no works' do
+    let(:collection) { create(:collection, depositor: actor) }
+
+    it 'updates successfully' do
+      visit(dashboard_form_members_path(collection))
+
+      expect(collection.works).to be_empty
+
+      FeatureHelpers::DashboardForm.save_and_continue
+
+      expect(page).to have_content('Collection was updated successfully')
+      expect(collection.works).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Due to the way the form is built, if there are no works in the collection, then there is no form data at all for that particular tab, so we allow the form to save without making any changes.