### PR TITLE
Update creators' positions when null

### DIFF
--- a/app/services/creator_order_fix.rb
+++ b/app/services/creator_order_fix.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class CreatorOrderFix
+  class << self
+    def call
+      Work.find_each do |work|
+        work.versions.order(:version_number).each_with_index do |work_version, index|
+          if index.zero?
+            update_first_version(work_version)
+          else
+            update_later_version(work_version, work.versions[index - 1])
+          end
+        end
+      end
+    end
+
+    def update_first_version(version)
+      return unless all_empty?(version.creator_aliases)
+
+      version.creator_aliases.sort_by(&:id).each_with_index do |creator_alias, index|
+        creator_alias.update(position: (index + 1) * 10, changed_by_system: true)
+      end
+    end
+
+    def update_later_version(current, previous)
+      return unless all_empty?(current.creator_aliases)
+
+      previous_ca_lookup = previous.creator_aliases.map { |ca| [ca.actor_id, ca.position] }.to_h
+      current.creator_aliases.each do |creator_alias|
+        creator_alias.update(position: previous_ca_lookup[creator_alias.actor_id], changed_by_system: true)
+      end
+    end
+
+    def all_empty?(aliases)
+      positions = aliases.map(&:position)
+
+      if positions.uniq.count > 1 && positions.uniq.any?(nil)
+        raise StandardError, "Work #{aliases.first.work_version.work.uuid} can't be corrected"
+      else
+        positions.uniq == [nil]
+      end
+    end
+  end
+end

--- a/app/services/creator_order_fix.rb
+++ b/app/services/creator_order_fix.rb
@@ -3,6 +3,8 @@
 class CreatorOrderFix
   class << self
     def call
+      errors = []
+
       Work.find_each do |work|
         work.versions.order(:version_number).each_with_index do |work_version, index|
           if index.zero?
@@ -10,8 +12,13 @@ class CreatorOrderFix
           else
             update_later_version(work_version, work.versions[index - 1])
           end
+        rescue StandardError => e
+          errors << "Work##{work.id}, WorkVersion##{work_version.id}, #{e.message}"
         end
       end
+
+      errors.each { |e| puts e }
+      errors.empty?
     end
 
     def update_first_version(version)

