### PR TITLE
Add upload endpoint to API

### DIFF
--- a/app/controllers/api/v1/rest_controller.rb
+++ b/app/controllers/api/v1/rest_controller.rb
@@ -20,7 +20,13 @@ module Api
         end
       end
 
+      # @note This is called before #authenticate_request! so we must check for a null token. We're returning a guest
+      # user to avoid any possible NillClass errors down the line. Public access to the API is not supported so this
+      # user will never be used. If this changes, however, we should probably create a default, public-level
+      # application.
       def current_user
+        return User.guest unless api_token
+
         api_token.application
       end
 

--- a/app/controllers/api/v1/uploads_controller.rb
+++ b/app/controllers/api/v1/uploads_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Api::V1
+  class UploadsController < RestController
+    def create
+      render json: {
+        url: signer.presigned_url(:put_object, bucket: ENV['AWS_BUCKET'], key: key),
+        id: id,
+        prefix: prefix
+      }
+    end
+
+    private
+
+      def signer
+        Aws::S3::Presigner.new(
+          client: Aws::S3::Client.new(**s3_options)
+        )
+      end
+
+      def s3_options
+        if ENV.key?('S3_ENDPOINT')
+          base_options.merge(endpoint: ENV['S3_ENDPOINT'], force_path_style: true)
+        else
+          base_options
+        end
+      end
+
+      def base_options
+        {
+          access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+          secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+          region: ENV['AWS_REGION']
+        }
+      end
+
+      def key
+        "#{prefix}/#{id}"
+      end
+
+      def prefix
+        Scholarsphere::ShrineConfig::CACHE_PREFIX
+      end
+
+      def id
+        @id ||= "#{SecureRandom.uuid}.#{extension}"
+      end
+
+      def extension
+        params.require(:extension).gsub('.', '')
+      end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,7 @@ Rails.application.routes.draw do
       resources :collections, only: [:create]
       resources :files, only: [:update]
       resources :featured_resources, only: [:create]
+      resources :uploads, only: [:create]
     end
   end
 

--- a/spec/controllers/api/v1/uploads_controller_spec.rb
+++ b/spec/controllers/api/v1/uploads_controller_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::UploadsController, type: :controller do
+  let(:api_token) { create(:api_token).token }
+
+  before { request.headers[:'X-API-Key'] = api_token }
+
+  describe 'POST #create' do
+    let(:presigned_url) { JSON.parse(response.body)['url'] }
+    let(:id) { JSON.parse(response.body)['id'] }
+    let(:prefix) { JSON.parse(response.body)['prefix'] }
+
+    before { post :create, params: { extension: extension } }
+
+    context 'with a valid extension' do
+      let(:extension) { Faker::File.extension }
+
+      it 'creates a presigned url' do
+        expect(response).to be_ok
+        expect(presigned_url).to include(ENV['S3_ENDPOINT'])
+        expect(URI.parse(presigned_url).path).to match(
+          "/#{ENV['AWS_BUCKET']}/#{Scholarsphere::ShrineConfig::CACHE_PREFIX}.*#{extension}"
+        )
+        expect(id).to end_with(extension)
+        expect(prefix).to eq(Scholarsphere::ShrineConfig::CACHE_PREFIX)
+      end
+    end
+
+    context 'when the extension includes the period' do
+      let(:extension) { ".#{Faker::File.extension}" }
+
+      it 'creates a presigned url without the duplicate period' do
+        expect(response).to be_ok
+        expect(URI.parse(presigned_url).path).not_to include('..')
+        expect(id).not_to include('..')
+      end
+    end
+
+    context 'with a missing key' do
+      let(:extension) { nil }
+
+      it { expect(response).to be_bad_request }
+    end
+  end
+end


### PR DESCRIPTION
Returns a presigned url to a client so that they may upload a file into our S3 instance. The endpoint requires an extension, such as pdf, or txt, so that it can construct a path for the file in the bucket.

Filenames are unique UUIDs, matching the current behavior in the UI via the Shrine/Uppy process.

Fixes #815 