### PR TITLE
Update Ingest API to publish only

### DIFF
--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -113,8 +113,6 @@ module Permissions
       grant_authorized_access
     when Visibility::PRIVATE
       revoke_open_access && revoke_authorized_access
-    else
-      raise ArgumentError, "#{level} is not a supported visibility" unless Visibility.all.include?(level)
     end
   end
 

--- a/app/services/publish_new_work.rb
+++ b/app/services/publish_new_work.rb
@@ -15,9 +15,6 @@ class PublishNewWork
   # @param [ActionController::Parameters] permissions
   # @return [Work]
   def self.call(metadata:, depositor:, content:, permissions: {})
-    deposited_at = metadata.delete(:deposited_at)
-    metadata[:rights] ||= WorkVersion::Licenses::DEFAULT
-
     # @todo start a transaction here in case we need to rollback and remove any Actors we've created
 
     depositor_actor = Actor.find_or_create_by(psu_id: depositor['psu_id']) do |actor|
@@ -40,11 +37,11 @@ class PublishNewWork
     end
 
     params = {
-      work_type: (metadata.delete(:work_type).presence || Work::Types.unspecified),
-      visibility: metadata.delete(:visibility) { Permissions::Visibility::OPEN },
+      work_type: metadata.delete(:work_type),
+      visibility: metadata.delete(:visibility),
       embargoed_until: metadata.delete(:embargoed_until),
       depositor: depositor_actor,
-      deposited_at: deposited_at,
+      deposited_at: metadata.delete(:deposited_at),
       doi: metadata.delete(:doi),
       versions_attributes: [metadata.to_hash.merge!('creators_attributes' => creators_attributes)]
     }

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -33,9 +33,12 @@ RSpec.describe Api::V1::IngestController, type: :controller do
         post :create, params: {
           metadata: {
             title: metadata[:title],
+            work_type: Work::Types.default,
             description: metadata[:description],
             published_date: metadata[:published_date],
-            creators_attributes: [creator]
+            creators_attributes: [creator],
+            rights: metadata[:rights],
+            visibility: Permissions::Visibility::OPEN
           },
           depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id },
           content: [{ file: fixture_file_upload(File.join(fixture_path, 'image.png')) }]
@@ -58,9 +61,12 @@ RSpec.describe Api::V1::IngestController, type: :controller do
         post :create, params: {
           metadata: {
             title: metadata[:title],
+            work_type: Work::Types.default,
             description: metadata[:description],
             published_date: metadata[:published_date],
-            creators_attributes: [creator]
+            creators_attributes: [creator],
+            rights: metadata[:rights],
+            visibility: Permissions::Visibility::OPEN
           },
           content: [{ file: file.to_shrine.to_json }],
           depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id }

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe Api::V1::IngestController, type: :controller do
 
   let(:metadata) { attributes_for(:work_version, :able_to_be_published) }
 
+  let(:json_response) { HashWithIndifferentAccess.new(JSON.parse(response.body)) }
+
   before { request.headers[:'X-API-Key'] = api_token }
 
   describe 'POST #create' do
@@ -102,11 +104,9 @@ RSpec.describe Api::V1::IngestController, type: :controller do
 
       it 'reports the error' do
         expect(response.status).to eq(422)
-        expect(response.body).to eq(
-          '{' \
-            '"message":"Unable to complete the request",' \
-            "\"errors\":[\"Versions title can't be blank\"]" \
-          '}'
+        expect(json_response[:message]).to eq('Unable to complete the request')
+        expect(json_response[:errors]).to include(
+          "Versions title can't be blank"
         )
       end
     end
@@ -124,13 +124,11 @@ RSpec.describe Api::V1::IngestController, type: :controller do
         }
       end
 
-      it 'saves the work with errors' do
-        expect(response).to be_created
-        expect(response.body).to eq(
-          '{' \
-            '"message":"Work was created but cannot be published",' \
-            "\"errors\":[\"#{i18n_error_message(:file_resources, :blank)}\"]" \
-          '}'
+      it 'reports the error' do
+        expect(response.status).to eq(422)
+        expect(json_response[:message]).to eq('Unable to complete the request')
+        expect(json_response[:errors]).to include(
+          "Versions file resources can't be blank"
         )
       end
     end
@@ -148,13 +146,11 @@ RSpec.describe Api::V1::IngestController, type: :controller do
         }
       end
 
-      it 'saves the work with errors' do
-        expect(response).to be_created
-        expect(response.body).to eq(
-          '{' \
-            '"message":"Work was created but cannot be published",' \
-            "\"errors\":[\"#{i18n_error_message(:creators, :blank)}\"]" \
-          '}'
+      it 'reports the error' do
+        expect(response.status).to eq(422)
+        expect(json_response[:message]).to eq('Unable to complete the request')
+        expect(json_response[:errors]).to include(
+          "Versions creators can't be blank"
         )
       end
     end

--- a/spec/controllers/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/dashboard/collections_controller_spec.rb
@@ -73,10 +73,10 @@ RSpec.describe Dashboard::CollectionsController, type: :controller do
       end
 
       context 'with an invalid visibility' do
-        it 'raises an error' do
+        it 'does nothing' do
           expect {
             post :update, params: { id: collection.id, collection: { visibility: 'bogus' } }
-          }.to raise_error(ArgumentError)
+          }.not_to change(collection, :visibility)
         end
       end
     end

