### PR TITLE
Change Matomo's default ID to the dev site

### DIFF
--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -25,7 +25,7 @@
       (function() {
         var u = "<%= ENV.fetch('MATOMO_URL', 'https://analytics.libraries.psu.edu/matomo/') %>";
         _paq.push(['setTrackerUrl', u+'matomo.php']);
-        _paq.push(['setSiteId', '<%= ENV.fetch('MATOMO_SITE_ID', '15') %>']);
+        _paq.push(['setSiteId', '<%= ENV.fetch('MATOMO_SITE_ID', '18') %>']);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
       })();

--- a/spec/features/matomo_spec.rb
+++ b/spec/features/matomo_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Matomo Traking Code' do
   it 'has the default configuration' do
     visit(blacklight_path)
     expect(page).to have_content('https://analytics.libraries.psu.edu/matomo')
-    expect(page).to have_content('15')
+    expect(page).to have_content('18')
     expect(page).to have_content('/* tracker methods like "setCustomDimension" should be called before "trackPageView" */')
   end
 end


### PR DESCRIPTION
Uses a site ID in Matomo that's exclusively for development. This will prevent any unwanted statistics from getting into other configured sites such as QA and Prod.

Fixes #756 