### PR TITLE
Adds the _dtrsim field back into the Solr schema

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -107,7 +107,7 @@
 
     <dynamicField name="*_dtri" type="rdate" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_dtrim" type="rdate" stored="false" indexed="true" multiValued="true"/>
-    <dynamicField name="*_dtrsm" type="rdate" stored="true" indexed="true" multiValued="true"/>
+    <dynamicField name="*_dtrsim" type="rdate" stored="true" indexed="true" multiValued="true"/>
     <dynamicField name="*_dtrsi" type="rdate" stored="true" indexed="true" multiValued="false"/>
 
     <!-- long (_l...) -->


### PR DESCRIPTION
This was inadvertently removed in a prior commit, and preserves the naming pattern in other dynamic fields.