### PR TITLE
Read-only mode

### DIFF
--- a/app/components/flash_message_component.rb
+++ b/app/components/flash_message_component.rb
@@ -8,9 +8,11 @@ class FlashMessageComponent < ApplicationComponent
   end
 
   def messages
-    flash.map do |message|
-      Message.new(*message)
-    end
+    read_only_message + flash_messages
+  end
+
+  def render?
+    messages.present?
   end
 
   class Message
@@ -38,4 +40,18 @@ class FlashMessageComponent < ApplicationComponent
       "alert-#{type}"
     end
   end
+
+  private
+
+    def flash_messages
+      flash.map do |message|
+        Message.new(*message)
+      end
+    end
+
+    def read_only_message
+      return [] unless Rails.application.read_only?
+
+      [Message.new('alert', I18n.t('read_only'))]
+    end
 end

--- a/app/controllers/api/v1/rest_controller.rb
+++ b/app/controllers/api/v1/rest_controller.rb
@@ -25,7 +25,7 @@ module Api
       # user will never be used. If this changes, however, we should probably create a default, public-level
       # application.
       def current_user
-        return User.guest unless api_token
+        return User.guest if api_token.blank?
 
         api_token.application
       end
@@ -33,10 +33,10 @@ module Api
       private
 
         def authenticate_request!
-          if api_token
+          if api_token && !Rails.application.read_only?
             api_token.record_usage
           else
-            render json: { message: I18n.t('api.errors.not_authorized'), code: 401 }, status: 401 unless api_token
+            render json: { message: I18n.t('api.errors.not_authorized'), code: 401 }, status: 401
           end
         end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,8 @@ class ApplicationController < ActionController::Base
   ActionDispatch::ExceptionWrapper.rescue_responses['Pundit::NotAuthorizedError'] = :not_found
 
   def current_user
+    return User.guest if Rails.application.read_only?
+
     UserDecorator.new(super || User.guest)
   end
 

--- a/app/controllers/dashboard/base_controller.rb
+++ b/app/controllers/dashboard/base_controller.rb
@@ -3,5 +3,13 @@
 class Dashboard::BaseController < ApplicationController
   include WithAuditing
 
-  before_action :authenticate_user!
+  before_action :authenticate_dashboard_user
+
+  private
+
+    def authenticate_dashboard_user
+      redirect_to root_path if Rails.application.read_only?
+
+      authenticate_user!
+    end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,6 +20,14 @@ module ApplicationHelper
     end
   end
 
+  def link_to_login(link, path, options = {})
+    if Rails.application.read_only?
+      link_to link, path, options.merge(class: 'nav-link disabled')
+    else
+      link_to link, path, options.merge(class: 'nav-link')
+    end
+  end
+
   # @note Based off of ActionView::Helpers::Tags::Base#tag_id. Because it's a private method, and we shouldn't override
   # it, we're redoing it here.
   def form_field_id(form, attribute)

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -1,7 +1,7 @@
 <% if current_user.guest? %>
 
   <li class="nav-item">
-    <%= link_to t('blacklight.header_links.login'), new_user_session_path, class: 'nav-link' %>
+    <%= link_to_login t('blacklight.header_links.login'), new_user_session_path %>
   </li>
 
 <% else %>

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -71,7 +71,7 @@
     </header>
 
     <main class="main">
-      <%= render FlashMessageComponent.new(flash: flash) if flash.present? %>
+      <%= render FlashMessageComponent.new(flash: flash) %>
       <% if content_for? :sidebar %>
         <%= render '/layouts/with_sidebar' %>
       <% elsif content_for? :content %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,10 @@ module Scholarsphere
     require 'qa/authorities/persons'
     require 'qa/authorities/users'
 
+    def read_only?
+      ENV['READ_ONLY'] == 'true'
+    end
+
     config.generators { |generator| generator.test_framework :rspec }
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,11 @@
 en:
   application_name: "ScholarSphere"
   description: >
-    ScholarSphere is an institutional repository managed by Penn State University Libraries. Anyone with a Penn State Access Account can deposit materials relating to the University’s teaching, learning, and research mission to ScholarSphere. All types of scholarly materials, including publications, instructional materials, creative works, and research data are accepted.
+    ScholarSphere is an institutional repository managed by Penn State University Libraries. Anyone with a Penn State
+    Access Account can deposit materials relating to the University’s teaching, learning, and research mission to
+    ScholarSphere. All types of scholarly materials, including publications, instructional materials, creative works,
+    and research data are accepted.
+  read_only: Scholarsphere is undergoing maintenance. No changes can be made during this time.
   activerecord:
     attributes:
       actor:

--- a/config/samples/application.yml
+++ b/config/samples/application.yml
@@ -130,6 +130,16 @@
 #  RECAPTCHA_SITE_KEY: 'xxxxxxx'
 #  RECAPTCHA_SECRET_KEY: 'yyyyyyy'
 # --------------------------------------------------------------------------------------------------------------------
+#
+# Read-Only Mode
+#
+# Prevents any database writes. Database reads and Solr will still work normally. This is used when performing updates
+# or destructive changes during the maintenance window, or any other time you don't want users making any changes to the
+# data.
+#
+# READ_ONLY: 'true'
+#
+# --------------------------------------------------------------------------------------------------------------------
 
 # Defaults for your local development environment
 DOWNLOAD_URL_TTL: 6

--- a/spec/components/flash_message_component_spec.rb
+++ b/spec/components/flash_message_component_spec.rb
@@ -59,5 +59,13 @@ RSpec.describe FlashMessageComponent, type: :component do
         expect(result.css('div.alert-danger').text).to match(/Second flash message/)
       end
     end
+
+    context 'when the application is read-only', :read_only do
+      let(:flash) { [] }
+
+      specify do
+        expect(result.css('div.alert-warning').text).to match(/#{I18n.t('read_only')}/)
+      end
+    end
   end
 end

--- a/spec/controllers/api/v1/rest_controller_spec.rb
+++ b/spec/controllers/api/v1/rest_controller_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe Api::V1::RestController, type: :controller do
 
       its(:status) { is_expected.to eq 401 }
     end
+
+    context 'when the application is read-only', :read_only do
+      before { get :index }
+
+      its(:status) { is_expected.to eq 401 }
+      its(:body) { is_expected.to include(I18n.t('api.errors.not_authorized')) }
+    end
   end
 
   context 'with an authenticated request' do
@@ -45,6 +52,11 @@ RSpec.describe Api::V1::RestController, type: :controller do
 
     its(:status) { is_expected.to eq 200 }
     its(:body) { is_expected.to eq 'success' }
+
+    context 'when the application is read-only', :read_only do
+      its(:status) { is_expected.to eq 401 }
+      its(:body) { is_expected.to include(I18n.t('api.errors.not_authorized')) }
+    end
   end
 
   context 'when a record is not found' do

--- a/spec/features/catalog/catalog_spec.rb
+++ b/spec/features/catalog/catalog_spec.rb
@@ -128,6 +128,17 @@ RSpec.describe 'Blacklight catalog page', :inline_jobs do
     end
   end
 
+  context 'when the application is read-only', :read_only do
+    it 'displays a message' do
+      visit(search_catalog_path)
+
+      within('.alert-warning') do
+        expect(page).to have_content(I18n.t('read_only'))
+      end
+      expect(page).to have_link('Login', class: 'disabled')
+    end
+  end
+
   def document_id(resource)
     if resource.is_a? WorkVersion
       "document-#{resource.work.uuid}"

--- a/spec/features/dashboard/catalog_spec.rb
+++ b/spec/features/dashboard/catalog_spec.rb
@@ -120,4 +120,15 @@ RSpec.describe 'Dashboard catalog page', :inline_jobs do
       expect(page).to have_content(I18n.t('dashboard.catalog.zero_results.info.content'))
     end
   end
+
+  context 'when the application is read-only', :read_only, with_user: :user do
+    it 'redirects to the home page' do
+      visit(dashboard_root_path)
+
+      within('.alert-warning') do
+        expect(page).to have_content(I18n.t('read_only'))
+      end
+      expect(page).to have_link('Login', class: 'disabled')
+    end
+  end
 end

--- a/spec/support/read_only.rb
+++ b/spec/support/read_only.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.before do |example|
+    if example.metadata[:read_only]
+      allow_any_instance_of(Scholarsphere::Application).to receive(:read_only?).and_return(true)
+    end
+  end
+end


### PR DESCRIPTION
When setting the appropriate environment variable, Scholarsphere will go into "read-only" mode whereby only Solr and database selects will work. Logins are prohibited as well as any other database writing operations.

This is a UI-level change only. Changes via the console are still permissible.

A flash message informs the user that Scholarsphere's content cannot be changed during this time.

![Screen Shot 2021-02-05 at 2 37 29 PM](https://user-images.githubusercontent.com/312085/107083745-16e09500-67c4-11eb-8316-92e1947b688f.png)


Fixes #848 