### PR TITLE
DeleteWork service

### DIFF
--- a/app/services/delete_work.rb
+++ b/app/services/delete_work.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# @abstract Deletes a work, including all of its versions, without regard to its publication data. Note, this service
+# is not intended to be used within the context of the application, but rather as a command-line only method reserved
+# for instances when a specific work needs to be deleted.
+
+class DeleteWork
+  def self.call(uuid)
+    new(uuid: uuid).destroy
+  end
+
+  attr_reader :work
+
+  def initialize(uuid:)
+    @work = Work.find_by(uuid: uuid)
+  end
+
+  def destroy
+    work.versions.map do |version|
+      version.aasm_state = 'withdrawn'
+      version.destroy!
+      IndexingService.delete_document(version.uuid)
+    end
+    work.destroy!
+    IndexingService.delete_document(work.uuid, commit: true)
+  end
+end

--- a/spec/services/delete_work_spec.rb
+++ b/spec/services/delete_work_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeleteWork do
+  describe '.call' do
+    let!(:work) { create(:work, versions_count: 3, has_draft: true) }
+
+    before { allow(SolrIndexingJob).to receive(:perform_later) }
+
+    specify do
+      expect(Work.count).to eq(1)
+      expect(WorkVersion.count).to eq(3)
+      described_class.call(work.uuid)
+      expect(SolrIndexingJob).not_to have_received(:perform_later)
+      expect(Work.count).to eq(0)
+      expect(WorkVersion.count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Adds a command-line only DeleteWork service to delete works when needed. It is only intended to be run from the console, and as yet, is not linked anywhere else in the application.