--- a/spec/controllers/dashboard/works_controller_spec.rb
+++ b/spec/controllers/dashboard/works_controller_spec.rb
@@ -72,8 +72,10 @@ RSpec.describe Dashboard::WorksController, type: :controller do
       end
 
       context 'with an invalid visibility' do
-        it 'raises an error' do
-          expect { post :update, params: { id: work.id, work: { visibility: 'bogus' } } }.to raise_error(ArgumentError)
+        it 'does nothing' do
+          expect {
+            post :update, params: { id: work.id, work: { visibility: 'bogus' } }
+          }.not_to change(work, :visibility)
         end
       end
     end

--- a/spec/features/ingest_spec.rb
+++ b/spec/features/ingest_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Migration', :inline_jobs, type: :feature do
     HashWithIndifferentAccess.new(
       work.metadata.merge(
         work_type: 'dataset',
+        visibility: Permissions::Visibility::OPEN,
         creators_attributes: [
           {
             display_name: user.name,

--- a/spec/services/publish_new_work_spec.rb
+++ b/spec/services/publish_new_work_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe PublishNewWork do
       described_class.call(
         metadata: HashWithIndifferentAccess.new(work.metadata.merge(
                                                   work_type: 'dataset',
+                                                  visibility: Permissions::Visibility::OPEN,
                                                   creators_attributes: [
                                                     {
                                                       display_name: user.name,
@@ -73,6 +74,7 @@ RSpec.describe PublishNewWork do
       described_class.call(
         metadata: HashWithIndifferentAccess.new(work.metadata.merge(
                                                   work_type: 'dataset',
+                                                  visibility: Permissions::Visibility::OPEN,
                                                   creators_attributes: [
                                                     {
                                                       display_name: user.name,
@@ -115,6 +117,7 @@ RSpec.describe PublishNewWork do
       described_class.call(
         metadata: HashWithIndifferentAccess.new(work.metadata.merge(
                                                   work_type: 'dataset',
+                                                  visibility: Permissions::Visibility::OPEN,
                                                   creators_attributes: [
                                                     {
                                                       display_name: user.name,
@@ -190,7 +193,10 @@ RSpec.describe PublishNewWork do
         "Versions creators can't be blank",
         "Versions file resources can't be blank",
         'Versions published date is not a valid date in EDTF format',
-        'Versions published date is required to publish the work'
+        'Versions published date is required to publish the work',
+        'Versions visibility cannot be private',
+        "Work type can't be blank",
+        'Versions rights is required to publish the work'
       )
     end
   end
@@ -243,6 +249,7 @@ RSpec.describe PublishNewWork do
       described_class.call(
         metadata: HashWithIndifferentAccess.new(work.metadata.merge(
                                                   work_type: 'dataset',
+                                                  visibility: Permissions::Visibility::OPEN,
                                                   creators_attributes: [
                                                     {
                                                       display_name: user.name,
@@ -279,6 +286,7 @@ RSpec.describe PublishNewWork do
       described_class.call(
         metadata: HashWithIndifferentAccess.new(work.metadata.merge(
                                                   work_type: 'dataset',
+                                                  visibility: Permissions::Visibility::OPEN,
                                                   creators_attributes: [
                                                     {
                                                       display_name: user.name,
@@ -342,9 +350,14 @@ RSpec.describe PublishNewWork do
       )
     end
 
-    it 'creates a work using the specified deposit dates' do
-      expect(new_work.latest_version).to be_published
-      expect(new_work.work_type).to eq(Work::Types.unspecified)
+    it 'does NOT save the work' do
+      expect { new_work }.not_to change(Work, :count)
+    end
+
+    it 'returns the work with errors' do
+      expect(new_work.errors.full_messages).to include(
+        "Work type can't be blank"
+      )
     end
   end
 end

--- a/spec/support/shared/a_resource_with_permissions.rb
+++ b/spec/support/shared/a_resource_with_permissions.rb
@@ -779,11 +779,11 @@ RSpec.shared_examples 'a resource with permissions' do
     end
 
     context 'with an unsupported visibility' do
-      subject(:resource) { open_access_resource }
+      subject(:resource) { build(factory_name, visibility: 'bogus') }
 
-      it 'raises an argument error' do
-        expect { resource.visibility = 'bogus' }.to raise_error(ArgumentError, 'bogus is not a supported visibility')
-      end
+      let(:default) { factory_name.to_s.capitalize.constantize.new }
+
+      its(:visibility) { is_expected.to eq(default.visibility) }
     end
   end
 end


### PR DESCRIPTION
The ingest API now no longer creates draft works. It will only publish new works, or return an error if there isn't sufficient metadata. Additionally, all parameters are now explicit. The client must provide values for work type, visibility, and rights.

Ref #898 