### PR TITLE
Remove references to file editor controller

### DIFF
--- a/app/views/dashboard/form/files/_uploaded_file_list.html.erb
+++ b/app/views/dashboard/form/files/_uploaded_file_list.html.erb
@@ -9,17 +9,13 @@
   </thead>
   <tbody class="work-files__file">
     <% file_version_memberships.each do |membership| %>
-      <tr id="<%= dom_id membership %>" data-controller="filename-editor">
+      <tr id="<%= dom_id membership %>">
         <td>
-          <span class="filename" data-target="filename-editor.titleStatic"><%= membership.title %></span>
-          <%# render 'inline_filename_editor', membership: membership %>
+          <span class="filename"><%= membership.title %></span>
         </td>
         <td><%= membership.mime_type %></td>
         <td><%= number_to_human_size membership.size %></td>
         <td>
-          <%# link_to t('dashboard.file_list.edit.rename'),
-                      edit_dashboard_file_path(membership),
-                      data: { action: 'click->filename-editor#toggleForm' } %>
           <%= link_to t('dashboard.file_list.edit.delete'),
                       dashboard_file_path(membership),
                       method: :delete,


### PR DESCRIPTION
Previously, filename_editor_controller.js enable inline editing of filenames, but that feature has been disabled for now. However, the stimulus controller was still being loaded in the form, which was causing errors in the console. Although this didn't affect the function of the form, it's better to not have the errors popping up.

References to the js controller have been removed, but the controller is still there in case we want to reenable these features in the future.