### PR TITLE
Client for the Orcid public API

### DIFF
--- a/app/models/orcid_id.rb
+++ b/app/models/orcid_id.rb
@@ -4,7 +4,7 @@
 # and can return any of those formats. The unformatted numeric string is preferred for database storage, but this
 # class be used to present the id in alternative, human-readable formats.
 
-class Orcid
+class OrcidId
   def self.valid?(value)
     new(value).valid?
   end

--- a/lib/orcid.rb
+++ b/lib/orcid.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'faraday'
+
+module Orcid
+  class Error < StandardError; end
+  class NotFound < StandardError; end
+
+  module Public
+    require 'orcid/public/email'
+    require 'orcid/public/person'
+
+    class << self
+      def get(action:, id:)
+        process_response do
+          connection.get("#{id}/#{action}") do |req|
+            req.headers['Content-Type'] = 'application/json'
+          end
+        end
+      end
+
+      def connection
+        Faraday.new(url: ENV.fetch('ORCID_ENDPOINT', 'https://pub.orcid.org/v2.1')) do |conn|
+          conn.adapter :net_http
+        end
+      end
+
+      def process_response
+        response = yield
+        parsed_body = JSON.parse(response.body)
+
+        raise error_klass(response.status), parsed_body['user-message'] unless response.success?
+
+        parsed_body
+      rescue JSON::ParserError
+        {}
+      end
+
+      def error_klass(status)
+        case status
+        when 404
+          NotFound
+        else
+          Error
+        end
+      end
+    end
+  end
+end

--- a/lib/orcid/public/email.rb
+++ b/lib/orcid/public/email.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Orcid
+  module Public
+    class Email
+      attr_reader :id
+
+      def initialize(id:, data: nil)
+        @id = id
+        @data = data
+      end
+
+      def addresses
+        @addresses ||= data.dig('email')
+          .map { |record| Address.new(record) }
+          .sort { |a, b| b.last_modified <=> a.last_modified }
+      end
+
+      def primary
+        addresses.select(&:primary?).first&.to_s
+      end
+
+      def default
+        primary || addresses.first&.to_s
+      end
+
+      class Address
+        def initialize(entry)
+          @entry = entry
+        end
+
+        def to_s
+          @entry.dig('email')
+        end
+
+        # @return [String]
+        # @note Options are 'LIMITED', 'REGISTERED_ONLY', 'PUBLIC', and 'PRIVATE', but since this is the public API,
+        # 'PUBLIC' emails are only returned.
+        def visibility
+          @entry.dig('visibility')
+        end
+
+        # @return [Boolean]
+        def verified?
+          @entry.dig('verified')
+        end
+
+        # @return [Boolean]
+        def primary?
+          @entry.dig('primary')
+        end
+
+        # @return [Integer]
+        def last_modified
+          @entry.dig('last-modified-date', 'value')
+        end
+      end
+
+      private
+
+        def data
+          @data ||= Public.get(action: 'email', id: id)
+        end
+    end
+  end
+end

--- a/lib/orcid/public/person.rb
+++ b/lib/orcid/public/person.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Orcid
+  module Public
+    class Person
+      attr_reader :id
+
+      # @param id [String] Formatted Orcid with dashes, ex: 0000-0001-8485-6532
+      def initialize(id)
+        @id = id
+      end
+
+      # @return [String]
+      def given_names
+        data.dig('name', 'given-names', 'value')
+      end
+
+      # @return [String]
+      def family_name
+        data.dig('name', 'family-name', 'value')
+      end
+
+      # @return [String]
+      def credit_name
+        data.dig('name', 'credit-name', 'value')
+      end
+
+      # @return [String]
+      def visibility
+        data.dig('name', 'visibility')
+      end
+
+      # @return [Orcid::Public::Email]
+      def emails
+        Email.new(id: id, data: data.dig('emails'))
+      end
+
+      private
+
+        def data
+          @data ||= Public.get(action: 'person', id: id)
+        end
+    end
+  end
+end

--- a/lib/qa/authorities/persons.rb
+++ b/lib/qa/authorities/persons.rb
@@ -32,6 +32,7 @@ module Qa
         def creators
           @creators ||= Actor
             .where('surname ILIKE :q OR given_name ILIKE :q OR psu_id ILIKE :q', q: "%#{term}%")
