### PR TITLE
Order versions according to their version number

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -16,7 +16,7 @@ class Work < ApplicationRecord
              optional: true
 
   has_many :versions,
-           -> { order(created_at: :asc) },
+           -> { order(version_number: :asc) },
            class_name: 'WorkVersion',
            inverse_of: 'work',
            dependent: :destroy

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -213,9 +213,9 @@ RSpec.describe Work, type: :model do
   describe 'version accessors' do
     subject(:work) { create :work, versions: [draft, v2, v1] }
 
-    let(:draft) { build :work_version, :draft, title: 'Draft', work: nil, created_at: 1.day.ago }
-    let(:v2) { build :work_version, :published, title: 'Published v2', work: nil, created_at: 2.days.ago }
-    let(:v1) { build :work_version, :published, title: 'Published v1', work: nil, created_at: 3.days.ago }
+    let(:draft) { build :work_version, :draft, title: 'Draft', work: nil, created_at: 1.day.ago, version_number: 3 }
+    let(:v2) { build :work_version, :published, title: 'Published v2', work: nil, created_at: 2.days.ago, version_number: 2 }
+    let(:v1) { build :work_version, :published, title: 'Published v1', work: nil, created_at: 3.days.ago, version_number: 1 }
 
     before { work.reload }
 


### PR DESCRIPTION
Instead of relying on the creation date, which assumes versions are created in a chronological order, we can use the version number which is an explicit indication of which version comes after another.

Fixes #829 