### PR TITLE
Catch unexpected errors in the editors form

### DIFF
--- a/app/forms/editors_form.rb
+++ b/app/forms/editors_form.rb
@@ -44,8 +44,8 @@ class EditorsForm
 
     def build_users
       edit_users.map do |access_id|
-        UserRegistrationService.call(uid: access_id) ||
-          errors.add(:edit_users, "#{access_id} does not exist") && access_id
+        service_wrapper(access_id) ||
+          errors.add(:edit_users, I18n.t('dashboard.works.editors.not_found', access_id: access_id)) && access_id
       end
     end
 
@@ -53,5 +53,16 @@ class EditorsForm
       edit_groups.map do |name|
         Group.find_by(name: name)
       end.compact
+    end
+
+    # @note There are four outcomes from calling this wrapper:
+    #   1) the call is successful and the user is found -> return the user's access id
+    #   2) the call is successful and the user is NOT found -> return null
+    #   3) the call is unsuccessful due to user error (URI::InvalidURIError) -> return the incorrect input
+    #   4) the call is unsuccessful due to to some unknown reason -> raise the exeception
+    def service_wrapper(access_id)
+      UserRegistrationService.call(uid: access_id)
+    rescue URI::InvalidURIError
+      errors.add(:edit_users, I18n.t('dashboard.works.editors.unexpected', access_id: access_id)) && access_id
     end
 end

--- a/app/views/form_fields/_multi_text.html.erb
+++ b/app/views/form_fields/_multi_text.html.erb
@@ -1,12 +1,22 @@
 <% terms = form.object.send(attribute).empty? ? [''] : form.object.send(attribute) %>
+<%- field_id = form_field_id(form, attribute) %>
+<%- hint_id = "#{field_id}-hint" %>
+<%- hint_i18n_key = ['helpers', 'hint', form.object.class.model_name.i18n_key, attribute].join('.') %>
+<%- has_hint = I18n.exists?(hint_i18n_key) %>
 
-<div class="mb-3" data-controller="multiple-fields">
-  <% terms.each_with_index do |term, index| %>
-    <div class="removable-input js-multiple-field-group mb-1">
-      <label class="has-float-label">
-        <%= form.text_field attribute, multiple: true, placeholder: true, value: term, class: 'form-control' %>
-        <span><%= form.object.class.human_attribute_name(attribute) %></span>
-      </label>
-    </div>
+<div class="mb-3">
+  <div data-controller="multiple-fields">
+    <% terms.each_with_index do |term, index| %>
+      <div class="removable-input js-multiple-field-group mb-1">
+        <label class="has-float-label">
+          <%= form.text_field attribute, multiple: true, placeholder: true, value: term, class: 'form-control' %>
+          <span><%= form.object.class.human_attribute_name(attribute) %></span>
+        </label>
+      </div>
+    <% end %>
+  </div>
+
+  <% if has_hint %>
+    <small id="<%= hint_id %>" class="form-text text-muted"><%= t hint_i18n_key %></small>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -144,6 +144,8 @@ en:
     copyright_statement: 'Copyright © 2020 The Pennsylvania State University'
   helpers:
     hint:
+      editors_form:
+        edit_users: Requires the user's Penn State Access ID (e.g., xyz500)
       permissions:
         visibility:
           authenticated: 'By choosing Penn State Only, files can only be accessed by users with a Penn State Access ID.'
@@ -234,6 +236,8 @@ en:
         heading: Editors
         explanation: Gives the ability for other users from Penn State to edit your work. This can be done on a per-user basis, or a group basis.
         submit_button: Update Editors 
+        not_found: "User %{access_id} could not be found"
+        unexpected: "%{access_id} is not a valid user"
       update:
         success: "Work settings successfully updated."
     form: 


### PR DESCRIPTION
The impetus for this PR was a user entering full names into the edit users field of the work settings page. The user-entered string is passed directly to the Penn State's identity search API, which was raising URI::InvalidURIError resulting in a 500 error and a blank page (see the screen shot in #795). To mitigate this, we're capturing that error and returning an error message to the user. Any _other_ error, however, will result in the same white screen. This seems to be the best solution to catch unexpected errors from the identity API.

Additionally, we've added some hint text to the edit users field to inform users that they need to a user's access id and not a full name or other string.

Fixes #795 