+            .where('psu_id IS NOT NULL OR orcid IS NOT NULL')
             .or(Actor.where(psu_id: identities.map(&:user_id)))
         end
 

--- a/lib/qa/authorities/persons.rb
+++ b/lib/qa/authorities/persons.rb
@@ -91,7 +91,7 @@ module Qa
             additional_metadata = "#{label}: #{value}"
           elsif orcid = result[:orcid].presence
             label = Actor.human_attribute_name(:orcid)
-            value = Orcid.new(orcid).to_human
+            value = OrcidId.new(orcid).to_human
             additional_metadata = "#{label}: #{value}"
           end
 

--- a/spec/factories/actors.rb
+++ b/spec/factories/actors.rb
@@ -18,5 +18,10 @@ FactoryBot.define do
     trait :without_an_orcid do
       orcid { nil }
     end
+
+    trait :with_no_identifiers do
+      orcid { nil }
+      psu_id { nil }
+    end
   end
 end

--- a/spec/fixtures/vcr_cassettes/Orcid_Public_Email/_addresses/when_calling_the_API/returns_all_public_addresses.yml
+++ b/spec/fixtures/vcr_cassettes/Orcid_Public_Email/_addresses/when_calling_the_API/returns_all_public_addresses.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pub.orcid.org/v2.1/0000-0001-8485-6532/email
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 04:36:04 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - X-Mapping-fjhppofk=814C785051499CB634650A2359C0B50C; path=/
+      - __cfduid=df992bf1432fab15415d4828857ec9aee1612499764; expires=Sun, 07-Mar-21
+        04:36:04 GMT; path=/; domain=.orcid.org; HttpOnly; SameSite=Lax
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '081212db6c00003016f68f4000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 61c9eda57ca93016-ORD
+    body:
+      encoding: ASCII-8BIT
+      string: '{"last-modified-date":{"value":1612465770316},"email":[{"created-date":{"value":1612465747618},"last-modified-date":{"value":1612465770316},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"agw13@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null},{"created-date":{"value":1601473260293},"last-modified-date":{"value":1612465218966},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"awead@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null}],"path":"/0000-0001-8485-6532/email"}'
+  recorded_at: Fri, 05 Feb 2021 04:36:04 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Orcid_Public_Email/_default/when_a_primary_email_is_NOT_present/default/1_3_2_1_1.yml
+++ b/spec/fixtures/vcr_cassettes/Orcid_Public_Email/_default/when_a_primary_email_is_NOT_present/default/1_3_2_1_1.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pub.orcid.org/v2.1/0000-0001-8485-6532/email
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Feb 2021 21:06:30 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - X-Mapping-fjhppofk=4842165633BFDE68C17EFF06BB2B96E5; path=/
+      - __cfduid=d00657df118a7cb884103c2a24002fbb91612472790; expires=Sat, 06-Mar-21
+        21:06:30 GMT; path=/; domain=.orcid.org; HttpOnly; SameSite=Lax
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '08107745f000003f60db28b000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 61c75b1cbd0a3f60-ORD
+    body:
+      encoding: ASCII-8BIT
+      string: '{"last-modified-date":{"value":1612465770316},"email":[{"created-date":{"value":1612465747618},"last-modified-date":{"value":1612465770316},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"agw13@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null},{"created-date":{"value":1601473260293},"last-modified-date":{"value":1612465218966},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"awead@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null}],"path":"/0000-0001-8485-6532/email"}'
+  recorded_at: Thu, 04 Feb 2021 21:06:30 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Orcid_Public_Email/_default/when_a_primary_email_is_present/default/1_3_1_1_1.yml
+++ b/spec/fixtures/vcr_cassettes/Orcid_Public_Email/_default/when_a_primary_email_is_present/default/1_3_1_1_1.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pub.orcid.org/v2.1/0000-0001-8485-6532/email
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Feb 2021 21:06:29 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - X-Mapping-fjhppofk=4842165633BFDE68C17EFF06BB2B96E5; path=/
+      - __cfduid=d081fe641223f369191cb56fec2da9f721612472789; expires=Sat, 06-Mar-21
+        21:06:29 GMT; path=/; domain=.orcid.org; HttpOnly; SameSite=Lax
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '08107741b30000853a19073000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 61c75b15ea6c853a-ORD
+    body:
+      encoding: ASCII-8BIT
+      string: '{"last-modified-date":{"value":1612465770316},"email":[{"created-date":{"value":1612465747618},"last-modified-date":{"value":1612465770316},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"agw13@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null},{"created-date":{"value":1601473260293},"last-modified-date":{"value":1612465218966},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"awead@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":true,"put-code":null}],"path":"/0000-0001-8485-6532/email"}'
+  recorded_at: Thu, 04 Feb 2021 21:06:29 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Orcid_Public_Email/_primary/when_a_primary_email_is_NOT_present/primary/1_2_2_1_1.yml
+++ b/spec/fixtures/vcr_cassettes/Orcid_Public_Email/_primary/when_a_primary_email_is_NOT_present/primary/1_2_2_1_1.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pub.orcid.org/v2.1/0000-0001-8485-6532/email
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Feb 2021 20:57:20 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - X-Mapping-fjhppofk=4842165633BFDE68C17EFF06BB2B96E5; path=/
+      - __cfduid=de271b7ff01ce5c366386898db715d47e1612472240; expires=Sat, 06-Mar-21
+        20:57:20 GMT; path=/; domain=.orcid.org; HttpOnly; SameSite=Lax
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '08106ee14400009da198b64000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 61c74daede339da1-ORD
+    body:
+      encoding: ASCII-8BIT
+      string: '{"last-modified-date":{"value":1612465770316},"email":[{"created-date":{"value":1612465747618},"last-modified-date":{"value":1612465770316},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"agw13@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null},{"created-date":{"value":1601473260293},"last-modified-date":{"value":1612465218966},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"awead@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null}],"path":"/0000-0001-8485-6532/email"}'
+  recorded_at: Thu, 04 Feb 2021 20:57:20 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Orcid_Public_Email/_primary/when_a_primary_email_is_present/primary/1_2_1_1_1.yml
+++ b/spec/fixtures/vcr_cassettes/Orcid_Public_Email/_primary/when_a_primary_email_is_present/primary/1_2_1_1_1.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pub.orcid.org/v2.1/0000-0001-8485-6532/email
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Feb 2021 20:57:25 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - X-Mapping-fjhppofk=4842165633BFDE68C17EFF06BB2B96E5; path=/
+      - __cfduid=d0a7248be07bdf4719cf53282415fe5361612472245; expires=Sat, 06-Mar-21
+        20:57:25 GMT; path=/; domain=.orcid.org; HttpOnly; SameSite=Lax
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '08106ef594000003acb43ff000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 61c74dcf5a1503ac-ORD
+    body:
+      encoding: ASCII-8BIT
+      string: '{"last-modified-date":{"value":1612465770316},"email":[{"created-date":{"value":1612465747618},"last-modified-date":{"value":1612465770316},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"agw13@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null},{"created-date":{"value":1601473260293},"last-modified-date":{"value":1612465218966},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"awead@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":true,"put-code":null}],"path":"/0000-0001-8485-6532/email"}'
+  recorded_at: Thu, 04 Feb 2021 20:57:25 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Orcid_Public_Person/with_a_valid_orcid/returns_the_data.yml
+++ b/spec/fixtures/vcr_cassettes/Orcid_Public_Person/with_a_valid_orcid/returns_the_data.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pub.orcid.org/v2.1/0000-0001-8485-6532/person
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 04:26:20 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - X-Mapping-fjhppofk=4842165633BFDE68C17EFF06BB2B96E5; path=/
+      - __cfduid=dd61003a10f77f48be838876d387cd6001612499180; expires=Sun, 07-Mar-21
+        04:26:20 GMT; path=/; domain=.orcid.org; HttpOnly; SameSite=Lax
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '081209f3fc000003f0888c0000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 61c9df66596a03f0-ORD
+    body:
+      encoding: ASCII-8BIT
+      string: '{"last-modified-date":{"value":1612465770316},"name":{"created-date":{"value":1601473260303},"last-modified-date":{"value":1612452781871},"given-names":{"value":"Adam"},"family-name":{"value":"Wead"},"credit-name":{"value":"Dr.
+        Adam Wead"},"source":null,"visibility":"PUBLIC","path":"0000-0001-8485-6532"},"other-names":{"last-modified-date":null,"other-name":[],"path":"/0000-0001-8485-6532/other-names"},"biography":{"created-date":{"value":1612452696013},"last-modified-date":{"value":1612452696013},"content":"Developer
+        working for Penn State University Libraries.","visibility":"PUBLIC","path":"/0000-0001-8485-6532/biography"},"researcher-urls":{"last-modified-date":null,"researcher-url":[],"path":"/0000-0001-8485-6532/researcher-urls"},"emails":{"last-modified-date":{"value":1612465770316},"email":[{"created-date":{"value":1612465747618},"last-modified-date":{"value":1612465770316},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"agw13@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null},{"created-date":{"value":1601473260293},"last-modified-date":{"value":1612465218966},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"awead@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null}],"path":"/0000-0001-8485-6532/email"},"addresses":{"last-modified-date":null,"address":[],"path":"/0000-0001-8485-6532/address"},"keywords":{"last-modified-date":null,"keyword":[],"path":"/0000-0001-8485-6532/keywords"},"external-identifiers":{"last-modified-date":null,"external-identifier":[],"path":"/0000-0001-8485-6532/external-identifiers"},"path":"/0000-0001-8485-6532/person"}'
+  recorded_at: Fri, 05 Feb 2021 04:26:21 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Orcid_Public_Person/with_an_invalid_orcid/raises_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/Orcid_Public_Person/with_an_invalid_orcid/raises_an_error.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pub.orcid.org/v2.1/12341234/person
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Thu, 04 Feb 2021 16:00:00 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - X-Mapping-fjhppofk=814C785051499CB634650A2359C0B50C; path=/
+      - __cfduid=ddefd88833784e39ebf11b6f6d1ace60d1612454400; expires=Sat, 06-Mar-21
+        16:00:00 GMT; path=/; domain=.orcid.org; HttpOnly; SameSite=Lax
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '080f5eaa2600000e92de166000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 61c59a236ddc0e92-PHL
+    body:
+      encoding: ASCII-8BIT
+      string: '{"response-code":404,"developer-message":"404 Not Found: The resource
+        was not found. Full validation error: ORCID iD 12341234 not found","user-message":"The
+        resource was not found.","error-code":9016,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
+  recorded_at: Thu, 04 Feb 2021 16:00:00 GMT
+recorded_with: VCR 6.0.0

--- a/spec/lib/orcid/public/email_spec.rb
+++ b/spec/lib/orcid/public/email_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rspec/its'
+require 'support/vcr'
+require 'orcid'
+
+RSpec.describe Orcid::Public::Email, :vcr do
+  subject(:email) { described_class.new(id: id) }
+
+  let(:id) { '0000-0001-8485-6532' }
+
+  describe '#addresses' do
+    context 'when calling the API' do
+      it 'returns all public addresses' do
+        expect(email.addresses[0].to_s).to eq('agw13@psu.edu')
+        expect(email.addresses[0].visibility).to eq('PUBLIC')
+        expect(email.addresses[0]).to be_verified
+        expect(email.addresses[0]).not_to be_primary
+        expect(email.addresses[1].to_s).to eq('awead@psu.edu')
+        expect(email.addresses[1].visibility).to eq('PUBLIC')
+        expect(email.addresses[1]).to be_verified
+        expect(email.addresses[1]).not_to be_primary
+      end
+    end
+
+    context 'when providing data' do
+      subject(:email) { described_class.new(id: id, data: data) }
+
+      let(:data) do
+        { 'email' => [] }
+      end
+
+      it 'returns all the addresses' do
+        expect(email.addresses).to be_empty
+      end
+    end
+  end
+
+  describe '#primary' do
+    context 'when a primary email is present' do
+      its(:primary) { is_expected.to eq('awead@psu.edu') }
+    end
+
+    context 'when a primary email is NOT present' do
+      its(:primary) { is_expected.to be_nil }
+    end
+  end
+
+  describe '#default' do
+    context 'when a primary email is present' do
+      its(:default) { is_expected.to eq('awead@psu.edu') }
+    end
+
+    context 'when a primary email is NOT present' do
+      its(:default) { is_expected.to eq('agw13@psu.edu') }
+    end
+  end
+end

--- a/spec/lib/orcid/public/person_spec.rb
+++ b/spec/lib/orcid/public/person_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/vcr'
+require 'orcid'
+
+RSpec.describe Orcid::Public::Person, :vcr do
+  subject(:person) { described_class.new(id) }
+
+  context 'with a valid orcid' do
+    let(:id) { '0000-0001-8485-6532' }
+
+    it 'returns the data' do
+      expect(person.given_names).to eq('Adam')
+      expect(person.family_name).to eq('Wead')
+      expect(person.credit_name).to eq('Dr. Adam Wead')
+      expect(person.visibility).to eq('PUBLIC')
+      expect(person.emails).to be_an(Orcid::Public::Email)
+    end
+  end
+
+  context 'with an invalid orcid' do
+    let(:id) { '12341234' }
+
+    it 'raises an error' do
+      expect { person.family_name }.to raise_error(Orcid::NotFound, 'The resource was not found.')
+    end
+  end
+end

--- a/spec/lib/orcid/public_spec.rb
+++ b/spec/lib/orcid/public_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'orcid'
+
+RSpec.describe Orcid::Public do
+  describe '::get' do
+    subject(:call) { described_class.get(action: 'endpoint', id: 'id') }
+
+    let(:connection) { instance_double('Faraday::Connection') }
+
+    before do
+      allow(Faraday).to receive(:new).and_return(connection)
+      allow(connection).to receive(:get).and_return(response)
+    end
+
+    context 'with a successful response' do
+      let(:response) { instance_spy('Faraday::Response', body: '{ "success": "true" }') }
+
+      it { is_expected.to eq({ 'success' => 'true' }) }
+    end
+
+    context 'with an unparseable response' do
+      let(:response) { instance_spy('Faraday::Response', body: "can't parse this") }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the orcid does not exist' do
+      let(:response) do
+        instance_spy(
+          'Faraday::Response',
+          body: '{"response-code":404, "user-message":"Nothing to see here..."}',
+          status: 404,
+          success?: false
+        )
+      end
+
+      it 'raises Orcid::NotFound' do
+        expect { call }.to raise_error(Orcid::NotFound, 'Nothing to see here...')
+      end
+    end
+
+    context 'with an unknown error' do
+      let(:response) do
+        instance_spy(
+          'Faraday::Response',
+          body: '{"response-code":500, "user-message":"Something went wrong."}',
+          status: 500,
+          success?: false
+        )
+      end
+
+      it 'raises Orcid::Error' do
+        expect { call }.to raise_error(Orcid::Error, 'Something went wrong.')
+      end
+    end
+  end
+end

--- a/spec/lib/qa/authorities/persons_spec.rb
+++ b/spec/lib/qa/authorities/persons_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Qa::Authorities::Persons, type: :authority do
         let(:search_term) { creator.surname.slice(0..3).downcase }
 
         let(:expected_result) { formatted_result.merge(
-          additional_metadata: "#{Actor.human_attribute_name(:orcid)}: #{Orcid.new(creator.orcid).to_human}"
+          additional_metadata: "#{Actor.human_attribute_name(:orcid)}: #{OrcidId.new(creator.orcid).to_human}"
         ) }
 
         it { is_expected.to include(expected_result) }

--- a/spec/lib/qa/authorities/persons_spec.rb
+++ b/spec/lib/qa/authorities/persons_spec.rb
@@ -70,6 +70,13 @@ RSpec.describe Qa::Authorities::Persons, type: :authority do
 
         it { is_expected.to be_empty }
       end
+
+      context 'when PSU ID and ORCiD are absent' do
+        let!(:creator) { create(:actor, :with_no_identifiers) }
+        let(:search_term) { creator.surname.slice(0..3).downcase }
+
+        it { is_expected.to be_empty }
+      end
     end
 
     context "with results from Penn State's identity service" do

--- a/spec/models/orcid_id_spec.rb
+++ b/spec/models/orcid_id_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Orcid, type: :model do
+RSpec.describe OrcidId, type: :model do
   let(:id) { FactoryBotHelpers.generate_orcid }
   let(:formatted_id) { id.gsub(/(\d{4})(?!$)/, '\1-') }
   let(:uri) { URI("https://orcid.org/#{formatted_id}") }


### PR DESCRIPTION
Adds a client to integration with Orcid's public API. Currently, only querying the `/person` operation with a given orcid is supported.

Fixes #820 