### PR TITLE
Migrate Authorships

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ Metrics/BlockLength:
 Metrics/CyclomaticComplexity:
   Exclude:
     - 'app/services/doi_service.rb'
+    - 'app/services/authorship_migration/work_version_creation_migration.rb'
 
 Rails/FilePath:
   EnforcedStyle: arguments

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -76,6 +76,7 @@ Metrics/PerceivedComplexity:
   Exclude:
     - 'app/services/publish_new_work.rb'
     - 'app/services/doi_service.rb'
+    - 'app/services/authorship_migration/work_version_creation_migration.rb'
 
 # Offense count: 1
 # Configuration parameters: CustomIncludeMethods.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -68,6 +68,7 @@ Metrics/ClassLength:
     - 'app/controllers/dashboard/work_versions_controller.rb'
     - 'app/models/collection.rb'
     - 'app/models/work_version.rb'
+    - 'app/services/authorship_migration/work_version_creation_migration.rb'
 
 # Offense count: 1
 # Configuration parameters: IgnoredMethods, Max.

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development, :test do
   gem 'rubocop-performance', '= 1.5.2'
   gem 'rubocop-rails', '= 2.5.2'
   gem 'rubocop-rspec', '= 1.39.0'
+  gem 'timecop'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -456,6 +456,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.0.1)
     thread_safe (0.3.6)
+    timecop (0.9.2)
     tzinfo (1.2.8)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -558,6 +559,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
+  timecop
   uppy-s3_multipart (~> 0.3)
   vcr
   view_component

--- a/app/components/work_histories/paper_trail_change_base_component.rb
+++ b/app/components/work_histories/paper_trail_change_base_component.rb
@@ -13,6 +13,10 @@ class WorkHistories::PaperTrailChangeBaseComponent < ApplicationComponent
     @user = user
   end
 
+  def render?
+    !paper_trail_version.changed_by_system # Do not render changes by system
+  end
+
   private
 
     # Implement these in your subclass

--- a/app/models/authorship.rb
+++ b/app/models/authorship.rb
@@ -12,15 +12,15 @@ class Authorship < ApplicationRecord
 
   after_initialize :set_defaults
 
-  attr_accessor :changed_by_system
+  attr_writer :changed_by_system
 
   has_paper_trail(
-    unless: ->(record) { record.changed_by_system },
     meta: {
       # Explicitly store the resource type and id in the PaperTrail::Version to allow
       # easy access in the work history
       resource_id: :resource_id,
-      resource_type: :resource_type
+      resource_type: :resource_type,
+      changed_by_system: :changed_by_system
     },
     skip: [:instance_token]
   )
@@ -52,6 +52,11 @@ class Authorship < ApplicationRecord
   # @deprecated Use :display_name= instead. This will be removed in 4.3
   def alias=(val)
     self.display_name = val
+  end
+
+  # Force changed_by_system to a boolean
+  def changed_by_system
+    !!@changed_by_system
   end
 
   private

--- a/app/services/authorship_migration/collection_creation_migration.rb
+++ b/app/services/authorship_migration/collection_creation_migration.rb
@@ -12,11 +12,11 @@ module AuthorshipMigration
           errors << call(collection: collection)
         end
 
-        errors.flatten
+        errors = errors.flatten
 
         if $stdout.tty?
           errors.each { |err| puts err }
-          errors.any? # return true or false
+          errors.empty? # return true or false
         else
           errors
         end

--- a/app/services/authorship_migration/collection_creation_migration.rb
+++ b/app/services/authorship_migration/collection_creation_migration.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module AuthorshipMigration
+  class CollectionCreationMigration
+    class AuthorMigrationError < StandardError; end
+
+    class << self
+      def migrate_all_collections
+        errors = []
+
+        Collection.includes(creator_aliases: :actor).find_each do |collection|
+          errors << call(collection: collection)
+        end
+
+        errors.flatten
+
+        if $stdout.tty?
+          errors.each { |err| puts err }
+          errors.any? # return true or false
+        else
+          errors
+        end
+      end
+
+      def call(collection:)
+        errors = []
+
+        collection.creator_aliases.each do |creator_alias|
+          next if already_migrated?(collection_id: collection.id, actor_id: creator_alias.actor_id)
+
+          actor = creator_alias.actor
+
+          authorship_attributes = map_actor_to_authorship_attributes(actor: actor)
+            .merge(map_creator_alias_to_authorship_attributes(creator_alias: creator_alias))
+            .merge(
+              resource_type: 'Collection',
+              resource_id: collection.id
+            )
+
+          Authorship.create!(authorship_attributes)
+        rescue ActiveRecord::ActiveRecordError => e
+          errors << "Collection##{collection.id}, CollectionCreation##{creator_alias.id}, #{e.message}"
+        end
+
+        errors
+      end
+
+      private
+
+        def already_migrated?(collection_id:, actor_id:)
+          Authorship.where(
+            resource_type: 'Collection',
+            resource_id: collection_id,
+            actor_id: actor_id
+          ).any?
+        end
+
+        def map_actor_to_authorship_attributes(actor:)
+          {
+            display_name: actor.default_alias,
+            given_name: actor.given_name,
+            surname: actor.surname,
+            email: actor.email
+          }.with_indifferent_access
+        end
+
+        def map_creator_alias_to_authorship_attributes(creator_alias:)
+          attrs = creator_alias
+            .attributes
+            .with_indifferent_access
+            .slice(
+              :alias,
+              :position,
+              :actor_id,
+              :created_at,
+              :updated_at
+            )
+
+          # Rename alias to display_name
+          attrs[:display_name] = attrs.delete(:alias) if attrs.key?(:alias)
+
+          attrs
+        end
+    end
+  end
+end

