### PR TITLE
Fix bug in the ordering of works in the collection edit form

### DIFF
--- a/app/controllers/dashboard/form/members_controller.rb
+++ b/app/controllers/dashboard/form/members_controller.rb
@@ -4,7 +4,9 @@ module Dashboard
   module Form
     class MembersController < BaseController
       def edit
-        @resource = Collection.find(params[:id])
+        @resource = Collection
+          .includes(collection_work_memberships: [:work])
+          .find(params[:id])
         (@member_works, _deprecated_document_list) = search_service.search_results
         authorize(@resource)
       end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -34,10 +34,7 @@ class Collection < ApplicationRecord
   has_many :collection_work_memberships,
            dependent: :destroy
 
-  # Beware that the order clause here references the join table. You may need to
-  # account for that in your `includes` or `eager_load` statements
   has_many :works,
-           -> { order('collection_work_memberships.position ASC') },
            through: :collection_work_memberships,
            inverse_of: :collections
 

--- a/app/models/collection_work_membership.rb
+++ b/app/models/collection_work_membership.rb
@@ -3,4 +3,12 @@
 class CollectionWorkMembership < ApplicationRecord
   belongs_to :collection
   belongs_to :work
+
+  # Always order these records based on their position. I know that using
+  # default_scope is considered by some to be an antipattern, but in this
+  # particular cause, adding this order to the association in the Collection
+  # model produced undesirable and strange results. I find it very unlikely that
+  # we'd want to order the works _not_ according to their explicitly defined
+  # position, so I think this is a good solution in this case.
+  default_scope -> { order(position: :asc) }
 end


### PR DESCRIPTION
When the works were being shown on the Collection Edit form, the position ordering wasn't being observed. This fixes that.

Unrelated to the bug, but related to that area of the code, I added some database eager loading to the the controller that renders that form. Again, this was not the cause of the bug, and did not affect said bug, but while I was there I thought I'd add a little performance boost.

Fixes #790 