### PR TITLE
Allow admins to edit published works

### DIFF
--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -38,7 +38,7 @@ module Dashboard
         # actually attempt it. However, we want to be nice and not yell at them for something they _haven't_ seen yet
         # like rights.
         def prevalidate
-          @resource.publish
+          @resource.publish unless @resource.published?
           @resource.validate
           @resource.errors.delete(:rights)
         end

--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -38,9 +38,22 @@ module Dashboard
         # actually attempt it. However, we want to be nice and not yell at them for something they _haven't_ seen yet
         # like rights.
         def prevalidate
-          @resource.publish unless @resource.published?
-          @resource.validate
-          @resource.errors.delete(:rights)
+          temporarily_publish @resource do
+            @resource.validate
+            @resource.errors.delete(:rights)
+          end
+        end
+
+        # Temporarily mark a resource as published (do not save to the
+        # database), allow some actions to be performed in a block, then reset
+        # the aasm state back to whatever it was previously.
+        def temporarily_publish(resource)
+          initial_state = resource.aasm_state
+          resource.publish unless resource.published?
+
+          yield
+        ensure
+          resource.aasm_state = initial_state
         end
 
         def redirect_upon_success

--- a/app/policies/work_version_policy.rb
+++ b/app/policies/work_version_policy.rb
@@ -13,13 +13,18 @@ class WorkVersionPolicy < ApplicationPolicy
   alias_method :diff?, :show?
 
   def edit?
-    return false if record.published?
+    return false if record.published? && !user.admin?
 
     editable?
   end
   alias_method :update?, :edit?
-  alias_method :destroy?, :edit?
-  alias_method :publish?, :edit?
+
+  def destroy?
+    return false if record.published?
+
+    editable?
+  end
+  alias_method :publish?, :destroy?
 
   def download?
     return true if editable?

--- a/app/views/dashboard/form/publish/edit.html.erb
+++ b/app/views/dashboard/form/publish/edit.html.erb
@@ -44,7 +44,11 @@
             </div>
             <%= render 'fields', form: form %>
 
-            <%= render 'dashboard/form/shared/action_footer', form: form, primary_action: :publish %>
+            <% if form.object.aasm.from_state == WorkVersion::STATE_DRAFT %>
+              <%= render 'dashboard/form/shared/action_footer', form: form, primary_action: :publish %>
+            <% else %>
+              <%= render 'dashboard/form/shared/action_footer', form: form, primary_action: :finish %>
+            <% end %>
           <% end %>
 
         </div>

--- a/app/views/dashboard/form/publish/edit.html.erb
+++ b/app/views/dashboard/form/publish/edit.html.erb
@@ -44,11 +44,10 @@
             </div>
             <%= render 'fields', form: form %>
 
-            <% if form.object.aasm.from_state == WorkVersion::STATE_DRAFT %>
-              <%= render 'dashboard/form/shared/action_footer', form: form, primary_action: :publish %>
-            <% else %>
-              <%= render 'dashboard/form/shared/action_footer', form: form, primary_action: :finish %>
-            <% end %>
+            <%= render 'dashboard/form/shared/action_footer',
+                       form: form,
+                       primary_action: form.object.published? ? :finish : :publish %>
+
           <% end %>
 
         </div>

--- a/app/views/dashboard/form/shared/_action_footer.html.erb
+++ b/app/views/dashboard/form/shared/_action_footer.html.erb
@@ -1,7 +1,8 @@
 <% primary_action = local_assigns.fetch(:primary_action, :save_and_continue) %>
+<% button_key = current_user.admin? ? :admin_save : param_key %>
 
 <footer class="footer footer--actions footer--fixed d-flex justify-content-center">
-  <%= form.button t("dashboard.form.actions.save_and_exit.#{param_key}"), name: 'save_and_exit', class: 'btn btn-outline-primary btn--rounded' %>
+  <%= form.button t("dashboard.form.actions.save_and_exit.#{button_key}"), name: 'save_and_exit', class: 'btn btn-outline-primary btn--rounded' %>
   <div>
     <%= link_to t('dashboard.form.actions.cancel'), cancel_path, class: 'btn btn-outline-dark btn--rounded' %>
     <%= form.submit t("dashboard.form.actions.#{primary_action}"), name: primary_action, class: 'btn btn-primary btn--rounded ml-2' %>

--- a/app/views/dashboard/form/shared/_action_footer.html.erb
+++ b/app/views/dashboard/form/shared/_action_footer.html.erb
@@ -1,8 +1,8 @@
 <% primary_action = local_assigns.fetch(:primary_action, :save_and_continue) %>
-<% button_key = current_user.admin? ? :admin_save : param_key %>
+<% secondary_action = current_user.admin? ? :admin_save : param_key %>
 
 <footer class="footer footer--actions footer--fixed d-flex justify-content-center">
-  <%= form.button t("dashboard.form.actions.save_and_exit.#{button_key}"), name: 'save_and_exit', class: 'btn btn-outline-primary btn--rounded' %>
+  <%= form.button t("dashboard.form.actions.save_and_exit.#{secondary_action}"), name: 'save_and_exit', class: 'btn btn-outline-primary btn--rounded' %>
   <div>
     <%= link_to t('dashboard.form.actions.cancel'), cancel_path, class: 'btn btn-outline-dark btn--rounded' %>
     <%= form.submit t("dashboard.form.actions.#{primary_action}"), name: primary_action, class: 'btn btn-primary btn--rounded ml-2' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -311,6 +311,7 @@ en:
         save_and_exit:
           collection: Save and Exit
           work_version: Save as Draft & Exit
+          admin_save: Save and Exit
       details:
         about_collections: 
           label: About Collections

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -592,4 +592,21 @@ RSpec.describe 'Publishing a work', with_user: :user do
       expect(version.creators.first.display_name).to eq user.actor.display_name
     end
   end
+
+  describe 'Editing a published work' do
+    let(:work_version) { create :work_version, :published }
+    let(:different_metadata) { attributes_for(:work_version, :with_complete_metadata) }
+    let(:user) { create(:user, :admin) }
+
+    it 'allows an administrator to update the metadata' do
+      visit dashboard_form_publish_path(work_version)
+
+      FeatureHelpers::DashboardForm.fill_in_publishing_details(different_metadata)
+      FeatureHelpers::DashboardForm.finish
+      expect(SolrIndexingJob).to have_received(:perform_now)
+
+      work_version.reload
+      expect(work_version.rights).to eq(different_metadata[:rights])
+    end
+  end
 end


### PR DESCRIPTION
Administrators can edit published works. Changes will appear as they typically do, in chronological order, after publishing.

Fixes #895 