### PR TITLE
Drop support for migration features in the API

### DIFF
--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -2,8 +2,6 @@
 
 module Api::V1
   class CollectionsController < RestController
-    before_action :return_migrated_collection
-
     def create
       if collection.errors.any?
         render json: unprocessable_entity_response, status: :unprocessable_entity
@@ -13,14 +11,6 @@ module Api::V1
     end
 
     private
-
-      def return_migrated_collection
-        ids = LegacyIdentifier.where(old_id: metadata_params['noid'], version: 3, resource_type: 'Collection')
-        return if ids.empty?
-
-        collection = Collection.find(ids.first.resource_id)
-        render json: migrated_response(collection), status: 303
-      end
 
       def migrated_response(collection)
         {
@@ -47,8 +37,7 @@ module Api::V1
         @collection ||= CreateNewCollection.call(
           metadata: metadata_params,
           depositor: depositor_params,
-          permissions: permission_params,
-          work_noids: work_noid_params
+          permissions: permission_params
         )
       end
 
@@ -59,7 +48,6 @@ module Api::V1
             :title,
             :subtitle,
             :rights,
-            :noid,
             :published_date,
             :deposited_at,
             :description,
@@ -107,10 +95,6 @@ module Api::V1
             discover_users: [],
             discover_group: []
           )
-      end
-
-      def work_noid_params
-        params.fetch(:work_noids, [])
       end
   end
 end

--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -48,7 +48,7 @@ module Api::V1
       def publishing_errors
         work_version = work.latest_version
         work_version.publish
-        work_version.validate(:migration_api)
+        work_version.validate
         work_version.errors.full_messages
       end
 

--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -2,8 +2,6 @@
 
 module Api::V1
   class IngestController < RestController
-    before_action :return_migrated_work
-
     def create
       if work.errors.any?
         render json: unprocessable_entity_response, status: :unprocessable_entity
@@ -13,14 +11,6 @@ module Api::V1
     end
 
     private
-
-      def return_migrated_work
-        ids = LegacyIdentifier.where(old_id: metadata_params['noid'], version: 3, resource_type: 'Work')
-        return if ids.empty?
-
-        work = Work.find(ids.first.resource_id)
-        render json: { message: 'Work has already been migrated', url: resource_path(work.uuid) }, status: 303
-      end
 
       def success_response
         if work.latest_version.published?
@@ -88,7 +78,6 @@ module Api::V1
             :rights,
             :version_name,
             :published_date,
-            :noid,
             :deposited_at,
             :description,
             :doi,
@@ -130,8 +119,7 @@ module Api::V1
           content_parameter
             .permit(
               :file,
-              :deposited_at,
-              :noid
+              :deposited_at
             )
         end
       end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -49,13 +49,11 @@ class Collection < ApplicationRecord
             presence: true
 
   validates :description,
-            presence: true,
-            unless: -> { validation_context == :migration_api }
+            presence: true
 
   validates :published_date,
             edtf_date: true,
-            allow_blank: true,
-            unless: -> { validation_context == :migration_api }
+            allow_blank: true
 
   accepts_nested_attributes_for :creators,
                                 reject_if: :all_blank,

--- a/app/models/legacy_identifier.rb
+++ b/app/models/legacy_identifier.rb
@@ -9,13 +9,4 @@ class LegacyIdentifier < ApplicationRecord
     legacy_id&.resource&.uuid ||
       raise(ActiveRecord::RecordNotFound)
   end
-
-  # @param [Collection,Work,WorkVersion,FileResource] resource
-  # @param [String] noid
-  # @note Creates a legacy identifier for a Scholarsphere 3 noid
-  def self.create_noid(resource:, noid:)
-    return if noid.nil?
-
-    resource.legacy_identifiers.find_or_initialize_by(version: 3, old_id: noid)
-  end
 end

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -129,13 +129,11 @@ class WorkVersion < ApplicationRecord
   validates :published_date,
             presence: true,
             edtf_date: true,
