### PR TITLE
Disable saved searches

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -220,4 +220,13 @@ class CatalogController < ApplicationController
     # default 'mySuggester', uncomment and provide it below
     # config.autocomplete_suggester = 'mySuggester'
   end
+
+  private
+
+    # @note Overrides Blacklight::SearchContext to NOT save searches into the current session. This prevents searches
+    # from being written to the Search table, and also disables the feature to allow users to save their searches for
+    # future use.
+    def current_search_session
+      session
+    end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CatalogController, type: :controller do
+  describe 'GET #search' do
+    it 'does NOT save search history' do
+      expect {
+        get :index, params: { q: 'foo' }
+      }.not_to change(Search, :count)
+    end
+  end
+end


### PR DESCRIPTION
A feature of Blacklight allows users to save searches for future reference; however, we don't use this and a side-effect is that the searches table can grow excessively large. This disables any searches from being saved into the table.

Fixes #857 