### PR TITLE
Orcid id is not present for unidentified creators

### DIFF
--- a/lib/data_cite/metadata/base.rb
+++ b/lib/data_cite/metadata/base.rb
@@ -57,7 +57,7 @@ module DataCite
         def creator_attributes(creator)
           attrs = { name: creator.alias }
 
-          if orcid = creator.actor.orcid.presence
+          if orcid = creator.orcid.presence
             attrs[:nameIdentifiers] = [
               {
                 nameIdentifier: orcid,

--- a/spec/lib/data_cite/metadata/work_version_spec.rb
+++ b/spec/lib/data_cite/metadata/work_version_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe DataCite::Metadata::WorkVersion do
       subject(:first_creator) { attributes[:creators].first }
 
       context 'when the creator has no orcid' do
-        before { creator.actor.orcid = nil }
+        before { creator.actor = nil }
 
         it "sets the creator's name" do
           expect(first_creator).to eq(


### PR DESCRIPTION
Since a creator (Authorship) may or may not have an associated actor, the Orcid will only be present if the actor is. For now, we can interrogate the authorship about the presence or absence of an Orcid.

In the future, however, we may want to adopt an null object pattern if we keep having to check for the presence of an actor or not.

Ref #887 