-            if: :published?,
-            unless: -> { validation_context == :migration_api }
+            if: :published?
 
   validates :description,
             presence: true,
-            if: :published?,
-            unless: -> { validation_context == :migration_api }
+            if: :published?
 
   after_save :perform_update_index
 

--- a/app/schemas/work_version_schema.rb
+++ b/app/schemas/work_version_schema.rb
@@ -36,7 +36,7 @@ class WorkVersionSchema < BaseSchema
     def build_migration_errors
       current_state = resource.aasm_state
       resource.publish unless resource.published?
-      resource.validate(:migration_api)
+      resource.validate
       resource.aasm_state = current_state
       resource.errors
     end

--- a/app/services/create_new_collection.rb
+++ b/app/services/create_new_collection.rb
@@ -65,7 +65,7 @@ class CreateNewCollection
     LegacyIdentifier.create_noid(resource: collection, noid: noid)
     UpdatePermissionsService.call(resource: collection, permissions: permissions, create_agents: true)
 
-    if collection.save(context: :migration_api)
+    if collection.save
       collection.reload
     else
       collection

--- a/app/services/publish_new_work.rb
+++ b/app/services/publish_new_work.rb
@@ -17,7 +17,6 @@ class PublishNewWork
   # @param [ActionController::Parameters] permissions
   # @return [Work]
   def self.call(metadata:, depositor:, content:, permissions: {})
-    noid = metadata.delete(:noid)
     deposited_at = metadata.delete(:deposited_at)
     metadata[:rights] ||= WorkVersion::Licenses::DEFAULT
 
@@ -53,13 +52,11 @@ class PublishNewWork
     }
 
     work = Work.build_with_empty_version(params)
-    LegacyIdentifier.create_noid(resource: work, noid: noid)
     UpdatePermissionsService.call(resource: work, permissions: permissions, create_agents: true)
     work_version = work.versions.first
 
     content.map do |file|
-      file_resource = work_version.file_resources.build(file: file[:file], deposited_at: file[:deposited_at])
-      LegacyIdentifier.create_noid(resource: file_resource, noid: file[:noid])
+      work_version.file_resources.build(file: file[:file], deposited_at: file[:deposited_at])
     end
 
     return work unless work.valid?

--- a/app/services/publish_new_work.rb
+++ b/app/services/publish_new_work.rb
@@ -68,12 +68,12 @@ class PublishNewWork
     # not valid, roll back to previous state
     begin
       work_version.publish
-      work_version.validate!(:migration_api)
+      work_version.validate!
     rescue ActiveRecord::RecordInvalid
       work_version.aasm_state = work_version.aasm.from_state
     end
 
-    if work.save(context: :migration_api)
+    if work.save
       work.reload
     else
       work

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,10 +150,9 @@ Rails.application.routes.draw do
   get '/401', to: 'errors#not_found'
   get '/500', to: 'errors#server_error'
 
-  # Legacy URL support
-  # Note that collections and works go to the same place. This works because the
-  # legacy IDs are unique noids. It could lead to an extraordinarily unlikely
-  # false positive, but it would never lead to a false negative.
+  # Scholarsphere 3 Legacy URL support
+  # Note that collections and works go to the same place. This works because the legacy IDs are unique noids. It could
+  # lead to an extraordinarily unlikely false positive, but it would never lead to a false negative.
   get '/concern/generic_works/:id', to: 'legacy_urls#v3'
   get '/collections/:id', to: 'legacy_urls#v3'
 end

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -54,35 +54,6 @@ RSpec.describe Api::V1::CollectionsController, type: :controller do
       end
     end
 
