### PR TITLE
Maintain author order when creating a new version

### DIFF
--- a/app/services/build_new_work_version.rb
+++ b/app/services/build_new_work_version.rb
@@ -26,6 +26,7 @@ class BuildNewWorkVersion
       new_version.creator_aliases.build(
         actor_id: previous_creation.actor_id,
         alias: previous_creation.alias,
+        position: previous_creation.position,
         changed_by_system: true # mute papertrail for this change
       )
     end

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -19,12 +19,13 @@ FactoryBot.define do
       after(:build, :stub) do |work_version, evaluator|
         actors = build_list(:actor, evaluator.creator_count)
 
-        actors.each do |actor|
+        actors.each_with_index do |actor, index|
           # Alias "Pat Doe" to "Dr. Pat Doe"
           creator_alias = "#{Faker::Name.prefix} #{actor.given_name} #{actor.surname}"
           work_version.creator_aliases.build(
             actor: actor,
-            alias: creator_alias
+            alias: creator_alias,
+            position: index + 1
           )
         end
       end

--- a/spec/services/build_new_work_version_spec.rb
+++ b/spec/services/build_new_work_version_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe BuildNewWorkVersion, type: :model do
 
   before do
     initial_file_membership.update!(title: 'overridden-title.png')
-    initial_creation.update!(alias: 'My Creator Alias')
+    initial_creation.update!(alias: 'My Creator Alias', position: 100)
   end
 
   describe '.call' do
@@ -50,6 +50,7 @@ RSpec.describe BuildNewWorkVersion, type: :model do
       new_version.creator_aliases.first.tap do |creation|
         expect(creation.alias).to eq 'My Creator Alias'
         expect(creation.actor).to eq creator
+        expect(creation.position).to eq 100
       end
     end
 


### PR DESCRIPTION
Author's position wasn't being copied over when the creators join table was copied over between the old and new work version.

Also, tangentially related, I added an explicit position to `factories/work_version.rb`. This wasn't causing any issues, but I figured while I was thinking about it, it would be a good idea to add it.

Closes #809 