--- a/app/services/authorship_migration/work_version_creation_migration.rb
+++ b/app/services/authorship_migration/work_version_creation_migration.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+module AuthorshipMigration
+  class WorkVersionCreationMigration
+    class AuthorMigrationError < StandardError; end
+
+    class << self
+      def call(work_version:)
+        instance = new(work_version: work_version)
+        instance.call
+        instance.errors
+      end
+
+      def migrate_all_work_versions
+        errors = []
+
+        WorkVersion.find_each do |work_version|
+          errors << call(work_version: work_version)
+        end
+
+        errors = errors.flatten
+
+        if $stdout.tty?
+          errors.each { |err| puts err }
+          errors.any? # return true or false
+        else
+          errors
+        end
+      end
+    end
+
+    attr_reader :work_version,
+                :errors
+
+    def initialize(work_version:)
+      @work_version = work_version
+      @errors = []
+    end
+
+    def call
+      @errors = []
+
+      paper_trail_versions__by_creator = all_paper_trail_changes_for_creators.group_by(&:item_id)
+
+      paper_trail_versions__by_creator.each do |work_version_creation_id, versions|
+        migrate_work_version_creation_to_authorship(versions: versions)
+      rescue StandardError => e
+        errors << "WorkVersion##{work_version.id}, WorkVersionCreation##{work_version_creation_id}, #{e}"
+      end
+
+      errors.empty?
+    end
+
+    private
+
+      def migrate_work_version_creation_to_authorship(versions:)
+        actor_id = extract_author_ids(paper_trail_changes: versions).first
+        actor = actor_lookup[actor_id]
+
+        return if already_migrated?(actor_id: actor_id)
+
+        if versions.first.event != 'create'
+          raise(AuthorMigrationError,
+                'Cannot find the PaperTrail::Version for when the record was created')
+        end
+        raise AuthorMigrationError, "Could not find Actor##{actor_id.inspect}" if actor.blank?
+
+        base_authorship_attributes = map_actor_to_authorship_attributes(actor: actor)
+          .merge(
+            resource_type: 'WorkVersion',
+            resource_id: work_version.id
+          )
+
+        # Note that we use `new` below with the base attributes coming in from
+        # the Actor. The Authorship will be saved to the database after merging
+        # in the changeset from the first papertrail version.
+        authorship = Authorship.new(base_authorship_attributes)
+
+        ActiveRecord::Base.transaction do
+          versions.each do |version|
+            PaperTrail.request(whodunnit: version.whodunnit) do
+              case version.event
+              when 'create', 'update'
+                changes = map_paper_trail_updates_to_authorship_attributes(version: version)
+                authorship.update!(changes)
+              when 'destroy'
+                authorship.destroy
+              end
+            end
+          end
+        end
+      end
+
+      def already_migrated?(actor_id:)
+        PaperTrail::Version.where(
+          item_type: 'Authorship',
+          resource_type: 'WorkVersion',
+          resource_id: work_version.id
+        ).where_object_changes(actor_id: actor_id).any?
+      end
+
+      def all_paper_trail_changes_for_creators
+        @all_paper_trail_changes_for_creators ||= PaperTrail::Version
+          .where(
+            item_type: 'WorkVersionCreation',
+            work_version_id: work_version.id
+          )
+          .order(created_at: :asc)
+      end
+
+      # Takes a list of paper trail changes, and extracts all unique actor ids
+      def extract_author_ids(paper_trail_changes:)
+        _actor_ids = paper_trail_changes
+          .flat_map { |ptv| ptv.changeset.fetch('actor_id', []) }
+          .compact
+          .uniq
+      end
+
+      # Returns a hash in the form of
+      #   {id => Actor record}
+      def actor_lookup
+        @actor_lookup ||= load_actor_lookup
+      end
+
+      def load_actor_lookup
+        actor_ids = extract_author_ids(paper_trail_changes: all_paper_trail_changes_for_creators)
+
+        Actor
+          .where(id: actor_ids)
+          .index_by(&:id)
+      end
+
+      def map_actor_to_authorship_attributes(actor:)
+        {
+          display_name: actor.default_alias,
+          given_name: actor.given_name,
+          surname: actor.surname,
+          email: actor.email
+        }.with_indifferent_access
+      end
+
+      # Accepts a PaperTrail::Version representing a change to a
+      # WorkVersionCreation
+      #
+      # Returns a hash of these changes, with the appropriate attribute names
+      # for an Authorship
+      def map_paper_trail_updates_to_authorship_attributes(version:)
+        attrs = version
+          .changeset
+          .map { |attr, changes| [attr, changes.last] } # changes are in the form [old_val, new_val]
+          .to_h
+          .with_indifferent_access
+          .except(:id, :work_version_id)
+
+        # Rename alias to display_name
+        attrs[:display_name] = attrs.delete(:alias) if attrs.key?(:alias)
+
+        attrs
+      end
+  end
+end

--- a/app/services/authorship_migration/work_version_creation_migration.rb
+++ b/app/services/authorship_migration/work_version_creation_migration.rb
@@ -14,15 +14,17 @@ module AuthorshipMigration
       def migrate_all_work_versions
         errors = []
 
-        WorkVersion.find_each do |work_version|
+        WorkVersion.find_each.with_index do |work_version, index|
+          print '.' if $stdout.tty? && (index % 100).zero?
           errors << call(work_version: work_version)
         end
 
         errors = errors.flatten
 
         if $stdout.tty?
+          puts 'done'
           errors.each { |err| puts err }
-          errors.any? # return true or false
+          errors.empty? # return true or false
         else
           errors
         end

--- a/app/services/authorship_migration/ye_olde_build_new_work_version.rb
+++ b/app/services/authorship_migration/ye_olde_build_new_work_version.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module AuthorshipMigration
+  class YeOldeBuildNewWorkVersion
+    def self.call(previous_version)
+      parent_work = previous_version.work
+      highest_version_number = parent_work.versions.maximum(:version_number).to_i
+
+      # Instantiate new draft version using the previous version's metadata and increment the version number
+      new_version = parent_work.versions.build(
+        metadata: previous_version.metadata,
+        aasm_state: WorkVersion::STATE_DRAFT,
+        version_number: highest_version_number + 1
+      )
+
+      # Copy over files
+      previous_version.file_version_memberships.each do |previous_membership|
+        new_version.file_version_memberships.build(
+          file_resource_id: previous_membership.file_resource_id,
+          title: previous_membership.title,
+          changed_by_system: true # mute papertrail for this change
+        )
+      end
+
+      # Copy over creators
+      previous_version.creator_aliases.each do |previous_creation|
+        new_version.creator_aliases.build(
+          actor_id: previous_creation.actor_id,
+          alias: previous_creation.alias,
+          position: previous_creation.position,
+          changed_by_system: true # mute papertrail for this change
+        )
+      end
+
+      new_version
+    end
+  end
+end

