### PR TITLE
Index resources only when completing or exiting the form

### DIFF
--- a/app/controllers/dashboard/form/base_controller.rb
+++ b/app/controllers/dashboard/form/base_controller.rb
@@ -36,6 +36,14 @@ module Dashboard
           params.key?(:save_and_exit)
         end
 
+        def publish?
+          params.key?(:publish)
+        end
+
+        def finish?
+          params.key?(:finish)
+        end
+
         def redirect_upon_success
           if save_and_exit?
             redirect_to resource_path(@resource.uuid), notice: "#{@resource.model_name.human} was successfully updated."
@@ -63,7 +71,7 @@ module Dashboard
         end
 
         def save_resource(index: true)
-          @resource.indexing_source = if index
+          @resource.indexing_source = if (publish? || finish? || save_and_exit?) && index
                                         SolrIndexingJob.public_method(:perform_now)
                                       else
                                         null_indexer

--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -24,7 +24,7 @@ module Dashboard
         # against the draft validations, then mark the record as published and
         # save again--this time using the published validations. That way the
         # appropriate error messages will appear on the form when it's re-rendered
-        if publish_work?
+        if publish?
           save_resource(index: false)
           @resource.publish
         end
@@ -43,12 +43,8 @@ module Dashboard
           @resource.errors.delete(:rights)
         end
 
-        def publish_work?
-          !save_and_exit?
-        end
-
         def redirect_upon_success
-          notice = if publish_work?
+          notice = if publish?
                      'Successfully published work!'
                    else
                      'Work version was successfully updated.'

--- a/app/views/dashboard/form/contributors/edit.html.erb
+++ b/app/views/dashboard/form/contributors/edit.html.erb
@@ -24,7 +24,7 @@
 
             <%= render 'contributors', form: form %>
 
-            <%= render 'dashboard/form/shared/action_footer', form: form, publish: false %>
+            <%= render 'dashboard/form/shared/action_footer', form: form %>
           <% end %>
         </div>
       </div>

--- a/app/views/dashboard/form/details/_form.html.erb
+++ b/app/views/dashboard/form/details/_form.html.erb
@@ -4,5 +4,5 @@
 
   <%= render "#{param_key}_fields", form: form %>
 
-  <%= render 'dashboard/form/shared/action_footer', form: form, publish: false %>
+  <%= render 'dashboard/form/shared/action_footer', form: form %>
 <% end %>

--- a/app/views/dashboard/form/files/edit.html.erb
+++ b/app/views/dashboard/form/files/edit.html.erb
@@ -19,7 +19,7 @@
               ) do |form| %>
             <%= render 'fields', form: form %>
 
-            <%= render 'dashboard/form/shared/action_footer', form: form, publish: false %>
+            <%= render 'dashboard/form/shared/action_footer', form: form %>
           <% end %>
 
         </div>

--- a/app/views/dashboard/form/members/edit.html.erb
+++ b/app/views/dashboard/form/members/edit.html.erb
@@ -23,7 +23,7 @@
 
             <%= render 'search' %>
 
-            <%= render 'dashboard/form/shared/action_footer', form: form, publish: false %>
+            <%= render 'dashboard/form/shared/action_footer', form: form, primary_action: :finish %>
           <% end %>
 
         </div>

--- a/app/views/dashboard/form/publish/edit.html.erb
+++ b/app/views/dashboard/form/publish/edit.html.erb
@@ -44,7 +44,7 @@
             </div>
             <%= render 'fields', form: form %>
 
-            <%= render 'dashboard/form/shared/action_footer', form: form, publish: true %>
+            <%= render 'dashboard/form/shared/action_footer', form: form, primary_action: :publish %>
           <% end %>
 
         </div>

--- a/app/views/dashboard/form/shared/_action_footer.html.erb
+++ b/app/views/dashboard/form/shared/_action_footer.html.erb
@@ -1,9 +1,9 @@
-<% primary_text = local_assigns[:publish].presence ? t('dashboard.form.actions.publish') : t('dashboard.form.actions.save_and_continue') -%>
+<% primary_action = local_assigns.fetch(:primary_action, :save_and_continue) %>
 
 <footer class="footer footer--actions footer--fixed d-flex justify-content-center">
   <%= form.button t("dashboard.form.actions.save_and_exit.#{param_key}"), name: 'save_and_exit', class: 'btn btn-outline-primary btn--rounded' %>
   <div>
     <%= link_to t('dashboard.form.actions.cancel'), cancel_path, class: 'btn btn-outline-dark btn--rounded' %>
-    <%= form.submit primary_text, class: 'btn btn-primary btn--rounded ml-2' %>
+    <%= form.submit t("dashboard.form.actions.#{primary_action}"), name: primary_action, class: 'btn btn-primary btn--rounded ml-2' %>
   </div>
 </footer>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -257,6 +257,7 @@ en:
         save_and_continue: Save and Continue
         cancel: Cancel
         publish: Publish
+        finish: Finish
         save_and_exit:
           collection: Save and Exit
           work_version: Save as Draft & Exit

--- a/spec/support/feature_helpers/dashboard_form.rb
+++ b/spec/support/feature_helpers/dashboard_form.rb
@@ -103,6 +103,11 @@ module FeatureHelpers
       click_on I18n.t('dashboard.form.actions.publish')
     end
 
+    def self.finish
+      fix_sticky_footer
+      click_on I18n.t('dashboard.form.actions.finish')
+    end
+
     def self.fix_sticky_footer
       Capybara.current_session.current_window.resize_to(1000, 1000)
     rescue Capybara::NotSupportedByDriverError


### PR DESCRIPTION
When editing work versions or collections, it's only necessary to index the resources in Solr when completing the last step of the form, or when exiting in the middle. For work versions, this means that we'll only index the work in Solr if publishing is successful, or if the user saves and exits the form. Likewise, with collections, they will only be indexed after the final "finish" step when members are added, or if the user saves and exits the form.

This will improve performance between steps, since no sync. indexing will be done, and will hopefully avoid any issues with multiple index jobs overwriting one another.

Indexing will always be sync. or won't happen at all.

Fixes #651 
Fixes #751 (we hope)