--- a/spec/services/creator_order_fix_spec.rb
+++ b/spec/services/creator_order_fix_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreatorOrderFix, versioning: true do
+  context 'when everything is hunky-dory' do
+    let(:work) do
+      first_version = create(:work_version, :published, creator_count: 3)
+      work = first_version.work
+      work.versions[0].destroy # this is a bug with the factory builder
+      work.reload
+      new_version = BuildNewWorkVersion.call(work.latest_version)
+      new_version.save
+      work.reload
+      work
+    end
+
+    it 'does not change the positions' do
+      expect(work.versions[0].creator_aliases[0].position).to eq(1)
+      expect(work.versions[0].creator_aliases[1].position).to eq(2)
+      expect(work.versions[0].creator_aliases[2].position).to eq(3)
+      expect(work.versions[1].creator_aliases[0].position).to eq(1)
+      expect(work.versions[1].creator_aliases[1].position).to eq(2)
+      expect(work.versions[1].creator_aliases[2].position).to eq(3)
+
+      expect {
+        described_class.call
+      }.not_to change(PaperTrail::Version, :count)
+
+      work.reload
+      expect(work.versions[0].creator_aliases[0].position).to eq(1)
+      expect(work.versions[0].creator_aliases[1].position).to eq(2)
+      expect(work.versions[0].creator_aliases[2].position).to eq(3)
+      expect(work.versions[1].creator_aliases[0].position).to eq(1)
+      expect(work.versions[1].creator_aliases[1].position).to eq(2)
+      expect(work.versions[1].creator_aliases[2].position).to eq(3)
+    end
+  end
+
+  # Use case: User creates a new version of an existing published work and the positions is NOT copied over to the new
+  # version. This was the bug that Ryan fixed recently, but we must account for works that had new versions added prior
+  # to the fix.
+  context 'with three creators and three versions' do
+    let(:work) do
+      first_version = create(:work_version, :published, creator_count: 3)
+      work = first_version.work
+      work.versions[0].destroy # this is a bug with the factory builder
+      work.reload
+      second_version = BuildNewWorkVersion.call(work.latest_version)
+      second_version.save
+      third_version = BuildNewWorkVersion.call(second_version)
+      third_version.save
+      work.reload
+      work.versions[1].creator_aliases.map do |creator_alias|
+        creator_alias.update(position: nil)
+      end
+      work.versions[2].creator_aliases.map do |creator_alias|
+        creator_alias.update(position: nil)
+      end
+      work.reload
+    end
+
+    it 'updates the null positions' do
+      expect(work.versions[0].creator_aliases[0].position).to eq(1)
+      expect(work.versions[0].creator_aliases[1].position).to eq(2)
+      expect(work.versions[0].creator_aliases[2].position).to eq(3)
+      expect(work.versions[1].creator_aliases[0].position).to eq(nil)
+      expect(work.versions[1].creator_aliases[1].position).to eq(nil)
+      expect(work.versions[1].creator_aliases[2].position).to eq(nil)
+      expect(work.versions[2].creator_aliases[0].position).to eq(nil)
+      expect(work.versions[2].creator_aliases[1].position).to eq(nil)
+      expect(work.versions[2].creator_aliases[2].position).to eq(nil)
+
+      expect {
+        described_class.call
+      }.not_to change(PaperTrail::Version, :count)
+
+      work.reload
+      expect(work.versions[0].creator_aliases[0].position).to eq(1)
+      expect(work.versions[0].creator_aliases[1].position).to eq(2)
+      expect(work.versions[0].creator_aliases[2].position).to eq(3)
+      expect(work.versions[1].creator_aliases[0].position).to eq(1)
+      expect(work.versions[1].creator_aliases[1].position).to eq(2)
+      expect(work.versions[1].creator_aliases[2].position).to eq(3)
+      expect(work.versions[2].creator_aliases[0].position).to eq(1)
+      expect(work.versions[2].creator_aliases[1].position).to eq(2)
+      expect(work.versions[2].creator_aliases[2].position).to eq(3)
+    end
+  end
+
+  # Use case: A work was migrated with all of its initial creator positions set to nil.
+  context 'with a migrated work' do
+    let(:work) do
+      first_version = create(:work_version, :published, creator_count: 3)
+      work = first_version.work
+      work.versions[0].destroy # this is a bug with the factory builder
+      work.reload
+      work.versions[0].creator_aliases.map do |creator_alias|
+        creator_alias.update(position: nil)
+      end
+      work.reload
+    end
+
+    # Note: positions here are in increments of 10 because that's what the UI does
+    it 'updates the null positions' do
+      expect(work.versions[0].creator_aliases[0].position).to eq(nil)
+      expect(work.versions[0].creator_aliases[1].position).to eq(nil)
+      expect(work.versions[0].creator_aliases[2].position).to eq(nil)
+
+      expect {
+        described_class.call
+      }.not_to change(PaperTrail::Version, :count)
+
+      work.reload
+      expect(work.versions[0].creator_aliases[0].position).to eq(10)
+      expect(work.versions[0].creator_aliases[1].position).to eq(20)
+      expect(work.versions[0].creator_aliases[2].position).to eq(30)
+    end
+  end
+
+  context 'when something is very wrong' do
+    let(:work) do
+      first_version = create(:work_version, :published, creator_count: 3)
+      work = first_version.work
+      work.versions[0].destroy # this is a bug with the factory builder
+      work.reload
+      work.versions[0].creator_aliases[1].update(position: nil)
+      work.reload
+    end
+
+    it 'raises an error' do
+      expect(work.versions[0].creator_aliases[0].position).to eq(1)
+      expect(work.versions[0].creator_aliases[1].position).to eq(3)
+      expect(work.versions[0].creator_aliases[2].position).to eq(nil)
+      expect { described_class.call }.to raise_error(StandardError, "Work #{work.uuid} can't be corrected")
+    end
+  end
+end

--- a/spec/services/creator_order_fix_spec.rb
+++ b/spec/services/creator_order_fix_spec.rb
@@ -128,11 +128,16 @@ RSpec.describe CreatorOrderFix, versioning: true do
       work.reload
     end
 
-    it 'raises an error' do
+    it 'returns false and puts errors to stdout' do
       expect(work.versions[0].creator_aliases[0].position).to eq(1)
       expect(work.versions[0].creator_aliases[1].position).to eq(3)
       expect(work.versions[0].creator_aliases[2].position).to eq(nil)
-      expect { described_class.call }.to raise_error(StandardError, "Work #{work.uuid} can't be corrected")
+
+      expected_output = /Work##{work.id}, WorkVersion##{work.versions[0].id}, Work #{work.uuid} can't be corrected/
+
+      return_value = nil
+      expect { return_value = described_class.call }.to output(expected_output).to_stdout
+      expect(return_value).to eq false
     end
   end
 end


### PR DESCRIPTION
Due to a migration oversight, migrated works did not have any position indicators. Additionally, there was a bug that was not copying over a creator's positioning indicators to new versions. The bug has since been fixed, but there remained many creator records will null positions.

This is a service class, designed to run in the console only, and add any missing positions. Any first version without positions has them added according to the order of the primary key. This represents the
order in which they were added to the database. Any subsequent versions that don't have positions have them copied over from their previous versions.

The process is idempotent and can be re-run multiple times and never affect creators that have position values. If a version is encountered that somehow has a mix of creators with and without null positions, it
aborts.

Fixes #822 

## Note

I was initially going to throw this code away, but since it might come in handy later, I thought we'd keep it around. I've put it under `app/services` but I'm not sold that's where it should live.