### PR TITLE
Migrate FileVersionMembership's papertrail versions to the new approach

### DIFF
--- a/app/components/work_histories/work_history_component.rb
+++ b/app/components/work_histories/work_history_component.rb
@@ -75,7 +75,11 @@ module WorkHistories
       # @return [Hash<FileMembershipChangePresenter, PaperTrail::Version, User>]
       def changes_to_work_versions_files(work_version)
         PaperTrail::Version
-          .where(item_type: 'FileVersionMembership', work_version_id: work_version.id)
+          .where(
+            item_type: 'FileVersionMembership',
+            resource_id: work_version.id,
+            resource_type: 'WorkVersion'
+          )
           .map do |paper_trail_version|
             {
               component: FileMembershipChangeComponent,

--- a/app/models/file_version_membership.rb
+++ b/app/models/file_version_membership.rb
@@ -16,16 +16,23 @@ class FileVersionMembership < ApplicationRecord
 
   delegate :size, :mime_type, :original_filename, :virus, to: :uploader
 
-  attr_accessor :changed_by_system
+  attr_writer :changed_by_system
 
   has_paper_trail(
-    unless: ->(record) { record.changed_by_system },
     meta: {
       # Explicitly store the work_version_id to the PaperTrail::Version to allow
       # easy access in the work history
-      work_version_id: :work_version_id
-    }
+      resource_id: :work_version_id,
+      resource_type: WorkVersion.name,
+      changed_by_system: :changed_by_system
+    },
+    skip: [:instance_token]
   )
+
+  # Force changed_by_system to a boolean
+  def changed_by_system
+    !!@changed_by_system
+  end
 
   private
 

--- a/spec/models/file_version_membership_spec.rb
+++ b/spec/models/file_version_membership_spec.rb
@@ -69,20 +69,24 @@ RSpec.describe FileVersionMembership, type: :model do
     context 'when the record is marked as changed by the system' do
       let(:file_version_membership) { create(:file_version_membership, changed_by_system: true) }
 
-      it 'does not write a papertrail version' do
-        expect(file_version_membership.reload.versions).to be_empty
+      it "writes a version with the flag saved in PaperTrail's metadata" do
+        expect(file_version_membership.reload.versions.length).to eq 1
+
+        paper_trail_version = file_version_membership.versions.first
+
+        expect(paper_trail_version.changed_by_system).to eq(true)
       end
     end
 
     context 'when the record is NOT marked as changed by the system' do
       let(:file_version_membership) { create(:file_version_membership, changed_by_system: false) }
 
-      it "writes a version and stores the WorkVersion's FK into the version metadata" do
+      it "writes a version and stores the record's type and id into the version metadata" do
         paper_trail_version = file_version_membership.versions.first
 
-        expect(paper_trail_version.work_version_id).to eq(
-          file_version_membership.work_version_id
-        )
+        expect(paper_trail_version.resource_id).to eq(file_version_membership.work_version_id)
+        expect(paper_trail_version.resource_type).to eq('WorkVersion')
+        expect(paper_trail_version.changed_by_system).to eq(false)
       end
     end
   end

--- a/spec/services/authorship_migration/file_version_membership_backfill_spec.rb
+++ b/spec/services/authorship_migration/file_version_membership_backfill_spec.rb
@@ -2,7 +2,9 @@
 
 require 'rails_helper'
 
-RSpec.describe AuthorshipMigration::FileVersionMembershipBackfill, type: :model, versioning: true do
+# This spec no longer works, because the incorrect setup has been fixed by this
+# commit. If you want to run the spec, check out the previous commit
+RSpec.xdescribe AuthorshipMigration::FileVersionMembershipBackfill, type: :model, versioning: true do
   let(:user) { create :user }
 
   before do


### PR DESCRIPTION
Updates FileVersionMembership to the new papertrail approach taken by Authorships—where records are written to the db but flagged as `changed_by_system`.

To run the migration, you should use

```ruby
AuthorshipMigration::FileVersionMembershipMigration.migrate_all_file_version_memberships
```

This method does two things:
- Backfills missing "creation" events in papertrail, caused by the old way that `BuildNewWorkVersion` worked
- Updates all FileVersionMembership papertrail events to use the new polymorphic `resource_type` and `resource_id` metadata columns, instead of the depricated `work_version_id` column

Note: This was originally a 2-commit PR, but 559477e7b01307bdcc7a654c0546d4f4bf2ad0c9 was cherry-picked into development directly. This was so we could test it quickly. The remaining commit is in this PR.

Fixes #872 