### PR TITLE
Azure Domain Hint

### DIFF
--- a/config/samples/application.yml
+++ b/config/samples/application.yml
@@ -97,6 +97,9 @@
 # 
 # OAUTH_AUTHORIZE_URL: "/oauth/authorize"
 # OAUTH_TOKEN_URL: "/oauth/token"
+# Domain Hint is used to add the domain_hint query parameter into the authorization URL
+# an empty string, or value that doesn't match a tenant will be ignored.
+# AZURE_DOMAIN_HINT: "psu.edu"
 
 # --------------------------------------------------------------------------------------------------------------------
 # 

--- a/lib/omniauth/strategies/azure_oauth.rb
+++ b/lib/omniauth/strategies/azure_oauth.rb
@@ -9,6 +9,9 @@ module OmniAuth
 
       option :name, :azure_oauth
 
+      option :authorize_params,
+             domain_hint: ENV.fetch('AZURE_DOMAIN_HINT', 'psu.edu')
+
       option :client_options,
              site: ENV['OAUTH_APP_URL'],
              token_url: ENV.fetch('OAUTH_TOKEN_URL', '/oauth/token'),


### PR DESCRIPTION
adding domain_hint query parameter in the authorization URL informs Azure to redirect to our IdP instead of letting users choose

Fixes #922 