### PR TITLE
Refactor Google Scholar meta tags

### DIFF
--- a/app/components/google_scholar_metadata_component.html.erb
+++ b/app/components/google_scholar_metadata_component.html.erb
@@ -1,0 +1,9 @@
+<!-- Google Scholar metadata -->
+<meta name="citation_title" content="<%= title %>">
+<%- citation_authors.each do |author| %>
+  <meta name="citation_author" content="<%= author %>">
+<%- end %>
+<meta name="citation_publication_date" content="<%= citation_publication_date %>">
+<%- file_resources.each do |file| %>
+  <meta name="citation_pdf_url" content="<%= resource_download_url(file.id, resource_id: resource.uuid) %>">
+<%- end %>

--- a/app/components/google_scholar_metadata_component.rb
+++ b/app/components/google_scholar_metadata_component.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class GoogleScholarMetadataComponent < ApplicationComponent
+  attr_reader :resource,
+              :policy
+
+  delegate :title,
+           :creator_aliases,
+           :deposited_at,
+           :published_date,
+           to: :resource
+
+  # @param [ResourceDecorator] resource
+  # @param [ApplicationPolicy] policy
+  def initialize(resource:, policy:)
+    @resource = resource
+    @policy = policy
+  end
+
+  def render?
+    resource.is_a?(WorkVersionDecorator)
+  end
+
+  def citation_authors
+    creator_aliases.map(&:alias)
+  end
+
+  def citation_publication_date
+    return deposited_at.year unless EdtfDate.valid?(published_date)
+
+    Date.edtf(published_date).year
+  end
+
+  def file_resources
+    return [] unless policy.download?
+
+    resource.file_resources
+  end
+end

--- a/app/decorators/resource_decorator.rb
+++ b/app/decorators/resource_decorator.rb
@@ -43,11 +43,4 @@ class ResourceDecorator < SimpleDelegator
       creator_aliases.take(3)
     end
   end
-
-  # @note Google Scholar prefers the year alone
-  def published_date_or_deposited_year
-    return deposited_at.year unless EdtfDate.valid?(published_date)
-
-    Date.edtf(published_date).year
-  end
 end

--- a/app/views/resources/_meta_tags.html.erb
+++ b/app/views/resources/_meta_tags.html.erb
@@ -8,9 +8,4 @@
 <meta property="og:description" content="<%= resource.description %>">
 <meta property="og:url" content="<%= resource_url(uuid) %>">
 
-<!-- Google Scholar metadata -->
-<meta name="citation_title" content="<%= resource.title %>">
-<%- resource.creator_aliases.each do |creator_alias| %>
-  <meta name="citation_author" content="<%= creator_alias.alias %>">
-<%- end %>
-<meta name="citation_publication_date" content="<%= resource.published_date_or_deposited_year %>">
+<%= render GoogleScholarMetadataComponent.new(resource: resource, policy: policy(resource)) %>

