### PR TITLE
i#839/nil groups

### DIFF
--- a/lib/omniauth/strategies/azure_oauth.rb
+++ b/lib/omniauth/strategies/azure_oauth.rb
@@ -20,6 +20,7 @@ module OmniAuth
 
       info do
         raw_info['groups'] = graph_groups if ENV['AZURE_GRAPH_GROUPS'].present?
+        raw_info['groups'] = raw_info.fetch('groups', []) unless ENV['AZURE_GRAPH_GRUPS'].present?
         raw_info
       end
 

--- a/lib/omniauth/strategies/azure_oauth.rb
+++ b/lib/omniauth/strategies/azure_oauth.rb
@@ -20,7 +20,7 @@ module OmniAuth
 
       info do
         raw_info['groups'] = graph_groups if ENV['AZURE_GRAPH_GROUPS'].present?
-        raw_info['groups'] = raw_info.fetch('groups', []) unless ENV['AZURE_GRAPH_GRUPS'].present?
+        raw_info['groups'] = raw_info.fetch('groups', []) if ENV['AZURE_GRAPH_GRUPS'].blank?
         raw_info
       end
 


### PR DESCRIPTION
Sets groups returned from azure to an empty array if none are returned from azure. 

Fixes #839 

This may impact a users abilities to change edit rights on works, I'm working with OIS to determine what conditions a users groups may be nil, I figure at least a user can upload and create works if this happens. 

I also am not a fan of how i have if and unless. i'd like a more clever solution, but this works. 