### PR TITLE
Prevent DOI minting for invalid resources

### DIFF
--- a/app/components/minting_status_doi_component.html.erb
+++ b/app/components/minting_status_doi_component.html.erb
@@ -1,4 +1,4 @@
-<% if resource_is_minting_doi? %>
+<% if resource_is_minting_doi? || invalid? %>
   <span class="<%= css_class %>"><%= display_content %></span>
 <% else %>
   <%= render display_doi_component %>

--- a/app/components/minting_status_doi_component.rb
+++ b/app/components/minting_status_doi_component.rb
@@ -14,14 +14,15 @@ class MintingStatusDoiComponent < ApplicationComponent
   end
 
   def render?
-    display_doi_component.render? || resource_is_minting_doi?
+    display_doi_component.render? || resource_is_minting_doi? || invalid?
   end
 
   def css_class
     {
       waiting: 'badge badge-light',
       minting: 'badge badge-light',
-      error: 'text-danger'
+      error: 'text-danger',
+      blocked: 'text-danger'
     }[status]
   end
 
@@ -38,6 +39,8 @@ class MintingStatusDoiComponent < ApplicationComponent
   end
 
   def status
+    return :blocked if invalid?
+
     if resource_is_minting_doi?
       return :waiting if minting_status.waiting?
       return :minting if minting_status.minting?
@@ -53,4 +56,18 @@ class MintingStatusDoiComponent < ApplicationComponent
   def minting_status_source
     @minting_status_source ||= DoiMintingStatus.public_method(:new)
   end
+
+  def invalid?
+    !validation
+  end
+
+  private
+
+    def validation
+      @validation ||= if resource.is_a?(Work)
+                        resource.latest_version.validate
+                      else
+                        resource.validate
+                      end
+    end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -495,6 +495,7 @@ en:
       create: 'Create a DOI for this work'
       confirm: 'Do you want to create a DOI? This DOI will always resolve to the most recently published version of this work.'
       disable_with: 'Creating...'
+      blocked: 'The resource must be updated before a DOI can be minted'
     work_version:
       edit_button:
         text: 'Edit %{version}'

--- a/spec/components/mintable_doi_component_spec.rb
+++ b/spec/components/mintable_doi_component_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe MintableDoiComponent, type: :component do
 
   before do
     allow(component).to receive(:helpers).and_return(mock_helpers)
+    allow(resource).to receive(:validate).and_return(true)
   end
 
   context 'when the resource already has a doi' do

--- a/spec/components/minting_status_doi_component_spec.rb
+++ b/spec/components/minting_status_doi_component_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe MintingStatusDoiComponent, type: :component do
 
   before do
     allow(DoiMintingStatus).to receive(:new).with(resource).and_return(mock_minting_status)
+    allow(resource).to receive(:validate).and_return(true)
   end
 
   context 'when the doi is nil' do
@@ -27,6 +28,14 @@ RSpec.describe MintingStatusDoiComponent, type: :component do
       before { allow(mock_minting_status).to receive(:present?).and_return(true) }
 
       it { is_expected.to be_render }
+    end
+
+    context 'when the resource is invalid' do
+      before { allow(resource).to receive(:validate).and_return(false) }
+
+      it { is_expected.to be_render }
+      its(:css_class) { is_expected.to eq('text-danger') }
+      specify { expect(html.text).to include(I18n.t('resources.doi.blocked')) }
     end
   end
 


### PR DESCRIPTION
If the collection or work has invalid metadata, we don't want the user to attempt to mint a DOI.

Fixes #911 