--- a/spec/components/google_scholar_metadata_component_spec.rb
+++ b/spec/components/google_scholar_metadata_component_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GoogleScholarMetadataComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  subject(:component) { described_class.new(resource: decorated_resource, policy: mock_policy) }
+
+  let(:decorated_resource) { ResourceDecorator.decorate(resource) }
+  let(:mock_policy) { instance_double('WorkVersionPolicy', download?: true) }
+  let(:html) { render_inline(component) }
+
+  context 'with a downloadable work version' do
+    let(:resource) { create(:work_version, :with_files, :with_creators) }
+    let(:file) { resource.file_resources.first }
+
+    it 'renders all the meta tags' do
+      expect(html.search('meta[@name="citation_title"]').first['content']).to eq(resource.title)
+      expect(html.search('meta[@name="citation_author"]').first['content']).to eq(resource.creator_aliases.first.alias)
+      expect(html.search('meta[@name="citation_publication_date"]').first['content']).to eq(Time.zone.now.year.to_s)
+      expect(html.search('meta[@name="citation_pdf_url"]').first['content']).to eq(
+        resource_download_url(file.id, resource_id: resource.uuid, host: 'test.host')
+      )
+    end
+  end
+
+  context 'when the work is not downloadable' do
+    let(:resource) { create(:work_version, :with_files, :with_creators) }
+    let(:mock_policy) { instance_double('WorkVersionPolicy', download?: false) }
+
+    it 'renders all the meta tags' do
+      expect(html.search('meta[@name="citation_title"]').first['content']).to eq(resource.title)
+      expect(html.search('meta[@name="citation_author"]').first['content']).to eq(resource.creator_aliases.first.alias)
+      expect(html.search('meta[@name="citation_publication_date"]').first['content']).to eq(Time.zone.now.year.to_s)
+      expect(html.search('meta[@name="citation_pdf_url"]')).to be_empty
+    end
+  end
+
+  context 'with a collection' do
+    let(:resource) { build(:collection) }
+
+    it { expect(html.content).to be_empty }
+  end
+
+  describe '#citation_publication_date' do
+    context 'with a missing published date' do
+      let(:resource) { build(:work_version, published_date: nil) }
+
+      its(:citation_publication_date) { is_expected.to eq(resource.deposited_at.year) }
+    end
+
+    context 'with invalid EDTF' do
+      let(:resource) { build(:work_version, published_date: 'Last Thursday') }
+
+      its(:citation_publication_date) { is_expected.to eq(resource.deposited_at.year) }
+    end
+
+    context 'with valid EDTF' do
+      let(:resource) { build(:work_version, :able_to_be_published) }
+
+      its(:citation_publication_date) { is_expected.to eq Date.edtf(resource.published_date).year }
+    end
+
+    context 'with valid EDTF but an uncertain year' do
+      let(:resource) { build(:work_version, published_date: '2002?-12') }
+
+      its(:citation_publication_date) { is_expected.to eq(2002) }
+    end
+  end
+end

--- a/spec/decorators/resource_decorator_spec.rb
+++ b/spec/decorators/resource_decorator_spec.rb
@@ -157,44 +157,4 @@ RSpec.describe ResourceDecorator do
       its(:first_creators) { is_expected.to eq(resource.creator_aliases.take(3) + ['&hellip;']) }
     end
   end
-
-  describe '#published_date_or_deposited_year' do
-    subject { decorator.published_date_or_deposited_year }
-
-    context 'when a work version has a missing published date' do
-      let(:resource) { build(:work_version, published_date: nil) }
-
-      it { is_expected.to eq(resource.deposited_at.year) }
-    end
-
-    context 'when a work version has invalid EDTF' do
-      let(:resource) { build(:work_version, published_date: 'Last Thursday') }
-
-      it { is_expected.to eq(resource.deposited_at.year) }
-    end
-
-    context 'when a work verison has valid EDTF' do
-      let(:resource) { build(:work_version, :able_to_be_published) }
-
-      it { is_expected.to eq Date.edtf(resource.published_date).year }
-    end
-
-    context 'when a work version has valid EDTF but an uncertain year' do
-      let(:resource) { build(:work_version, published_date: '2002?-12') }
-
-      it { is_expected.to eq(2002) }
-    end
-
-    context 'when a collection has a published date' do
-      let(:resource) { build(:collection, :with_complete_metadata) }
-
-      it { is_expected.to eq Date.edtf(resource.published_date).year }
-    end
-
-    context 'when a collection does NOT have a published date' do
-      let(:resource) { build(:collection) }
-
-      it { is_expected.to eq(resource.deposited_at.year) }
-    end
-  end
 end

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -128,11 +128,6 @@ RSpec.describe 'Public Resources', type: :feature do
         # Below was failing in CI due to hostnames getting weird
         expect(page.find('meta[property="og:url"]', visible: false)[:content])
           .to match(resource_path(collection.uuid)).and match(/^https?:/)
-        expect(page.find('meta[name="citation_title"]', visible: false)[:content]).to eq collection.title
-        expect(page.find('meta[name="citation_publication_date"]', visible: false)[:content])
-          .to eq Date.edtf(collection.published_date).year.to_s
-        all_authors = page.all(:css, 'meta[name="citation_author"]', visible: false)
-        expect(all_authors.map { |a| a[:content] }).to match_array collection.creator_aliases.map(&:alias)
 
         expect(page).to have_selector('h1', text: collection.title)
         expect(page).to have_content collection.description


### PR DESCRIPTION
Adds meta tags for links to the files in the work, enabling Google to perform fulltext indexing. Additionally, collections will no longer have Google Scholar meta tags.

Refactoring removes previous code from the ResourceDecorator and puts it in a newly created GoogleScholarMetadataComponent. This new component encapsulates all the logic and content required to render the tags.

Fixes #796 