### PR TITLE
Update UI with new Authorship workflow

### DIFF
--- a/app/controllers/dashboard/form/authorships_controller.rb
+++ b/app/controllers/dashboard/form/authorships_controller.rb
@@ -33,6 +33,8 @@ module Dashboard
         end
 
         def actor
+          return unless params[:psu_id].present? || params[:orcid].present?
+
           Actor.find(authorship_params[:actor_id])
         rescue ActiveRecord::RecordNotFound
           Actor.new(authorship_params.slice(:given_name, :email, :surname, :psu_id, :default_alias, :orcid))

--- a/app/controllers/dashboard/form/contributors_controller.rb
+++ b/app/controllers/dashboard/form/contributors_controller.rb
@@ -29,12 +29,16 @@ module Dashboard
                 :_destroy,
                 :display_name,
                 :position,
+                :given_name,
+                :surname,
+                :email,
                 actor_attributes: [
                   :id,
                   :email,
                   :given_name,
                   :surname,
-                  :psu_id
+                  :psu_id,
+                  :orcid
                 ]
               ]
             )

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -34,11 +34,7 @@ export default class extends Controller {
       ]
     ).on('autocomplete:selected', (event, suggestion, dataset, context) => {
       event.preventDefault()
-      if (suggestion.last_option) {
-        this.element.dispatchEvent(new CustomEvent('autocomplete:alternative', { bubbles: true }))
-      } else {
-        this.element.dispatchEvent(this.afterSelectedEvent(suggestion))
-      }
+      this.element.dispatchEvent(this.afterSelectedEvent(suggestion))
     })
   }
 

--- a/app/models/orcid_id.rb
+++ b/app/models/orcid_id.rb
@@ -13,7 +13,7 @@ class OrcidId
 
   # @param [String, URI] id
   def initialize(id)