-    context 'with a legacy identifiers' do
-      let(:legacy_identifiers) do
-        Array.new(3).map do
-          create(:legacy_identifier, :with_work, version: 3)
-        end
-      end
-
-      before do
-        post :create, params: {
-          metadata: {
-            title: FactoryBotHelpers.work_title,
-            description: Faker::Lorem.paragraph,
-            creators_attributes: [creator]
-          },
-          depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id },
-          work_noids: legacy_identifiers.map(&:old_id)
-        }
-      end
-
-      it 'creates a new collection with works using their legacy identifiers' do
-        expect(response).to be_ok
-        expect(json_response).to include(
-          'message' => 'Collection was successfully created',
-          'url' => "/resources/#{new_collection.uuid}"
-        )
-        expect(new_collection.work_ids).to contain_exactly(*legacy_identifiers.map(&:resource_id))
-      end
-    end
-
     context 'with missing parameters' do
       before do
         post :create, params: {
@@ -112,46 +83,6 @@ RSpec.describe Api::V1::CollectionsController, type: :controller do
         expect(json_response).to include(
           'message' => 'Unable to complete the request',
           'errors' => ["Title can't be blank", "Description can't be blank"]
-        )
-      end
-    end
-
-    context 'with missing legacy works' do
-      before do
-        post :create, params: {
-          metadata: {
-            title: FactoryBotHelpers.work_title,
-            creators_attributes: [creator]
-          },
-          depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id },
-          work_noids: ['idontexist']
-        }
-      end
-
-      it 'reports the error' do
-        expect(response.status).to eq(422)
-        expect(json_response).to include(
-          'message' => 'Unable to complete the request',
-          'errors' => ['Legacy identifiers idontexist were not found']
-        )
-      end
-    end
-
-    context 'when a collection with the same noid already exists' do
-      let(:legacy_identifier) { create(:legacy_identifier, :with_collection, version: 3) }
-
-      before do
-        post :create, params: {
-          metadata: { title: FactoryBotHelpers.work_title, noid: legacy_identifier.old_id },
-          depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id }
-        }
-      end
-
-      it 'returns the url of the previously migrated collection' do
-        expect(response.status).to eq(303)
-        expect(json_response).to include(
-          'message' => 'Collection has already been migrated',
-          'url' => "/resources/#{legacy_identifier.resource.uuid}"
         )
       end
     end

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Api::V1::CollectionsController, type: :controller do
         post :create, params: {
           metadata: {
             title: FactoryBotHelpers.work_title,
+            description: Faker::Lorem.paragraph,
             work_ids: works.map(&:id),
             creators_attributes: [creator]
           },
@@ -64,6 +65,7 @@ RSpec.describe Api::V1::CollectionsController, type: :controller do
         post :create, params: {
           metadata: {
             title: FactoryBotHelpers.work_title,
+            description: Faker::Lorem.paragraph,
             creators_attributes: [creator]
           },
           depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id },
@@ -109,7 +111,7 @@ RSpec.describe Api::V1::CollectionsController, type: :controller do
         expect(response.status).to eq(422)
         expect(json_response).to include(
           'message' => 'Unable to complete the request',
-          'errors' => ["Title can't be blank"]
+          'errors' => ["Title can't be blank", "Description can't be blank"]
         )
       end
     end

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -158,25 +158,6 @@ RSpec.describe Api::V1::IngestController, type: :controller do
         )
       end
     end
-
-    context 'when a work with the same noid already exists' do
-      let(:legacy_identifier) { create(:legacy_identifier, :with_work, version: 3) }
-
-      before do
-        post :create, params: {
-          metadata: { title: FactoryBotHelpers.work_title, noid: legacy_identifier.old_id },
-          depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id },
-          content: [{ file: fixture_file_upload(File.join(fixture_path, 'image.png')) }]
-        }
-      end
-
-      it 'returns the url of the previously migrated work' do
-        expect(response.status).to eq(303)
-        expect(response.body).to eq(
-          "{\"message\":\"Work has already been migrated\",\"url\":\"/resources/#{legacy_identifier.resource.uuid}\"}"
-        )
-      end
-    end
   end
 
   def i18n_error_message(attr, validation)

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -21,13 +21,20 @@ RSpec.describe Api::V1::IngestController, type: :controller do
     }
   end
 
