### PR TITLE
Allow published works with drafts in collections

### DIFF
--- a/app/models/dashboard/member_works_search_builder.rb
+++ b/app/models/dashboard/member_works_search_builder.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
 module Dashboard
-  class MemberWorksSearchBuilder < Dashboard::SearchBuilder
-    self.default_processor_chain += %i(
-      build_member_works_query
-    )
-
+  class MemberWorksSearchBuilder < SearchBuilder
     # @note Builds a Solr query to return a list of all the works a user may add to a collection
-    def build_member_works_query(solr_parameters)
+    def main_query(solr_parameters)
       solr_parameters[:fl] = 'work_id_isi, title_tesim'
-      solr_parameters[:fq] << '({!terms f=aasm_state_tesim}published)'
+      solr_parameters[:fq] << '{!terms f=model_ssi}Work'
       solr_parameters[:rows] = max_documents
       solr_parameters[:facet] = false
     end

--- a/app/models/dashboard/search_builder.rb
+++ b/app/models/dashboard/search_builder.rb
@@ -5,12 +5,12 @@ module Dashboard
     include Blacklight::Solr::SearchBuilderBehavior
 
     self.default_processor_chain += %i(
-      search_only_latest_work_versions
+      main_query
       apply_gated_edit
       log_solr_parameters
     )
 
-    def search_only_latest_work_versions(solr_parameters)
+    def main_query(solr_parameters)
       solr_parameters[:fq] ||= []
       latest_work_versions = '({!terms f=model_ssi}WorkVersion AND {!terms f=latest_version_bsi}true})'
       collections = '({!terms f=model_ssi}Collection)'

--- a/spec/models/dashboard/member_works_search_builder_spec.rb
+++ b/spec/models/dashboard/member_works_search_builder_spec.rb
@@ -13,9 +13,8 @@ RSpec.describe Dashboard::MemberWorksSearchBuilder do
     its(:default_processor_chain) do
       is_expected.to include(
         :log_solr_parameters,
-        :search_only_latest_work_versions,
         :apply_gated_edit,
-        :build_member_works_query
+        :main_query
       )
     end
   end
@@ -25,7 +24,7 @@ RSpec.describe Dashboard::MemberWorksSearchBuilder do
 
     it 'searches only published work versions' do
       expect(parameters['fq']).to include(
-        '({!terms f=aasm_state_tesim}published)'
+        '{!terms f=model_ssi}Work'
       )
     end
   end

--- a/spec/models/dashboard/search_builder_spec.rb
+++ b/spec/models/dashboard/search_builder_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Dashboard::SearchBuilder do
     its(:default_processor_chain) do
       is_expected.to include(
         :log_solr_parameters,
-        :search_only_latest_work_versions,
+        :main_query,
         :apply_gated_edit
       )
     end


### PR DESCRIPTION
Fixes a bug with the MemberWorksSearchBuilder that was omitting works which had previously been published but had a current draft version.

Fixes #791 