-    @id = URI(id.to_s).path.gsub(/^\//, '').delete('-')
+    @id = URI(id.to_s.gsub(/ /, '')).path.gsub(/^\//, '').delete('-')
   end
 
   def valid?

--- a/app/views/dashboard/form/contributors/_authorship_fields.html.erb
+++ b/app/views/dashboard/form/contributors/_authorship_fields.html.erb
@@ -5,18 +5,26 @@
 <div class="nested-fields contributor-wrapper js-contributor-wrapper">
   <div class="row">
     <div class="col-2">
+      <%= form.hidden_field :position, class: 'js-position-index' %>
       <span class="badge badge-dark badge--outline">
         <%= t('dashboard.form.contributors.edit.badge') %>
         <span class="badge--index"><%= index + 1 %></span>
       </span>
     </div>
 
+    <%= form.hidden_field :actor_id %>
+    <%= form.fields_for :actor do |actor_fields| %>
+      <%= actor_fields.hidden_field :email %>
+      <%= actor_fields.hidden_field :given_name %>
+      <%= actor_fields.hidden_field :surname %>
+      <%= actor_fields.hidden_field :psu_id %>
+      <%= actor_fields.hidden_field :orcid %>
+    <% end %>
+
     <div class="col-8 pr-2">
-      <%= form.hidden_field :actor_id %>
-      <%= form.hidden_field :position, class: 'js-position-index' %>
       <div class="form-group has-float-label">
-        <%= form.text_field :alias, class: 'form-control', placeholder: true, required: true %>
-        <%= form.label :alias %>
+        <%= form.text_field :display_name, class: 'form-control', placeholder: true, required: true %>
+        <%= form.label :display_name %>
       </div>
     </div>
 
@@ -55,31 +63,43 @@
 
   <div class="row">
     <div class="col-10 offset-2">
-      <table class="table table-sm">
-        <thead>
-          <tr>
-            <th><%= Actor.human_attribute_name(:given_name) %></th>
-            <th><%= Actor.human_attribute_name(:surname) %></th>
-            <th><%= Actor.human_attribute_name(:email) %></th>
-            <th><%= Actor.human_attribute_name(:psu_id) %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><%= form.object.given_name %></td>
-            <td><%= form.object.surname %></td>
-            <td><%= form.object.email %></td>
-            <td><%= form.object.psu_id %></td>
-          </tr>
-        </tbody>
-      </table>
 
-      <%= form.fields_for :actor do |actor_fields| %>
-        <%= actor_fields.hidden_field :email %>
-        <%= actor_fields.hidden_field :given_name %>
-        <%= actor_fields.hidden_field :surname %>
-        <%= actor_fields.hidden_field :psu_id %>
-      <% end %>
+      <div class="row">
+        <div class="col-6">
+          <div class="form-group has-float-label">
+            <%= form.text_field :given_name, class: 'form-control', placeholder: true, required: false %>
+            <%= form.label :given_name %>
+          </div>
+        </div>
+
+        <div class="col-6">
+          <div class="form-group has-float-label">
+            <%= form.text_field :surname, class: 'form-control', placeholder: true, required: false %>
+            <%= form.label :surname %>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-6">
+          <div class="form-group has-float-label">
+            <%= form.text_field :email, class: 'form-control', placeholder: true, required: false %>
+            <%= form.label :email %>
+          </div>
+        </div>
+
+        <div class="col-6">
+          <span class="badge badge-dark badge--outline">
+            <% if form.object.psu_id.present? %>
+              <%= t('dashboard.form.contributors.edit.psu_identity', id: form.object.psu_id) %>
+            <% elsif form.object.orcid.present? %>
+              <%= t('dashboard.form.contributors.edit.orcid_identity', id: OrcidId.new(form.object.orcid).to_human) %>
+            <% else %>
+              <%= t('dashboard.form.contributors.edit.unknown_identity') %>
+            <% end %>
+          </span>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,12 @@ en:
           authenticated: Penn State Only
           restricted: Private
       authorship:
-        alias: Display Name
+        display_name: Display Name
+        given_name: Given Name
+        surname: Family Name
+        email: Email
+        psu_id: Access Account
+        orcid: ORCiD
       work_version:
         title: Work Title
         version_name: Semantic Version
@@ -301,6 +306,9 @@ en:
           search_heading: Add another creator
           search_label: Search creators
           search_results: Search Results
+          orcid_identity: "ORCiD: %{id}"
+          psu_identity: "Access Account: %{id}"
+          unknown_identity: "Unidentified"
         new:
           heading: New Creator
           cancel: Cancel

--- a/lib/qa/authorities/persons.rb
+++ b/lib/qa/authorities/persons.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
+# @abstract This is a single authority service that wraps three different types of sources: Scholarsphere Actor records,
+# Penn State identity service records, and Orcid ids. The results of all three are combined into a uniform json output
+# that can be used by the forms for adding creators to work versions and collections. This class can remove duplicate
+# results from the different sources ensuring that Actor records are preferred over the other two.
+
 require 'penn_state/search_service'
+require 'orcid'
 
 module Qa
   module Authorities
@@ -10,25 +16,31 @@ module Qa
       def search(term)
         @term = term
 
-        persons.map.with_index do |person, index|
-          formatted_response(person)
-            .merge(
-              result_number: index + 1,
-              total_results: persons.count
-            )
+        formatted_persons.map.with_index do |person, index|
+          person.merge(
+            result_number: index + 1,
+            total_results: persons.count,
+            additional_metadata: additional_metadata(person)
+          )
         end
       end
 
       private
 
-        # @return Array<Actor, PennState::SearchService::Person>
-        # @note if the same person is in both sources, prefer the Actor over the PennState::SearchService::Person
+        # @note if the same person exists as a PennState::SearchService::Person and an Actor, prefer the Actor
         def persons
-          (creators + identities).reject do |person|
+          (creators + identities + orcid).reject do |person|
             person.is_a?(PennState::SearchService::Person) && creator_ids.include?(person.user_id)
           end
         end
 
+        def formatted_persons
+          persons.map { |person| formatted_response(person) }
+        end
+
+        # @note Augments the fuzzy search with any additional results from the Penn State identity search. If the person
+        # exists as an Actor in Scholarsphere, but wasn't picked up by the fuzzy search, the identity search would
+        # return their record.
         def creators
           @creators ||= Actor
             .where('surname ILIKE :q OR given_name ILIKE :q OR psu_id ILIKE :q', q: "%#{term}%")
@@ -45,17 +57,31 @@ module Qa
           @identities ||= PennState::SearchService::Client.new.search(text: term)
         end
 
-        def formatted_response(result)
-          formatted = case result
-                      when Actor
-                        formatted_creator(result)
-                      when PennState::SearchService::Person
-                        formatted_person(result)
-                      else
-                        raise NotImplementedError, "#{result.class} is not a valid person"
-                      end
+        # @note If the person already exists in Scholarsphere with the given orcid, return the Actor record instead.
+        # Because none of the other searches rely on orcid id, there is no concern for duplicate results.
+        def orcid
+          @orcid ||= begin
+                       orcid = OrcidId.new(term)
 
-          add_additional_metadata(formatted)
+                       return [] unless orcid.valid?
+
+                       Array.wrap(Actor.find_by(orcid: orcid.to_s) || Orcid::Public::Person.new(orcid.to_human))
+                     rescue Orcid::NotFound
+                       []
+                     end
+        end
+
+        def formatted_response(result)
+          case result
+          when Actor
+            formatted_creator(result)
+          when PennState::SearchService::Person
+            formatted_person(result)
+          when Orcid::Public::Person
+            formatted_orcid(result)
+          else
+            raise NotImplementedError, "#{result.class} is not a valid person"
+          end
         end
 
         def formatted_creator(result)
@@ -83,20 +109,23 @@ module Qa
           }
         end
 
-        def add_additional_metadata(result)
-          additional_metadata = nil
+        def formatted_orcid(result)
+          {
+            given_name: result.given_names,
+            surname: result.family_name,
+            email: result.emails.default,
+            orcid: OrcidId.new(result.id).to_s,
+            default_alias: result.credit_name,
+            source: 'orcid'
+          }
+        end
 
-          if psu_id = result[:psu_id].presence
-            label = Actor.human_attribute_name(:psu_id)
-            value = psu_id
-            additional_metadata = "#{label}: #{value}"
-          elsif orcid = result[:orcid].presence
-            label = Actor.human_attribute_name(:orcid)
-            value = OrcidId.new(orcid).to_human
-            additional_metadata = "#{label}: #{value}"
+        def additional_metadata(result)
+          if result[:psu_id].presence
+            I18n.t('dashboard.form.contributors.edit.psu_identity', id: result[:psu_id])
+          elsif result[:orcid].presence
+            I18n.t('dashboard.form.contributors.edit.orcid_identity', id: OrcidId.new(result[:orcid]).to_human)
           end
-
-          result.merge(additional_metadata: additional_metadata)
         end
     end
   end

--- a/spec/features/dashboard/collection_form_spec.rb
+++ b/spec/features/dashboard/collection_form_spec.rb
@@ -85,14 +85,10 @@ RSpec.describe 'Creating and editing collections', :inline_jobs, with_user: :use
       within('#creators') do
         expect(page).to have_content('CREATOR 1')
         expect(find_field('Display Name').value).to eq("#{actor.given_name} #{actor.surname}")
-        expect(page).to have_content('Given Name')
-        expect(page).to have_content('Family Name')
-        expect(page).to have_content('Email')
-        expect(page).to have_content('Access Account')
-        expect(page).to have_content(actor.email)
-        expect(page).to have_content(actor.given_name)
-        expect(page).to have_content(actor.surname)
-        expect(page).to have_content(actor.psu_id)
+        expect(page).to have_field('Given Name')
+        expect(page).to have_field('Family Name')
+        expect(page).to have_field('Email')
+        expect(page).to have_content("Access Account: #{actor.psu_id}".upcase)
       end
 
       fill_in 'collection_contributor', with: metadata[:contributor]

--- a/spec/fixtures/vcr_cassettes/Publishing_a_work/The_Contributors_tab/when_adding_additional_users_with_an_orcid_id/inserts_the_Orcid_person_as_a_creator_into_the_form.yml
+++ b/spec/fixtures/vcr_cassettes/Publishing_a_work/The_Contributors_tab/when_adding_additional_users_with_an_orcid_id/inserts_the_Orcid_person_as_a_creator_into_the_form.yml
@@ -1,0 +1,112 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people?text=0000-0001-8485-6532
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 18 Feb 2021 16:39:40 GMT
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Content-Length:
+      - '2'
+      Connection:
+      - keep-alive
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      Set-Cookie:
+      - JSESSIONID=x2Buz_lbmf3h6Oaxh8MC8wrGER0uQYtHTLTrceLs.search-service-86858dc69c-krgn9;
+        path=/search-service
+      X-Request-Id:
+      - 58a4ca39ca53520b082025819e105efd
+      X-Frame-Options:
+      - DENY
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Uniqueid:
+      - c11065a0-61e2-4a36-8e4f-2c64624e6d04
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: "[]"
+  recorded_at: Thu, 18 Feb 2021 16:39:41 GMT
+- request:
+    method: get
+    uri: https://pub.orcid.org/v2.1/0000-0001-8485-6532/person
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 18 Feb 2021 16:39:41 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - X-Mapping-fjhppofk=4842165633BFDE68C17EFF06BB2B96E5; path=/
+      - __cfduid=d2e31f3c7ea03938558f865b4e972e8041613666381; expires=Sat, 20-Mar-21
+        16:39:41 GMT; path=/; domain=.orcid.org; HttpOnly; SameSite=Lax
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '08579c04d900003fcdaa16c000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 62392f815af23fcd-YYZ
+    body:
+      encoding: ASCII-8BIT
+      string: '{"last-modified-date":{"value":1612465770316},"name":{"created-date":{"value":1601473260303},"last-modified-date":{"value":1612452781871},"given-names":{"value":"Adam"},"family-name":{"value":"Wead"},"credit-name":{"value":"Dr.
+        Adam Wead"},"source":null,"visibility":"PUBLIC","path":"0000-0001-8485-6532"},"other-names":{"last-modified-date":null,"other-name":[],"path":"/0000-0001-8485-6532/other-names"},"biography":{"created-date":{"value":1612452696013},"last-modified-date":{"value":1612452696013},"content":"Developer
+        working for Penn State University Libraries.","visibility":"PUBLIC","path":"/0000-0001-8485-6532/biography"},"researcher-urls":{"last-modified-date":null,"researcher-url":[],"path":"/0000-0001-8485-6532/researcher-urls"},"emails":{"last-modified-date":{"value":1612465770316},"email":[{"created-date":{"value":1612465747618},"last-modified-date":{"value":1612465770316},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"agw13@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null},{"created-date":{"value":1601473260293},"last-modified-date":{"value":1612465218966},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"awead@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null}],"path":"/0000-0001-8485-6532/email"},"addresses":{"last-modified-date":null,"address":[],"path":"/0000-0001-8485-6532/address"},"keywords":{"last-modified-date":null,"keyword":[],"path":"/0000-0001-8485-6532/keywords"},"external-identifiers":{"last-modified-date":null,"external-identifier":[],"path":"/0000-0001-8485-6532/external-identifiers"},"path":"/0000-0001-8485-6532/person"}'
+  recorded_at: Thu, 18 Feb 2021 16:39:41 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Publishing_a_work/The_Contributors_tab/when_adding_existing_actors_from_Scholarsphere/inserts_the_local_Scholarsphere_actor_as_a_creator_into_the_form.yml
+++ b/spec/fixtures/vcr_cassettes/Publishing_a_work/The_Contributors_tab/when_adding_existing_actors_from_Scholarsphere/inserts_the_local_Scholarsphere_actor_as_a_creator_into_the_form.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 07 Jan 2021 18:39:25 GMT
+      - Tue, 16 Feb 2021 18:37:04 GMT
       Content-Type:
       - application/vnd-psu.edu-v1+json
       Content-Length:
@@ -29,20 +29,20 @@ http_interactions:
       X-Content-Security-Policy:
       - frame-ancestors 'none'
       Set-Cookie:
-      - JSESSIONID=EKThsDneHCM6O9HBvasmU5eiMpk37LZU6h2rZeZ_.search-service-767dd98f7f-8ldrm;
+      - JSESSIONID=snoXlic3bMGPFo1xIVGClQwXyOy-eweNIRh477id.search-service-86858dc69c-krgn9;
         path=/search-service
       X-Request-Id:
-      - af7a65b8feaf2fd78958bcf519239b9f
+      - e7127b029b9186b36da1829a6cf72ca6
       X-Frame-Options:
       - DENY
       Content-Security-Policy:
       - frame-ancestors 'none'
       Uniqueid:
-      - 5fdad7d9-fb68-4583-b9b4-060a13a2f1de
+      - 7d842740-7873-4ca4-bb9f-98d539371f76
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: "[]"
-  recorded_at: Thu, 07 Jan 2021 18:39:25 GMT
+  recorded_at: Tue, 16 Feb 2021 18:37:06 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Qa_Authorities_Persons/_search/when_an_actor_exists_with_the_same_Orcid/1_1_5_1.yml
+++ b/spec/fixtures/vcr_cassettes/Qa_Authorities_Persons/_search/when_an_actor_exists_with_the_same_Orcid/1_1_5_1.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pub.orcid.org/v2.1/0000-0001-8485-6532/person
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 18 Feb 2021 19:44:04 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - X-Mapping-fjhppofk=C9CF0771B896904864254CD659E1CE8B; path=/
+      - __cfduid=d6b58079cb7f490abc53de01f4cf731f61613677443; expires=Sat, 20-Mar-21
+        19:44:03 GMT; path=/; domain=.orcid.org; HttpOnly; SameSite=Lax
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '085844d337000071b384099000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 623a3d98597871b3-ORD
+    body:
+      encoding: ASCII-8BIT
+      string: '{"last-modified-date":{"value":1612465770316},"name":{"created-date":{"value":1601473260303},"last-modified-date":{"value":1612452781871},"given-names":{"value":"Adam"},"family-name":{"value":"Wead"},"credit-name":{"value":"Dr.
+        Adam Wead"},"source":null,"visibility":"PUBLIC","path":"0000-0001-8485-6532"},"other-names":{"last-modified-date":null,"other-name":[],"path":"/0000-0001-8485-6532/other-names"},"biography":{"created-date":{"value":1612452696013},"last-modified-date":{"value":1612452696013},"content":"Developer
+        working for Penn State University Libraries.","visibility":"PUBLIC","path":"/0000-0001-8485-6532/biography"},"researcher-urls":{"last-modified-date":null,"researcher-url":[],"path":"/0000-0001-8485-6532/researcher-urls"},"emails":{"last-modified-date":{"value":1612465770316},"email":[{"created-date":{"value":1612465747618},"last-modified-date":{"value":1612465770316},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"agw13@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null},{"created-date":{"value":1601473260293},"last-modified-date":{"value":1612465218966},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"awead@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null}],"path":"/0000-0001-8485-6532/email"},"addresses":{"last-modified-date":null,"address":[],"path":"/0000-0001-8485-6532/address"},"keywords":{"last-modified-date":null,"keyword":[],"path":"/0000-0001-8485-6532/keywords"},"external-identifiers":{"last-modified-date":null,"external-identifier":[],"path":"/0000-0001-8485-6532/external-identifiers"},"path":"/0000-0001-8485-6532/person"}'
+  recorded_at: Thu, 18 Feb 2021 19:44:04 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Qa_Authorities_Persons/_search/when_searching_with_an_Orcid/1_1_4_1.yml
+++ b/spec/fixtures/vcr_cassettes/Qa_Authorities_Persons/_search/when_searching_with_an_Orcid/1_1_4_1.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pub.orcid.org/v2.1/0000-0001-8485-6532/person
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 18 Feb 2021 19:44:03 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - X-Mapping-fjhppofk=C9CF0771B896904864254CD659E1CE8B; path=/
+      - __cfduid=d48c930c85e5814809b68b2022f14956a1613677443; expires=Sat, 20-Mar-21
+        19:44:03 GMT; path=/; domain=.orcid.org; HttpOnly; SameSite=Lax
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '085844d23400007fa021a5f000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 623a3d96b9b97fa0-ORD
+    body:
+      encoding: ASCII-8BIT
+      string: '{"last-modified-date":{"value":1612465770316},"name":{"created-date":{"value":1601473260303},"last-modified-date":{"value":1612452781871},"given-names":{"value":"Adam"},"family-name":{"value":"Wead"},"credit-name":{"value":"Dr.
+        Adam Wead"},"source":null,"visibility":"PUBLIC","path":"0000-0001-8485-6532"},"other-names":{"last-modified-date":null,"other-name":[],"path":"/0000-0001-8485-6532/other-names"},"biography":{"created-date":{"value":1612452696013},"last-modified-date":{"value":1612452696013},"content":"Developer
+        working for Penn State University Libraries.","visibility":"PUBLIC","path":"/0000-0001-8485-6532/biography"},"researcher-urls":{"last-modified-date":null,"researcher-url":[],"path":"/0000-0001-8485-6532/researcher-urls"},"emails":{"last-modified-date":{"value":1612465770316},"email":[{"created-date":{"value":1612465747618},"last-modified-date":{"value":1612465770316},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"agw13@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null},{"created-date":{"value":1601473260293},"last-modified-date":{"value":1612465218966},"source":{"source-orcid":{"uri":"https://orcid.org/0000-0001-8485-6532","path":"0000-0001-8485-6532","host":"orcid.org"},"source-client-id":null,"source-name":{"value":"Dr.
+        Adam Wead"}},"email":"awead@psu.edu","path":null,"visibility":"PUBLIC","verified":true,"primary":false,"put-code":null}],"path":"/0000-0001-8485-6532/email"},"addresses":{"last-modified-date":null,"address":[],"path":"/0000-0001-8485-6532/address"},"keywords":{"last-modified-date":null,"keyword":[],"path":"/0000-0001-8485-6532/keywords"},"external-identifiers":{"last-modified-date":null,"external-identifier":[],"path":"/0000-0001-8485-6532/external-identifiers"},"path":"/0000-0001-8485-6532/person"}'
+  recorded_at: Thu, 18 Feb 2021 19:44:04 GMT
+recorded_with: VCR 6.0.0

--- a/spec/lib/qa/authorities/persons_spec.rb
+++ b/spec/lib/qa/authorities/persons_spec.rb
@@ -128,6 +128,52 @@ RSpec.describe Qa::Authorities::Persons, type: :authority do
       it { is_expected.to include(formatted_result) }
     end
 
+    context 'when searching with an Orcid', :vcr do
+      let(:formatted_result) do
+        {
+          given_name: 'Adam',
+          surname: 'Wead',
+          default_alias: 'Dr. Adam Wead',
+          email: 'agw13@psu.edu',
+          orcid: '0000000184856532',
+          source: 'orcid',
+          result_number: 1,
+          total_results: 1,
+          additional_metadata: "#{Actor.human_attribute_name(:orcid)}: #{search_term}"
+        }
+      end
+
+      let(:mock_identity_response) { [] }
+      let(:search_term) { '0000-0001-8485-6532' }
+
+      it { is_expected.to include(formatted_result) }
+    end
+
+    context 'when an actor exists with the same Orcid', :vcr do
+      let!(:creator) { create(:actor, orcid: search_term) }
+
+      let(:formatted_result) do
+        {
+          given_name: creator.given_name,
+          surname: creator.surname,
+          psu_id: creator.psu_id,
+          default_alias: creator.default_alias,
+          email: creator.email,
+          orcid: creator.orcid,
+          source: 'scholarsphere',
+          actor_id: creator.id,
+          result_number: 1,
+          total_results: 1,
+          additional_metadata: "#{Actor.human_attribute_name(:psu_id)}: #{creator.psu_id}"
+        }
+      end
+
+      let(:mock_identity_response) { [] }
+      let(:search_term) { '0000000184856532' }
+
+      it { is_expected.to include(formatted_result) }
+    end
+
     context 'with an unsupported person type' do
       let(:bad_actor) { Struct.new('BadActor', :given_name, :user_id).new('bad actor', 'bad123') }
       let(:mock_identity_response) { [bad_actor] }

--- a/spec/models/orcid_id_spec.rb
+++ b/spec/models/orcid_id_spec.rb
@@ -50,4 +50,10 @@ RSpec.describe OrcidId, type: :model do
 
     it { is_expected.not_to be_valid }
   end
+
+  context 'with string content' do
+    subject { described_class.new(Faker::Lorem.sentence) }
+
+    it { is_expected.not_to be_valid }
+  end
 end


### PR DESCRIPTION
Changes the UI workflow to remove the modal and integrate searching for creators using an Orcid id. Users may search via a name, email, or access id, as well as an orcid id, and the appropriate record is returned via the Persons authority endpoint.

![Screen Shot 2021-02-18 at 3 50 53 PM](https://user-images.githubusercontent.com/312085/108419913-1eab2b00-7201-11eb-8219-d6c242823158.png)


Fixes #821 