### PR TITLE
Add reload_on_index option to work versions

### DIFF
--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -11,7 +11,9 @@
 #
 
 class WorkIndexer
-  def self.call(work, commit: false)
+  def self.call(work, commit: false, reload: false)
+    work.reload if reload
+
     work.versions.map do |version|
       IndexingService.add_document(version.to_solr, commit: false)
     end

--- a/spec/support/feature_helpers/dashboard_form.rb
+++ b/spec/support/feature_helpers/dashboard_form.rb
@@ -77,8 +77,8 @@ module FeatureHelpers
       end
     end
 
-    def self.fill_in_publishing_details(metadata)
-      choose "work_version_work_attributes_visibility_#{Permissions::Visibility::OPEN}"
+    def self.fill_in_publishing_details(metadata, visibility: Permissions::Visibility::OPEN)
+      choose "work_version_work_attributes_visibility_#{visibility}"
       check 'work_version_depositor_agreement'
       select WorkVersion::Licenses.label(metadata[:rights]), from: 'work_version_rights'
     end


### PR DESCRIPTION
When indexing works and their versions, the versions can sometimes be out-of-sync with the database. Currently, this only happens during the publish phase if the visibility is set to Penn State. Just after the new version is published:

    @resource != @resource.work.versions[0]

Where @resource is the version to be published, and the work only has one version. Because the _work_ is submitted to the indexer, the out-of-date work version gets indexed instead of the current @resource work version.

We don't know why this happens, but the fix for now is to signal the WorkIndexer to reload the work if the version is being published.

Fixes #882