--- a/db/migrate/20210215172117_add_changed_by_system_to_versions.rb
+++ b/db/migrate/20210215172117_add_changed_by_system_to_versions.rb
@@ -1,0 +1,5 @@
+class AddChangedBySystemToVersions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :versions, :changed_by_system, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_26_195635) do
+ActiveRecord::Schema.define(version: 2021_02_15_172117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -211,6 +211,7 @@ ActiveRecord::Schema.define(version: 2021_01_26_195635) do
     t.integer "work_version_id"
     t.integer "resource_id"
     t.string "resource_type"
+    t.boolean "changed_by_system", default: false, null: false
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
     t.index ["resource_type", "resource_id"], name: "index_versions_on_resource_type_and_resource_id"
     t.index ["work_version_id"], name: "index_versions_on_work_version_id"

--- a/spec/components/work_histories/paper_trail_change_base_component_spec.rb
+++ b/spec/components/work_histories/paper_trail_change_base_component_spec.rb
@@ -51,6 +51,24 @@ RSpec.describe WorkHistories::PaperTrailChangeBaseComponent, type: :component do
     end
   end
 
+  describe '#render?' do
+    subject { component.render? }
+
+    let(:component) { HasItemType.new(user: user, paper_trail_version: paper_trail_version) }
+
+    context 'when the PaperTrail::Version has changed_by_system = true' do
+      before { allow(paper_trail_version).to receive(:changed_by_system).and_return(true) }
+
+      it { is_expected.to eq false }
+    end
+
+    context 'when the PaperTrail::Version has changed_by_system = false' do
+      before { allow(paper_trail_version).to receive(:changed_by_system).and_return(false) }
+
+      it { is_expected.to eq true }
+    end
+  end
+
   describe '#i18n_key' do
     context 'when the subclass does not implement #i18n_key' do
       it do

--- a/spec/models/authorship_spec.rb
+++ b/spec/models/authorship_spec.rb
@@ -98,19 +98,24 @@ RSpec.describe Authorship, type: :model do
     context 'when the record is marked as changed by the system' do
       let(:authorship) { create(:authorship, changed_by_system: true) }
 
-      it 'does not write a papertrail version' do
-        expect(authorship.reload.versions).to be_empty
+      it "writes a version with the flag saved in PaperTrail's metadata" do
+        expect(authorship.reload.versions.length).to eq 1
+
+        paper_trail_version = authorship.versions.first
+
+        expect(paper_trail_version.changed_by_system).to eq(true)
       end
     end
 
     context 'when the record is NOT marked as changed by the system' do
-      let(:authorship) { create(:authorship, changed_by_system: false) }
+      let(:authorship) { create(:authorship) }
 
       it "writes a version and stores the record's type and id into the version metadata" do
         paper_trail_version = authorship.versions.first
 
         expect(paper_trail_version.resource_id).to eq(authorship.resource_id)
         expect(paper_trail_version.resource_type).to eq(authorship.resource_type)
+        expect(paper_trail_version.changed_by_system).to eq(false)
       end
     end
   end

--- a/spec/services/authorship_migration/collection_creation_migration_spec.rb
+++ b/spec/services/authorship_migration/collection_creation_migration_spec.rb
@@ -92,9 +92,12 @@ RSpec.describe AuthorshipMigration::CollectionCreationMigration, type: :model do
     end
 
     it 'migrates all collecdtions' do
-      expect { described_class.migrate_all_collections }
+      return_value = nil
+      expect { return_value = described_class.migrate_all_collections }
         .to change(Authorship, :count)
         .by(3)
+
+      expect(return_value).to eq true
     end
   end
 end

--- a/spec/services/authorship_migration/collection_creation_migration_spec.rb
+++ b/spec/services/authorship_migration/collection_creation_migration_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AuthorshipMigration::CollectionCreationMigration, type: :model do
+  let(:collection) { create :collection }
+
+  before do
+    # We will create two CollectionCreations, and we need some Actors to be
+    # associated with them
+    @act1 = create(:actor, psu_id: 'act001', given_name: 'Actor1')
+    @act2 = create(:actor, psu_id: 'act002', given_name: 'Actor2')
+
+    @cc1 = nil
+    @cc2 = nil
+
+    Timecop.freeze(Time.zone.local(2021, 1, 1)) do
+      @cc1 = create(
+        :collection_creation,
+        collection: collection,
+        actor: @act1,
+        alias: 'Alias for Actor 1',
+        position: 10
+      )
+    end
+
+    Timecop.freeze(Time.zone.local(2021, 1, 2)) do
+      @cc1.update(position: 20)
+
+      @cc2 = create(
+        :collection_creation,
+        collection: collection,
+        actor: @act2,
+        alias: 'Alias for Actor 2',
+        position: 10
+      )
+    end
+  end
+
+  describe '.call' do
+    def perform_call
+      described_class.call(collection: collection)
+    end
+
+    context 'when on the happy path' do
+      it 'creates a corresponding number of Authorship records' do
+        expect { perform_call }
+          .to change(Authorship, :count)
+          .by(2)
+      end
+
+      it 'ports over the creators to Authorships' do
+        perform_call
+
+        authorship1 = Authorship.find_by(actor_id: @act1)
+        expect(authorship1.resource).to eq collection
+        expect(authorship1.display_name).to eq 'Alias for Actor 1'
+        expect(authorship1.given_name).to eq @act1.given_name
+        expect(authorship1.surname).to eq @act1.surname
+        expect(authorship1.email).to eq @act1.email
+        expect(authorship1.position).to eq 20
+        expect(authorship1.actor_id).to eq @act1.id
+        expect(authorship1.instance_token).to be_present
+        expect(authorship1.created_at.to_date).to eq Time.zone.local(2021, 1, 1).to_date
+        expect(authorship1.updated_at.to_date).to eq Time.zone.local(2021, 1, 2).to_date
+
+        authorship2 = Authorship.find_by(actor_id: @act2)
+        expect(authorship2.display_name).to eq 'Alias for Actor 2'
+        expect(authorship2.created_at.to_date).to eq Time.zone.local(2021, 1, 2).to_date
+        expect(authorship2.updated_at.to_date).to eq Time.zone.local(2021, 1, 2).to_date
+      end
+
+      it 'is idempotent' do
+        perform_call
+        expect { perform_call }.not_to change(Authorship, :count)
+      end
+    end
+  end
+
+  describe '.migrate_all_collections' do
+    let(:collection2) { create :collection }
+
+    before do
+      @act3 = create(:actor, psu_id: 'act003', given_name: 'Actor3')
+      @cc3 = create(
+        :collection_creation,
+        collection: collection2,
+        actor: @act1,
+        alias: 'Alias for Actor 3',
+        position: 10
+      )
+    end
+
+    it 'migrates all collecdtions' do
+      expect { described_class.migrate_all_collections }
+        .to change(Authorship, :count)
+        .by(3)
+    end
+  end
+end

--- a/spec/services/authorship_migration/work_version_creation_migration_spec.rb
+++ b/spec/services/authorship_migration/work_version_creation_migration_spec.rb
@@ -171,20 +171,16 @@ RSpec.describe AuthorshipMigration::WorkVersionCreationMigration, type: :model, 
         @wvc1.versions.first.destroy!
       end
 
-      it 'reports the error, continues to migrate the rest of the creators' do
+      it 'still works' do
         authorship_count_before = Authorship.count
         versions_count_before = PaperTrail::Version.count
 
         errors = perform_call
 
-        expect(errors.length).to eq 1
-        expect(errors.first).to match(/WorkVersion##{work_version.id}/i)
-          .and match(/cannot find the papertrail::version/i)
+        expect(errors).to be_empty
 
-        # It skips the first creator because it errors out, but continues to
-        # migrate the other two (one of which is deleted)
-        expect(Authorship.count - authorship_count_before).to eq 1
-        expect(PaperTrail::Version.count - versions_count_before).to eq 3
+        expect(Authorship.count - authorship_count_before).to eq 2
+        expect(PaperTrail::Version.count - versions_count_before).to eq 5
       end
     end
 

--- a/spec/services/authorship_migration/work_version_creation_migration_spec.rb
+++ b/spec/services/authorship_migration/work_version_creation_migration_spec.rb
@@ -210,4 +210,34 @@ RSpec.describe AuthorshipMigration::WorkVersionCreationMigration, type: :model, 
       end
     end
   end
+
+  describe '.migrate_all_work_versions' do
+    let(:work_version2) { create :work_version }
+
+    before do
+      @act4 = create(:actor, psu_id: 'act004', given_name: 'Actor4')
+      @wvc4 = nil
+
+      PaperTrail.request(whodunnit: user.to_gid) do
+        Timecop.freeze(Time.zone.local(2021, 1, 8)) do
+          @wvc4 = create(
+            :work_version_creation,
+            work_version: work_version,
+            actor: @act4,
+            alias: 'Original Alias for Actor 4',
+            position: 10
+          )
+        end
+      end
+    end
+
+    it 'migrates all work versions' do
+      return_value = nil
+      expect { return_value = described_class.migrate_all_work_versions }
+        .to change(Authorship, :count)
+        .by(3)
+
+      expect(return_value).to eq true
+    end
+  end
 end

--- a/spec/services/authorship_migration/work_version_creation_migration_spec.rb
+++ b/spec/services/authorship_migration/work_version_creation_migration_spec.rb
@@ -58,6 +58,14 @@ RSpec.describe AuthorshipMigration::WorkVersionCreationMigration, type: :model, 
       Timecop.freeze(Time.zone.local(2021, 1, 5)) do
         @wvc_deleted.destroy
       end
+
+      Timecop.freeze(Time.zone.local(2021, 1, 6)) do
+        # Simulate a bug fix to creator position data that we did
+        @wvc2.update(
+          position: 111,
+          changed_by_system: true
+        )
+      end
     end
   end
 
@@ -128,6 +136,7 @@ RSpec.describe AuthorshipMigration::WorkVersionCreationMigration, type: :model, 
           expect(v3.created_at.to_date).to eq Time.zone.local(2021, 1, 3).to_date
 
           authorship2 = Authorship.find_by(actor_id: @act2)
+          expect(authorship2.position).to eq 111 # Simulate a bug fix we did
           expect(authorship2.versions.length).to eq 1
 
           # Test deleted actor, have to extract from DB.
@@ -286,7 +295,7 @@ RSpec.describe AuthorshipMigration::WorkVersionCreationMigration, type: :model, 
         expect(authorship2.given_name).to eq @act2.given_name
         expect(authorship2.surname).to eq @act2.surname
         expect(authorship2.email).to eq @act2.email
-        expect(authorship2.position).to eq 10
+        expect(authorship2.position).to eq 111
         expect(authorship2.actor_id).to eq @act2.id
         expect(authorship2.instance_token).to be_present
         expect(authorship2.created_at.to_date).to eq Time.zone.local(2021, 1, 8).to_date

--- a/spec/services/authorship_migration/work_version_creation_migration_spec.rb
+++ b/spec/services/authorship_migration/work_version_creation_migration_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AuthorshipMigration::WorkVersionCreationMigration, type: :model, versioning: true do
+  let(:user) { create :user }
+  let(:work_version) { create :work_version }
+
+  before do
+    # We will create three WorkVerisonCreations, one of which will be deleted.
+    # We also need some Actors to be associated with them.
+    @act1 = create(:actor, psu_id: 'act001', given_name: 'Actor1')
+    @act2 = create(:actor, psu_id: 'act002', given_name: 'Actor2')
+    @act_deleted = create(:actor, psu_id: 'act000', given_name: 'ActorDeleted')
+
+    @wvc1 = nil
+    @wvc2 = nil
+    @wvc_deleted = nil
+
+    PaperTrail.request(whodunnit: user.to_gid) do
+      Timecop.freeze(Time.zone.local(2021, 1, 1)) do
+        @wvc1 = create(
+          :work_version_creation,
+          work_version: work_version,
+          actor: @act1,
+          alias: 'Original Alias for Actor 1',
+          position: 10
+        )
+      end
+
+      Timecop.freeze(Time.zone.local(2021, 1, 2)) do
+        @wvc1.update(alias: 'New Alias for Actor 1')
+      end
+
+      Timecop.freeze(Time.zone.local(2021, 1, 3)) do
+        @wvc1.update(position: 20)
+
+        @wvc2 = create(
+          :work_version_creation,
+          work_version: work_version,
+          actor: @act2,
+          alias: 'Original Alias for Actor 2',
+          position: 10
+        )
+      end
+
+      Timecop.freeze(Time.zone.local(2021, 1, 4)) do
+        @wvc_deleted = create(
+          :work_version_creation,
+          work_version: work_version,
+          actor: @act_deleted,
+          alias: 'Original Alias for Actor Deleted',
+          position: 10
+        )
+      end
+
+      Timecop.freeze(Time.zone.local(2021, 1, 5)) do
+        @wvc_deleted.destroy
+      end
+    end
+  end
+
+  describe '.call' do
+    def perform_call
+      described_class.call(work_version: work_version)
+    end
+
+    # Sanity checks
+    it 'sets up a sane test environment' do
+      expect(PaperTrail::Version.where(item_type: 'WorkVersionCreation').count)
+        .to eq 6
+
+      expect(@wvc1.versions.map { |v| v.created_at.to_date })
+        .to match_array([
+                          Time.zone.local(2021, 1, 1).to_date,
+                          Time.zone.local(2021, 1, 2).to_date,
+                          Time.zone.local(2021, 1, 3).to_date
+                        ])
+    end
+
+    context 'when on the happy path' do
+      it 'creates a corresponding number of Authorship records' do
+        expect { perform_call }
+          .to change(Authorship, :count)
+          .by(2) # Note, TWO, because one of the WVC's above is deleted
+      end
+
+      it 'recreates the editing history of the migrated WorkVersionCreations' do
+        perform_call
+        expect(PaperTrail::Version.where(item_type: 'WorkVersionCreation').count)
+          .to eq(PaperTrail::Version.where(item_type: 'Authorship').count)
+
+        authorship1 = Authorship.find_by(actor_id: @act1)
+        expect(authorship1.resource).to eq work_version
+        expect(authorship1.alias).to eq 'New Alias for Actor 1'
+        expect(authorship1.given_name).to eq @act1.given_name
+        expect(authorship1.surname).to eq @act1.surname
+        expect(authorship1.email).to eq @act1.email
+        expect(authorship1.position).to eq 20
+        expect(authorship1.actor_id).to eq @act1.id
+        expect(authorship1.instance_token).to be_present
+        expect(authorship1.created_at.to_date).to eq Time.zone.local(2021, 1, 1).to_date
+        expect(authorship1.updated_at.to_date).to eq Time.zone.local(2021, 1, 3).to_date
+
+        expect(authorship1.versions.length).to eq 3
+        v1, v2, v3 = authorship1.versions
+        expect(v1.whodunnit).to eq user.to_gid.to_s
+        expect(v1.event).to eq 'create'
+        expect(v1.changeset[:display_name]).to eq @wvc1.versions[0].changeset[:alias]
+        expect(v1.changeset[:actor_id]).to eq @wvc1.versions[0].changeset[:actor_id]
+        expect(v1.changeset[:position]).to eq @wvc1.versions[0].changeset[:position]
+        expect(v1.changeset[:created_at]).to eq @wvc1.versions[0].changeset[:created_at]
+        expect(v1.changeset[:updated_at]).to eq @wvc1.versions[0].changeset[:updated_at]
+        expect(v1.created_at.to_date).to eq Time.zone.local(2021, 1, 1).to_date
+
+        expect(v2.event).to eq 'update'
+        expect(v2.changeset[:display_name]).to eq(@wvc1.versions[1].changeset[:alias])
+        expect(v2.changeset[:created_at]).to eq(@wvc1.versions[1].changeset[:created_at])
+        expect(v2.changeset[:updated_at]).to eq(@wvc1.versions[1].changeset[:updated_at])
+        expect(v2.created_at.to_date).to eq Time.zone.local(2021, 1, 2).to_date
+
+        expect(v3.event).to eq 'update'
+        expect(v3.changeset).to eq(@wvc1.versions[2].changeset)
+        expect(v3.created_at.to_date).to eq Time.zone.local(2021, 1, 3).to_date
+
+        authorship2 = Authorship.find_by(actor_id: @act2)
+        expect(authorship2.versions.length).to eq 1
+
+        # Test deleted actor, have to extract from DB.
+        expect(Authorship.find_by(actor_id: @act_deleted)).to be_nil
+        deleted_v1 = PaperTrail::Version
+          .where(item_type: 'Authorship', event: 'create')
+          .where_object_changes(actor_id: @act_deleted.id)
+          .first
+        expect(deleted_v1.created_at.to_date).to eq Time.zone.local(2021, 1, 4).to_date
+        expect(deleted_v1.changeset[:display_name].last).to eq 'Original Alias for Actor Deleted'
+
+        deleted_v2 = deleted_v1.next
+        expect(deleted_v2.event).to eq 'destroy'
+      end
+
+      it 'is idempotent' do
+        perform_call
+        expect { perform_call }.not_to change(Authorship, :count)
+        expect { perform_call }.not_to change(PaperTrail::Version, :count)
+      end
+    end
+
+    context 'when an actor is missing' do
+      before { [@wvc1, @act1].each(&:destroy) }
+
+      it 'reports the error, continues to migrate the rest of the creators' do
+        authorship_count_before = Authorship.count
+        versions_count_before = PaperTrail::Version.count
+
+        errors = perform_call
+
+        expect(errors.length).to eq 1
+        expect(errors.first).to match(/WorkVersion##{work_version.id}/i)
+          .and match(/could not find Actor##{@act1.id}/i)
+
+        # It skips the first creator because it errors out, but continues to
+        # migrate the other two (one of which is deleted)
+        expect(Authorship.count - authorship_count_before).to eq 1
+        expect(PaperTrail::Version.count - versions_count_before).to eq 3
+      end
+    end
+
+    context 'when the paper trail version describing the _create_ is missing' do
+      before do
+        @wvc1.versions.first.destroy!
+      end
+
+      it 'reports the error, continues to migrate the rest of the creators' do
+        authorship_count_before = Authorship.count
+        versions_count_before = PaperTrail::Version.count
+
+        errors = perform_call
+
+        expect(errors.length).to eq 1
+        expect(errors.first).to match(/WorkVersion##{work_version.id}/i)
+          .and match(/cannot find the papertrail::version/i)
+
+        # It skips the first creator because it errors out, but continues to
+        # migrate the other two (one of which is deleted)
+        expect(Authorship.count - authorship_count_before).to eq 1
+        expect(PaperTrail::Version.count - versions_count_before).to eq 3
+      end
+    end
+
+    context 'when there is an error saving the Authorship' do
+      before do
+        # Go in and insert invalid data (actor_id has a FK constraint) to
+        # force an ActiveRecord Error when trying to update the Authorship
+        @wvc1.versions[1].object_changes['actor_id'] = [123456, 123456]
+        @wvc1.versions[1].save!
+      end
+
+      it 'reports the error, continues to migrate the rest of the creators' do
+        authorship_count_before = Authorship.count
+        versions_count_before = PaperTrail::Version.count
+
+        errors = perform_call
+
+        expect(errors.length).to eq 1
+
+        expect(errors.first).to match(/WorkVersion##{work_version.id}/i)
+          .and match(/foreign key/i)
+
+        # It skips the first creator because it errors out, but continues to
+        # migrate the other two (one of which is deleted)
+        expect(Authorship.count - authorship_count_before).to eq 1
+        expect(PaperTrail::Version.count - versions_count_before).to eq 3
+      end
+    end
+  end
+end

--- a/spec/services/authorship_migration/work_version_creation_migration_spec.rb
+++ b/spec/services/authorship_migration/work_version_creation_migration_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 RSpec.describe AuthorshipMigration::WorkVersionCreationMigration, type: :model, versioning: true do
   let(:user) { create :user }
-  let(:work_version) { create :work_version }
+  let(:work) { create :work, has_draft: true, versions_count: 1 }
+  let(:work_version) { work.versions.first }
 
   before do
     # We will create three WorkVerisonCreations, one of which will be deleted.
@@ -67,6 +68,8 @@ RSpec.describe AuthorshipMigration::WorkVersionCreationMigration, type: :model, 
 
     # Sanity checks
     it 'sets up a sane test environment' do
+      expect(work_version.version_number).to eq 1
+
       expect(PaperTrail::Version.where(item_type: 'WorkVersionCreation').count)
         .to eq 6
 
@@ -78,135 +81,222 @@ RSpec.describe AuthorshipMigration::WorkVersionCreationMigration, type: :model, 
                         ])
     end
 
-    context 'when on the happy path' do
-      it 'creates a corresponding number of Authorship records' do
-        expect { perform_call }
-          .to change(Authorship, :count)
-          .by(2) # Note, TWO, because one of the WVC's above is deleted
+    context 'when migrating the first version of a work' do
+      context 'when on the happy path' do
+        it 'creates a corresponding number of Authorship records' do
+          expect { perform_call }
+            .to change(Authorship, :count)
+            .by(2) # Note, TWO, because one of the WVC's above is deleted
+        end
+
+        it 'recreates the editing history of the migrated WorkVersionCreations' do
+          perform_call
+          expect(PaperTrail::Version.where(item_type: 'WorkVersionCreation').count)
+            .to eq(PaperTrail::Version.where(item_type: 'Authorship').count)
+
+          authorship1 = Authorship.find_by(actor_id: @act1)
+          expect(authorship1.resource).to eq work_version
+          expect(authorship1.alias).to eq 'New Alias for Actor 1'
+          expect(authorship1.given_name).to eq @act1.given_name
+          expect(authorship1.surname).to eq @act1.surname
+          expect(authorship1.email).to eq @act1.email
+          expect(authorship1.position).to eq 20
+          expect(authorship1.actor_id).to eq @act1.id
+          expect(authorship1.instance_token).to be_present
+          expect(authorship1.created_at.to_date).to eq Time.zone.local(2021, 1, 1).to_date
+          expect(authorship1.updated_at.to_date).to eq Time.zone.local(2021, 1, 3).to_date
+
+          expect(authorship1.versions.length).to eq 3
+          v1, v2, v3 = authorship1.versions
+          expect(v1.whodunnit).to eq user.to_gid.to_s
+          expect(v1.event).to eq 'create'
+          expect(v1.changeset[:display_name]).to eq @wvc1.versions[0].changeset[:alias]
+          expect(v1.changeset[:actor_id]).to eq @wvc1.versions[0].changeset[:actor_id]
+          expect(v1.changeset[:position]).to eq @wvc1.versions[0].changeset[:position]
+          expect(v1.changeset[:created_at]).to eq @wvc1.versions[0].changeset[:created_at]
+          expect(v1.changeset[:updated_at]).to eq @wvc1.versions[0].changeset[:updated_at]
+          expect(v1.created_at.to_date).to eq Time.zone.local(2021, 1, 1).to_date
+
+          expect(v2.event).to eq 'update'
+          expect(v2.changeset[:display_name]).to eq(@wvc1.versions[1].changeset[:alias])
+          expect(v2.changeset[:created_at]).to eq(@wvc1.versions[1].changeset[:created_at])
+          expect(v2.changeset[:updated_at]).to eq(@wvc1.versions[1].changeset[:updated_at])
+          expect(v2.created_at.to_date).to eq Time.zone.local(2021, 1, 2).to_date
+
+          expect(v3.event).to eq 'update'
+          expect(v3.changeset).to eq(@wvc1.versions[2].changeset)
+          expect(v3.created_at.to_date).to eq Time.zone.local(2021, 1, 3).to_date
+
+          authorship2 = Authorship.find_by(actor_id: @act2)
+          expect(authorship2.versions.length).to eq 1
+
+          # Test deleted actor, have to extract from DB.
+          expect(Authorship.find_by(actor_id: @act_deleted)).to be_nil
+          deleted_v1 = PaperTrail::Version
+            .where(item_type: 'Authorship', event: 'create')
+            .where_object_changes(actor_id: @act_deleted.id)
+            .first
+          expect(deleted_v1.created_at.to_date).to eq Time.zone.local(2021, 1, 4).to_date
+          expect(deleted_v1.changeset[:display_name].last).to eq 'Original Alias for Actor Deleted'
+
+          deleted_v2 = deleted_v1.next
+          expect(deleted_v2.event).to eq 'destroy'
+        end
+
+        it 'is idempotent' do
+          perform_call
+          expect { perform_call }.not_to change(Authorship, :count)
+          expect { perform_call }.not_to change(PaperTrail::Version, :count)
+        end
       end
 
-      it 'recreates the editing history of the migrated WorkVersionCreations' do
-        perform_call
-        expect(PaperTrail::Version.where(item_type: 'WorkVersionCreation').count)
-          .to eq(PaperTrail::Version.where(item_type: 'Authorship').count)
+      context 'when an actor is missing' do
+        before { [@wvc1, @act1].each(&:destroy) }
 
-        authorship1 = Authorship.find_by(actor_id: @act1)
-        expect(authorship1.resource).to eq work_version
-        expect(authorship1.alias).to eq 'New Alias for Actor 1'
+        it 'reports the error, continues to migrate the rest of the creators' do
+          authorship_count_before = Authorship.count
+          versions_count_before = PaperTrail::Version.count
+
+          errors = perform_call
+
+          expect(errors.length).to eq 1
+          expect(errors.first).to match(/WorkVersion##{work_version.id}/i)
+            .and match(/could not find Actor##{@act1.id}/i)
+
+          # It skips the first creator because it errors out, but continues to
+          # migrate the other two (one of which is deleted)
+          expect(Authorship.count - authorship_count_before).to eq 1
+          expect(PaperTrail::Version.count - versions_count_before).to eq 3
+        end
+      end
+
+      context 'when the paper trail version describing the _create_ is missing' do
+        before do
+          @wvc1.versions.first.destroy!
+        end
+
+        it 'reports the error, continues to migrate the rest of the creators' do
+          authorship_count_before = Authorship.count
+          versions_count_before = PaperTrail::Version.count
+
+          errors = perform_call
+
+          expect(errors.length).to eq 1
+          expect(errors.first).to match(/WorkVersion##{work_version.id}/i)
+            .and match(/cannot find the papertrail::version/i)
+
+          # It skips the first creator because it errors out, but continues to
+          # migrate the other two (one of which is deleted)
+          expect(Authorship.count - authorship_count_before).to eq 1
+          expect(PaperTrail::Version.count - versions_count_before).to eq 3
+        end
+      end
+
+      context 'when there is an error saving the Authorship' do
+        before do
+          # Go in and insert invalid data (actor_id has a FK constraint) to
+          # force an ActiveRecord Error when trying to update the Authorship
+          @wvc1.versions[1].object_changes['actor_id'] = [123456, 123456]
+          @wvc1.versions[1].save!
+        end
+
+        it 'reports the error, continues to migrate the rest of the creators' do
+          authorship_count_before = Authorship.count
+          versions_count_before = PaperTrail::Version.count
+
+          errors = perform_call
+
+          expect(errors.length).to eq 1
+
+          expect(errors.first).to match(/WorkVersion##{work_version.id}/i)
+            .and match(/foreign key/i)
+
+          # It skips the first creator because it errors out, but continues to
+          # migrate the other two (one of which is deleted)
+          expect(Authorship.count - authorship_count_before).to eq 1
+          expect(PaperTrail::Version.count - versions_count_before).to eq 3
+        end
+      end
+    end
+
+    context 'when migrating a second version' do
+      def perform_call
+        described_class.call(work_version: @work_version_v2)
+      end
+
+      before do
+        @work_version_v2 = nil
+        @wvc1_v2 = nil
+        @wvc2_v2 = nil
+
+        PaperTrail.request(whodunnit: user.to_gid) do
+          # Create a new version of the work
+          Timecop.freeze(Time.zone.local(2021, 1, 8)) do
+            @work_version_v2 = AuthorshipMigration::YeOldeBuildNewWorkVersion.call(work_version)
+            @work_version_v2.save!
+            @work_version_v2.reload
+          end
+
+          # Update one author record from that work, but not the other one
+          Timecop.freeze(Time.zone.local(2021, 1, 9)) do
+            @wvc1_v2 = @work_version_v2
+              .creator_aliases
+              .find { |wvc| wvc.actor_id == @act1.id }
+
+            @wvc1_v2.update!(alias: 'Updated Alias for Actor 1, Version 2')
+          end
+
+          @wvc2_v2 = @work_version_v2
+            .creator_aliases
+            .find { |wvc| wvc.actor_id == @act2.id }
+        end
+      end
+
+      it 'properly handles Authorships on a second version of a work' do
+        expect {
+          perform_call
+        }.to change(Authorship, :count).by(2)
+          .and change(PaperTrail::Version, :count).by(1)
+
+        authorship1 = Authorship.find_by(resource: @work_version_v2, actor_id: @act1)
+        expect(authorship1).to be_present
+        expect(authorship1.resource).to eq @work_version_v2
+        expect(authorship1.alias).to eq 'Updated Alias for Actor 1, Version 2'
         expect(authorship1.given_name).to eq @act1.given_name
         expect(authorship1.surname).to eq @act1.surname
         expect(authorship1.email).to eq @act1.email
         expect(authorship1.position).to eq 20
         expect(authorship1.actor_id).to eq @act1.id
         expect(authorship1.instance_token).to be_present
-        expect(authorship1.created_at.to_date).to eq Time.zone.local(2021, 1, 1).to_date
-        expect(authorship1.updated_at.to_date).to eq Time.zone.local(2021, 1, 3).to_date
+        expect(authorship1.created_at.to_date).to eq Time.zone.local(2021, 1, 8).to_date
+        expect(authorship1.updated_at.to_date).to eq Time.zone.local(2021, 1, 9).to_date
 
-        expect(authorship1.versions.length).to eq 3
-        v1, v2, v3 = authorship1.versions
-        expect(v1.whodunnit).to eq user.to_gid.to_s
-        expect(v1.event).to eq 'create'
-        expect(v1.changeset[:display_name]).to eq @wvc1.versions[0].changeset[:alias]
-        expect(v1.changeset[:actor_id]).to eq @wvc1.versions[0].changeset[:actor_id]
-        expect(v1.changeset[:position]).to eq @wvc1.versions[0].changeset[:position]
-        expect(v1.changeset[:created_at]).to eq @wvc1.versions[0].changeset[:created_at]
-        expect(v1.changeset[:updated_at]).to eq @wvc1.versions[0].changeset[:updated_at]
-        expect(v1.created_at.to_date).to eq Time.zone.local(2021, 1, 1).to_date
+        expect(authorship1.versions.length).to eq 1
+        v1 = authorship1.versions.first
+        expect(v1.event).to eq 'update'
+        expect(v1.changeset.keys.map(&:to_s)).to match_array %w[display_name updated_at]
+        expect(v1.changeset[:display_name]).to eq(@wvc1_v2.versions[0].changeset[:alias])
+        expect(v1.changeset[:updated_at]).to eq(@wvc1_v2.versions[0].changeset[:updated_at])
+        expect(v1.created_at.to_date).to eq Time.zone.local(2021, 1, 9).to_date
 
-        expect(v2.event).to eq 'update'
-        expect(v2.changeset[:display_name]).to eq(@wvc1.versions[1].changeset[:alias])
-        expect(v2.changeset[:created_at]).to eq(@wvc1.versions[1].changeset[:created_at])
-        expect(v2.changeset[:updated_at]).to eq(@wvc1.versions[1].changeset[:updated_at])
-        expect(v2.created_at.to_date).to eq Time.zone.local(2021, 1, 2).to_date
-
-        expect(v3.event).to eq 'update'
-        expect(v3.changeset).to eq(@wvc1.versions[2].changeset)
-        expect(v3.created_at.to_date).to eq Time.zone.local(2021, 1, 3).to_date
-
-        authorship2 = Authorship.find_by(actor_id: @act2)
-        expect(authorship2.versions.length).to eq 1
-
-        # Test deleted actor, have to extract from DB.
-        expect(Authorship.find_by(actor_id: @act_deleted)).to be_nil
-        deleted_v1 = PaperTrail::Version
-          .where(item_type: 'Authorship', event: 'create')
-          .where_object_changes(actor_id: @act_deleted.id)
-          .first
-        expect(deleted_v1.created_at.to_date).to eq Time.zone.local(2021, 1, 4).to_date
-        expect(deleted_v1.changeset[:display_name].last).to eq 'Original Alias for Actor Deleted'
-
-        deleted_v2 = deleted_v1.next
-        expect(deleted_v2.event).to eq 'destroy'
+        authorship2 = Authorship.find_by(resource: @work_version_v2, actor_id: @act2)
+        expect(authorship2).to be_present
+        expect(authorship2.resource).to eq @work_version_v2
+        expect(authorship2.alias).to eq 'Original Alias for Actor 2'
+        expect(authorship2.given_name).to eq @act2.given_name
+        expect(authorship2.surname).to eq @act2.surname
+        expect(authorship2.email).to eq @act2.email
+        expect(authorship2.position).to eq 10
+        expect(authorship2.actor_id).to eq @act2.id
+        expect(authorship2.instance_token).to be_present
+        expect(authorship2.created_at.to_date).to eq Time.zone.local(2021, 1, 8).to_date
+        expect(authorship2.updated_at.to_date).to eq Time.zone.local(2021, 1, 8).to_date
       end
 
       it 'is idempotent' do
         perform_call
         expect { perform_call }.not_to change(Authorship, :count)
         expect { perform_call }.not_to change(PaperTrail::Version, :count)
-      end
-    end
-
-    context 'when an actor is missing' do
-      before { [@wvc1, @act1].each(&:destroy) }
-
-      it 'reports the error, continues to migrate the rest of the creators' do
-        authorship_count_before = Authorship.count
-        versions_count_before = PaperTrail::Version.count
-
-        errors = perform_call
-
-        expect(errors.length).to eq 1
-        expect(errors.first).to match(/WorkVersion##{work_version.id}/i)
-          .and match(/could not find Actor##{@act1.id}/i)
-
-        # It skips the first creator because it errors out, but continues to
-        # migrate the other two (one of which is deleted)
-        expect(Authorship.count - authorship_count_before).to eq 1
-        expect(PaperTrail::Version.count - versions_count_before).to eq 3
-      end
-    end
-
-    context 'when the paper trail version describing the _create_ is missing' do
-      before do
-        @wvc1.versions.first.destroy!
-      end
-
-      it 'still works' do
-        authorship_count_before = Authorship.count
-        versions_count_before = PaperTrail::Version.count
-
-        errors = perform_call
-
-        expect(errors).to be_empty
-
-        expect(Authorship.count - authorship_count_before).to eq 2
-        expect(PaperTrail::Version.count - versions_count_before).to eq 5
-      end
-    end
-
-    context 'when there is an error saving the Authorship' do
-      before do
-        # Go in and insert invalid data (actor_id has a FK constraint) to
-        # force an ActiveRecord Error when trying to update the Authorship
-        @wvc1.versions[1].object_changes['actor_id'] = [123456, 123456]
-        @wvc1.versions[1].save!
-      end
-
-      it 'reports the error, continues to migrate the rest of the creators' do
-        authorship_count_before = Authorship.count
-        versions_count_before = PaperTrail::Version.count
-
-        errors = perform_call
-
-        expect(errors.length).to eq 1
-
-        expect(errors.first).to match(/WorkVersion##{work_version.id}/i)
-          .and match(/foreign key/i)
-
-        # It skips the first creator because it errors out, but continues to
-        # migrate the other two (one of which is deleted)
-        expect(Authorship.count - authorship_count_before).to eq 1
-        expect(PaperTrail::Version.count - versions_count_before).to eq 3
       end
     end
   end


### PR DESCRIPTION
For WorkVersions:
* Loads out all the PaperTrail::Versions corresponding to any WorkVersionCreation (creator) records that have ever been associated with it
* Groups them by their WorkVersionCreation id
* Finds and loads out the associated Actor
* Builds a base set of attributes for the new Authorship object based on that Actor
*Iterates through all the changes in the paper trail version history, and applies the same changes to the Authorship, so that it is built, edited, and destroyed in the same order as the WVC
* Maintains all the original timestamps
* Works even on creators that were deleted, and therefore have no record in the work_version_creations table anymore

For Collections:
* There is no PaperTrail version history for Collections creators
* Load out the associated Actor
* Builds a base set of attributes for the new Authorship object based on that Actor
* Merges in the other attributes that are in the CollectionCreation

Fixes #819