+  let(:metadata) { attributes_for(:work_version, :able_to_be_published) }
+
   before { request.headers[:'X-API-Key'] = api_token }
 
   describe 'POST #create' do
     context 'with valid input' do
       before do
         post :create, params: {
-          metadata: { title: FactoryBotHelpers.work_title, creators_attributes: [creator] },
+          metadata: {
+            title: metadata[:title],
+            description: metadata[:description],
+            published_date: metadata[:published_date],
+            creators_attributes: [creator]
+          },
           depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id },
           content: [{ file: fixture_file_upload(File.join(fixture_path, 'image.png')) }]
         }
@@ -47,7 +54,12 @@ RSpec.describe Api::V1::IngestController, type: :controller do
         file = Scholarsphere::S3::UploadedFile.new(path)
         Scholarsphere::S3::Uploader.new.upload(file)
         post :create, params: {
-          metadata: { title: FactoryBotHelpers.work_title, creators_attributes: [creator] },
+          metadata: {
+            title: metadata[:title],
+            description: metadata[:description],
+            published_date: metadata[:published_date],
+            creators_attributes: [creator]
+          },
           content: [{ file: file.to_shrine.to_json }],
           depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id }
         }
@@ -102,7 +114,12 @@ RSpec.describe Api::V1::IngestController, type: :controller do
     context 'with missing files' do
       before do
         post :create, params: {
-          metadata: { title: FactoryBotHelpers.work_title, creators_attributes: [creator] },
+          metadata: {
+            title: metadata[:title],
+            description: metadata[:description],
+            published_date: metadata[:published_date],
+            creators_attributes: [creator]
+          },
           depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id }
         }
       end
@@ -118,10 +135,14 @@ RSpec.describe Api::V1::IngestController, type: :controller do
       end
     end
 
-    context 'when the work cannot be published' do
+    context 'with missing creators' do
       before do
         post :create, params: {
-          metadata: { title: FactoryBotHelpers.work_title },
+          metadata: {
+            title: metadata[:title],
+            description: metadata[:description],
+            published_date: metadata[:published_date]
+          },
           depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id },
           content: [{ file: fixture_file_upload(File.join(fixture_path, 'image.png')) }]
         }

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -79,23 +79,15 @@ RSpec.describe Collection, type: :model do
   end
 
   describe 'validations' do
+    let(:collection) { subject }
+
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:description) }
 
-    context 'with the :migration_api validation context' do
-      it { is_expected.not_to validate_presence_of(:description).on(:migration_api) }
-      it { is_expected.to allow_value('').for(:published_date).on(:migration_api) }
-      it { is_expected.to allow_value('not an EDTF formatted date').for(:published_date).on(:migration_api) }
-    end
-
-    context 'without the :migration_api validation context' do
-      let(:collection) { subject }
-
-      it 'validates published_date is in EDTF format' do
-        expect(collection).to allow_value('').for(:published_date)
-        expect(collection).to allow_value('1999-uu-uu').for(:published_date)
-        expect(collection).not_to allow_value('not an EDTF formatted date').for(:published_date)
-      end
+    it 'validates published_date is in EDTF format' do
+      expect(collection).to allow_value('').for(:published_date)
+      expect(collection).to allow_value('1999-uu-uu').for(:published_date)
+      expect(collection).not_to allow_value('not an EDTF formatted date').for(:published_date)
     end
   end
 

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -112,13 +112,6 @@ RSpec.describe WorkVersion, type: :model do
         expect(work_version).to allow_value('1999-uu-uu').for(:published_date)
         expect(work_version).not_to allow_value('not an EDTF formatted date').for(:published_date)
       end
-
-      context 'with the :migration_api validation context' do
-        it { is_expected.to allow_value(nil).for(:description).on(:migration_api) }
-        it { is_expected.to allow_value(nil).for(:published_date).on(:migration_api) }
-
-        it { is_expected.to allow_value('not an EDTF formatted date').for(:published_date).on(:migration_api) }
-      end
     end
 
     context 'with the version number' do

