### PR TITLE
Updates to contributors stimulus controller

### DIFF
--- a/app/javascript/controllers/associations_controller.js
+++ b/app/javascript/controllers/associations_controller.js
@@ -1,3 +1,7 @@
+// @abstract Adds ordered associations to a resource, such as creators to work versions and collections, as well as
+// member works to a collection. A new association is posted to an endpoint and then the order updated in DOM. Existing
+// associations can be reordered on the page.
+
 import { Controller } from 'stimulus'
 import axios from 'axios'
 import { csrfToken } from './stimulus_modules'

--- a/app/javascript/controllers/contributors_controller.js
+++ b/app/javascript/controllers/contributors_controller.js
@@ -51,6 +51,7 @@ export default class extends Controller {
   }
 
   moveUp (event) {
+    event.preventDefault()
     const $target = $(event.target)
     const $parentWrapper = $target.closest(`.${this.wrapperClass}`)
     const $previousSibling = $parentWrapper.prevAll(`.${this.wrapperClass}:visible`).first()
@@ -62,6 +63,7 @@ export default class extends Controller {
   }
 
   moveDown (event) {
+    event.preventDefault()
     const $target = $(event.target)
     const $parentWrapper = $target.closest(`.${this.wrapperClass}`)
     const $nextSibling = $parentWrapper.nextAll(`.${this.wrapperClass}:visible`).first()

--- a/app/views/dashboard/form/contributors/_creator_alias_fields.html.erb
+++ b/app/views/dashboard/form/contributors/_creator_alias_fields.html.erb
@@ -33,7 +33,7 @@
                   class: 'move js-move-up',
                   title: t('dashboard.form.contributors.edit.move_up', name: form.object.alias),
                   data: {
-                    action: 'contributors#moveUp',
+                    action: 'associations#moveUp',
                     toggle: 'tooltip', placement: 'top', offset: '0,100%'
                   } do %>
         <span class="sr-only"><%= t('dashboard.form.contributors.edit.move_up', name: form.object.alias) %></span>
@@ -44,7 +44,7 @@
                   class: 'move js-move-down',
                   title: t('dashboard.form.contributors.edit.move_down', name: form.object.alias),
                   data: {
-                    action: 'contributors#moveDown',
+                    action: 'associations#moveDown',
                     toggle: 'tooltip', placement: 'top', offset: '0,100%'
                   } do %>
         <span class="sr-only"><%= t('dashboard.form.contributors.edit.move_down', name: form.object.alias) %></span>

--- a/app/views/dashboard/form/contributors/_creators.html.erb
+++ b/app/views/dashboard/form/contributors/_creators.html.erb
@@ -7,12 +7,12 @@
 </div>
 
 <div id="creator_aliases"
-     data-controller="contributors"
-     data-contributors-new="<%= dashboard_form_actors_path(resource_klass: klass) %>"
-     data-contributors-post="<%= dashboard_form_aliases_path(resource_klass: klass) %>"
-     data-contributors-wrapper-class="js-contributor-wrapper"
-     data-contributors-badge-class="badge--index"
-     data-contributors-position-class="js-position-index">
+     data-controller="associations"
+     data-associations-new="<%= dashboard_form_actors_path(resource_klass: klass) %>"
+     data-associations-post="<%= dashboard_form_aliases_path(resource_klass: klass) %>"
+     data-associations-wrapper-class="js-contributor-wrapper"
+     data-associations-badge-class="badge--index"
+     data-associations-position-class="js-position-index">
   <%= form.fields_for :creator_aliases do |creator_alias| %>
     <%= render 'dashboard/form/contributors/creator_alias_fields', form: creator_alias %>
   <% end %>

--- a/app/views/dashboard/form/members/_work_membership_fields.html.erb
+++ b/app/views/dashboard/form/members/_work_membership_fields.html.erb
@@ -39,7 +39,7 @@
                   class: 'move js-move-up',
                   title: t('dashboard.form.members.move_up', name: work_version.title),
                   data: {
-                    action: 'contributors#moveUp',
+                    action: 'associations#moveUp',
                     toggle: 'tooltip', placement: 'top', offset: '0,100%'
                   } do %>
         <span class="sr-only"><%= t('dashboard.form.members.move_up', name: work_version.title) %></span>
@@ -50,7 +50,7 @@
                   class: 'move js-move-down',
                   title: t('dashboard.form.members.move_down', name: work_version.title),
                   data: {
-                    action: 'contributors#moveDown',
+                    action: 'associations#moveDown',
                     toggle: 'tooltip', placement: 'top', offset: '0,100%'
                   } do %>
         <span class="sr-only"><%= t('dashboard.form.members.move_down', name: work_version.title) %></span>

--- a/app/views/dashboard/form/members/_works.html.erb
+++ b/app/views/dashboard/form/members/_works.html.erb
@@ -5,11 +5,11 @@
 </div>
 
 <div id="works"
-     data-controller="contributors"
-     data-contributors-post="<%= dashboard_form_collection_memberships_path %>"
-     data-contributors-wrapper-class="js-work-wrapper"
-     data-contributors-badge-class="badge--index"
-     data-contributors-position-class="js-position-index">
+     data-controller="associations"
+     data-associations-post="<%= dashboard_form_collection_memberships_path %>"
+     data-associations-wrapper-class="js-work-wrapper"
+     data-associations-badge-class="badge--index"
+     data-associations-position-class="js-position-index">
   <%= form.fields_for :collection_work_memberships do |work_membership| %>
     <%= render 'dashboard/form/members/work_membership_fields', form: work_membership %>
   <% end %>


### PR DESCRIPTION
Adds the `preventDefault()` action when moving associations up and down and renames the controller to `associations_controller.js` since it's being used for more than just contributors.

Fixes #773 