--- a/spec/services/create_new_collection_spec.rb
+++ b/spec/services/create_new_collection_spec.rb
@@ -181,36 +181,6 @@ RSpec.describe CreateNewCollection do
     end
   end
 
-  context 'when the collection has a NOID from Scholarpshere 3' do
-    let(:legacy_identifier) { build(:legacy_identifier) }
-
-    let(:new_collection) do
-      described_class.call(
-        metadata: HashWithIndifferentAccess.new(collection.metadata.merge(
-                                                  work_ids: [work.id],
-                                                  creators_attributes: [
-                                                    {
-                                                      display_name: user.name,
-                                                      actor_attributes: {
-                                                        email: user.email,
-                                                        given_name: user.actor.given_name,
-                                                        surname: user.actor.surname,
-                                                        psu_id: user.actor.psu_id
-                                                      }
-                                                    }
-                                                  ],
-                                                  noid: legacy_identifier.old_id
-                                                )),
-        depositor: depositor
-      )
-    end
-
-    it 'creates a new collection with a legacy identifier' do
-      expect(new_collection.legacy_identifiers.map(&:old_id)).to contain_exactly(legacy_identifier.old_id)
-      expect(new_collection.legacy_identifiers.map(&:version)).to contain_exactly(3)
-    end
-  end
-
   context 'with custom deposit dates' do
     let(:new_collection) do
       described_class.call(

--- a/spec/services/create_new_collection_spec.rb
+++ b/spec/services/create_new_collection_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe CreateNewCollection do
 
   context 'without a required title' do
     let(:new_collection) do
-      described_class.call(metadata: {}, depositor: depositor)
+      described_class.call(metadata: { description: Faker::Lorem.paragraph }, depositor: depositor)
     end
 
     it 'does NOT save the collection' do
@@ -208,33 +208,6 @@ RSpec.describe CreateNewCollection do
     it 'creates a new collection with a legacy identifier' do
       expect(new_collection.legacy_identifiers.map(&:old_id)).to contain_exactly(legacy_identifier.old_id)
       expect(new_collection.legacy_identifiers.map(&:version)).to contain_exactly(3)
-    end
-  end
-
-  context "when the collection has attributes that wouldn't pass validation outside of a migration" do
-    let(:new_collection) do
-      described_class.call(
-        metadata: HashWithIndifferentAccess.new(collection.metadata.merge(
-                                                  work_ids: [work.id],
-                                                  published_date: 'not a valid EDTF',
-                                                  creators_attributes: [
-                                                    {
-                                                      display_name: user.name,
-                                                      actor_attributes: {
-                                                        email: user.email,
-                                                        given_name: user.actor.given_name,
-                                                        surname: user.actor.surname,
-                                                        psu_id: user.actor.psu_id
-                                                      }
-                                                    }
-                                                  ]
-                                                )),
-        depositor: depositor
-      )
-    end
-
-    it 'creates a new collection' do
-      expect { new_collection }.to change(Collection, :count).by(1)
     end
   end
 

--- a/spec/services/publish_new_work_spec.rb
+++ b/spec/services/publish_new_work_spec.rb
@@ -235,42 +235,6 @@ RSpec.describe PublishNewWork do
     end
   end
 
-  context 'when the work has a NOID from Scholarpshere 3' do
-    let(:noid) { FactoryBotHelpers.noid }
-
-    let(:new_work) do
-      described_class.call(
-        metadata: HashWithIndifferentAccess.new(work.metadata.merge(
-                                                  work_type: 'dataset',
-                                                  creators_attributes: [
-                                                    {
-                                                      display_name: user.name,
-                                                      actor_attributes: {
-                                                        email: user.email,
-                                                        given_name: user.actor.given_name,
-                                                        surname: user.actor.surname,
-                                                        psu_id: user.actor.psu_id
-                                                      }
-                                                    }
-                                                  ],
-                                                  noid: noid
-                                                )),
-        depositor: depositor,
-        content: [
-          HashWithIndifferentAccess.new(file: fixture_file_upload(File.join(fixture_path, 'image.png')))
-        ]
-      )
-    end
-
-    it 'creates a new work with a legacy identifier' do
-      expect {
-        new_work
-      }.to change {
-        LegacyIdentifier.find_by(old_id: noid, resource_type: 'Work')
-      }.from(nil).to(a_kind_of(LegacyIdentifier))
-    end
-  end
-
   context 'when the work is embargoed' do
     let(:new_work) do
       described_class.call(
@@ -348,45 +312,6 @@ RSpec.describe PublishNewWork do
       expect(new_work.latest_published_version.file_resources.first.deposited_at.strftime('%Y-%m-%d')).to eq(
         '2018-03-01'
       )
-    end
-  end
-
-  context 'when the file has a NOID from Scholarsphere 3' do
-    let(:noid) { FactoryBotHelpers.noid }
-
-    let(:new_work) do
-      described_class.call(
-        metadata: HashWithIndifferentAccess.new(work.metadata.merge(
-                                                  work_type: 'dataset',
-                                                  creators_attributes: [
-                                                    {
-                                                      display_name: user.name,
-                                                      actor_attributes: {
-                                                        email: user.email,
-                                                        given_name: user.actor.given_name,
-                                                        surname: user.actor.surname,
-                                                        psu_id: user.actor.psu_id
-                                                      }
-                                                    }
-                                                  ],
-                                                  deposited_at: '2018-02-28T15:12:54Z'
-                                                )),
-        depositor: depositor,
-        content: [
-          HashWithIndifferentAccess.new(
-            file: fixture_file_upload(File.join(fixture_path, 'image.png')),
-            noid: noid
-          )
-        ]
-      )
-    end
-
-    it 'creates a file with the legacy identifier' do
-      expect {
-        new_work
-      }.to change {
-        LegacyIdentifier.find_by(old_id: noid, resource_type: 'FileResource')
-      }.from(nil).to(a_kind_of(LegacyIdentifier))
     end
   end
 

--- a/spec/services/publish_new_work_spec.rb
+++ b/spec/services/publish_new_work_spec.rb
@@ -188,39 +188,6 @@ RSpec.describe PublishNewWork do
     end
   end
 
-  context "when the collection has attributes that wouldn't pass validation outside of a migration" do
-    let(:new_work) do
-      described_class.call(
-        metadata: HashWithIndifferentAccess.new(work.metadata.merge(
-                                                  work_type: 'dataset',
-                                                  published_date: 'not a valid EDTF date',
-                                                  creators_attributes: [
-                                                    {
-                                                      display_name: user.name,
-                                                      actor_attributes: {
-                                                        email: user.email,
-                                                        given_name: user.actor.given_name,
-                                                        surname: user.actor.surname,
-                                                        psu_id: user.actor.psu_id
-                                                      }
-                                                    }
-                                                  ]
-                                                )),
-        depositor: depositor,
-        content: [
-          HashWithIndifferentAccess.new(file: fixture_file_upload(File.join(fixture_path, 'image.png'))),
-          HashWithIndifferentAccess.new(file: fixture_file_upload(File.join(fixture_path, 'ipsum.pdf')))
-        ]
-      )
-    end
-
-    it 'saves the work' do
-      expect(new_work).to be_persisted
-      expect(new_work.versions.count).to eq(1)
-      expect(new_work.latest_version).to be_persisted.and be_published
-    end
-  end
-
   context 'when the work has restricted visbility' do
     let(:new_work) do
       described_class.call(


### PR DESCRIPTION
Removes the API migration context, which we used to validate works that were being migrated from Scholarsphere 3. Also drops support for Noids, which were only a feature of migrated work as well.

Fixes #909 