### PR TITLE
Delete unpublished works and collections

### DIFF
--- a/app/components/delete_resource_button_component.html.erb
+++ b/app/components/delete_resource_button_component.html.erb
@@ -1,0 +1,6 @@
+<%= link_to path,
+            method: :delete,
+            class: html_class,
+            data: { confirm: confirm } do %>
+            <%= button_text %><span class="subtitle responsive-hide"> <%= button_subtitle %></span>
+<% end %>

--- a/app/components/delete_resource_button_component.rb
+++ b/app/components/delete_resource_button_component.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class DeleteResourceButtonComponent < ApplicationComponent
+  attr_reader :resource, :html_class, :hide_if_published
+
+  def initialize(resource:, html_class:, hide_if_published: false)
+    @resource = resource
+    @html_class = html_class
+    @hide_if_published = hide_if_published
+  end
+
+  def render?
+    return true if collection?
+
+    resource.draft? || !hide_if_published
+  end
+
+  def path
+    path_method = if work_version? then :dashboard_work_version_path
+                  elsif collection? then :dashboard_collection_path
+                  else
+                    raise ArgumentError, "#{type} is not supported by this component"
+                  end
+
+    method(path_method).call(resource)
+  end
+
+  def confirm
+    t('confirm', type: button_subtitle)
+  end
+
+  def button_text
+    t('button')
+  end
+
+  def button_subtitle
+    return t('collection') if collection?
+    return t('draft') if work_version? && resource.draft?
+
+    t('work_version')
+  end
+
+  private
+
+    def type
+      resource.class.name
+    end
+
+    def collection?
+      type == 'Collection'
+    end
+
+    def work_version?
+      type == 'WorkVersion'
+    end
+
+    def t(key, options = {})
+      I18n.t!("dashboard.form.actions.destroy.#{key}", options)
+    end
+end

--- a/app/controllers/dashboard/collections_controller.rb
+++ b/app/controllers/dashboard/collections_controller.rb
@@ -28,6 +28,7 @@ module Dashboard
     # DELETE /collections/1.json
     def destroy
       @collection = current_user.collections.find(params[:id])
+      authorize(@collection)
       @collection.destroy
       respond_to do |format|
         format.html { redirect_to dashboard_root_path, notice: t('.success') }

--- a/app/controllers/dashboard/work_versions_controller.rb
+++ b/app/controllers/dashboard/work_versions_controller.rb
@@ -56,10 +56,19 @@ module Dashboard
     def destroy
       @work_version = WorkVersion.find(params[:id])
       authorize(@work_version)
-      DestroyWorkVersion.call(@work_version)
+
+      parent_work = DestroyWorkVersion.call(
+        @work_version, force: current_user.admin?
+      )
+
+      redirect_path = if parent_work.nil?
+                        dashboard_root_path
+                      else
+                        resource_path(parent_work.latest_version.uuid)
+                      end
 
       respond_to do |format|
-        format.html { redirect_to dashboard_root_path, notice: 'Work version was successfully destroyed.' }
+        format.html { redirect_to redirect_path, notice: 'Work version was successfully destroyed.' }
         format.json { head :no_content }
       end
     end

--- a/app/javascript/frontend/styles/_common.scss
+++ b/app/javascript/frontend/styles/_common.scss
@@ -579,22 +579,38 @@ h4,
     padding: $spacer;
 
     @include media-breakpoint-up(md) {
-      > button:first-of-type {
+      > .pull-left,
+        .pull-right {
         position: absolute;
+      }
+
+      >.pull-left {
         left: $spacer;
+      }
+
+      >.pull-right {
+        right: $spacer;
       }
     }
 
     @include media-breakpoint-down(sm) {
-      button {
+      .btn {
         font-size: $font-size-sm;
         padding-left: $spacer;
         padding-right: $spacer;
       }
+
+      .responsive-hide {
+        display: none;
+      }
     }
 
-    > button:first-of-type {
+    >.pull-left {
       margin-right: $spacer;
+    }
+
+    >.pull-right {
+      margin-left: $spacer;
     }
   }
 

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -139,8 +139,13 @@ class WorkVersion < ApplicationRecord
 
   after_save :perform_update_index
 
+  attr_accessor :force_destroy
+
+  # Do not allow pubilshed works to be destroyed, unless specially flagged by
+  # setting `work_version.force_destroy = true`
   before_destroy do
-    raise ArgumentError, 'cannot delete published versions' if published?
+    prevent_destroy = published? && !force_destroy
+    raise ArgumentError, 'cannot delete published versions' if prevent_destroy
   end
 
   aasm do

--- a/app/policies/work_version_policy.rb
+++ b/app/policies/work_version_policy.rb
@@ -19,12 +19,21 @@ class WorkVersionPolicy < ApplicationPolicy
   end
   alias_method :update?, :edit?
 
+  # Work versions cannot be destroyed if they haven't been persisted.
+  # Admins can delete a work version in any state, as long as it's the latest one
+  # Regular users can only delete draft versions that they can edit
   def destroy?
+    return false if record.new_record?
+    return true if user.admin? && record == record.work.latest_version
+
+    !record.published? && editable?
+  end
+
+  def publish?
     return false if record.published?
 
     editable?
   end
-  alias_method :publish?, :destroy?
 
   def download?
     return true if editable?

--- a/app/services/destroy_work_version.rb
+++ b/app/services/destroy_work_version.rb
@@ -6,8 +6,12 @@ class DestroyWorkVersion
     parent_work = work_version.work
 
     if parent_work.versions.count == 1
-      parent_work.destroy!
-      IndexingService.delete_document(work_version.uuid, commit: true)
+      WorkVersion.transaction do
+        work_version.destroy!
+        parent_work.destroy!
+      end
+      IndexingService.delete_document(work_version.uuid, commit: false)
+      IndexingService.delete_document(parent_work.uuid, commit: true)
 
       nil
     else

--- a/app/services/destroy_work_version.rb
+++ b/app/services/destroy_work_version.rb
@@ -1,17 +1,22 @@
 # frozen_string_literal: true
 
 class DestroyWorkVersion
-  def self.call(work_version)
+  def self.call(work_version, force: false)
+    work_version.force_destroy = force
     parent_work = work_version.work
 
     if parent_work.versions.count == 1
       parent_work.destroy!
       IndexingService.delete_document(work_version.uuid, commit: true)
+
+      nil
     else
       work_version.destroy!
       parent_work.reload
       IndexingService.delete_document(work_version.uuid, commit: false)
       WorkIndexer.call(parent_work, commit: true)
+
+      parent_work
     end
   end
 end

--- a/app/views/dashboard/collections/edit.html.erb
+++ b/app/views/dashboard/collections/edit.html.erb
@@ -19,6 +19,9 @@
           <li class="nav-item">
             <%= link_to t('dashboard.shared.editors_form.heading'), "##{t('dashboard.shared.editors_form.heading').parameterize}", class: 'nav-link' %>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#<%= t('.danger.heading').parameterize %>"><%= t('.danger.heading') %></a>
+          </li>
         </ul>
       </aside>
     </div>
@@ -45,6 +48,28 @@
       <div class="actions mb-3">
         <%= render 'dashboard/shared/editors_form', editors_form: @editors_form, url: dashboard_collection_path(@collection) %>
       </div>
+
+      <% if policy(@collection).destroy? %>
+        <div class="keyline keyline--left">
+          <h2 id="<%= t('.danger.heading').parameterize %>" class="h4"><%= t('.danger.heading') %></h2>
+        </div>
+
+        <div class="border border-danger rounded p-2">
+          <div class="actions">
+            <div class="d-flex">
+              <div class="mr-auto">
+                <p><%= t('.danger.explanation') %></p>
+              </div>
+              <div>
+                <%= link_to t('dashboard.form.actions.destroy.button'),
+                            dashboard_collection_path(@collection),
+                            class: 'btn btn-danger btn--squish mr-lg-2',
+                            method: :delete,
+                            data: { confirm: t('dashboard.form.actions.destroy.confirm') } %>
+              </div>
+          </div>
+        </div>
+      <% end %>
     </div>
   </article>
 </div>

--- a/app/views/dashboard/collections/edit.html.erb
+++ b/app/views/dashboard/collections/edit.html.erb
@@ -19,9 +19,11 @@
           <li class="nav-item">
             <%= link_to t('dashboard.shared.editors_form.heading'), "##{t('dashboard.shared.editors_form.heading').parameterize}", class: 'nav-link' %>
           </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#<%= t('.danger.heading').parameterize %>"><%= t('.danger.heading') %></a>
-          </li>
+          <% if current_user.admin? && policy(@collection).destroy? %>
+            <li class="nav-item">
+              <a class="nav-link" href="#<%= t('.danger.heading').parameterize %>"><%= t('.danger.heading') %></a>
+            </li>
+          <% end %>
         </ul>
       </aside>
     </div>
@@ -49,7 +51,7 @@
         <%= render 'dashboard/shared/editors_form', editors_form: @editors_form, url: dashboard_collection_path(@collection) %>
       </div>
 
-      <% if policy(@collection).destroy? %>
+      <% if current_user.admin? && policy(@collection).destroy? %>
         <div class="keyline keyline--left">
           <h2 id="<%= t('.danger.heading').parameterize %>" class="h4"><%= t('.danger.heading') %></h2>
         </div>
@@ -61,11 +63,11 @@
                 <p><%= t('.danger.explanation') %></p>
               </div>
               <div>
-                <%= link_to t('dashboard.form.actions.destroy.button'),
-                            dashboard_collection_path(@collection),
-                            class: 'btn btn-danger btn--squish mr-lg-2',
-                            method: :delete,
-                            data: { confirm: t('dashboard.form.actions.destroy.confirm') } %>
+                <%= render DeleteResourceButtonComponent.new(
+                      resource: @collection,
+                      html_class: 'btn btn-outline-danger text-nowrap mr-lg-2',
+                      hide_if_published: false
+                    ) %>
               </div>
           </div>
         </div>

--- a/app/views/dashboard/form/shared/_action_footer.html.erb
+++ b/app/views/dashboard/form/shared/_action_footer.html.erb
@@ -2,9 +2,19 @@
 <% secondary_action = current_user.admin? ? :admin_save : param_key %>
 
 <footer class="footer footer--actions footer--fixed d-flex justify-content-center">
-  <%= form.button t("dashboard.form.actions.save_and_exit.#{secondary_action}"), name: 'save_and_exit', class: 'btn btn-outline-primary btn--rounded' %>
+  <%= form.button t("dashboard.form.actions.save_and_exit.#{secondary_action}"), name: 'save_and_exit', class: 'btn btn-outline-primary btn--rounded pull-left' %>
+
   <div>
     <%= link_to t('dashboard.form.actions.cancel'), cancel_path, class: 'btn btn-outline-dark btn--rounded' %>
     <%= form.submit t("dashboard.form.actions.#{primary_action}"), name: primary_action, class: 'btn btn-primary btn--rounded ml-2' %>
   </div>
+
+  <% if form.object.persisted? && policy(form.object).destroy? %>
+    <%- destroy_path = form.object.is_a?(Collection) ? method(:dashboard_collection_path) : method(:dashboard_work_version_path) %>
+    <%= link_to t('dashboard.form.actions.destroy.button'),
+                destroy_path.call(form.object),
+                method: :delete,
+                class: 'btn btn-outline-danger btn--rounded pull-right',
+                data: { confirm: t('dashboard.form.actions.destroy.confirm') } %>
+  <% end %>
 </footer>

--- a/app/views/dashboard/form/shared/_action_footer.html.erb
+++ b/app/views/dashboard/form/shared/_action_footer.html.erb
@@ -10,11 +10,10 @@
   </div>
 
   <% if form.object.persisted? && policy(form.object).destroy? %>
-    <%- destroy_path = form.object.is_a?(Collection) ? method(:dashboard_collection_path) : method(:dashboard_work_version_path) %>
-    <%= link_to t('dashboard.form.actions.destroy.button'),
-                destroy_path.call(form.object),
-                method: :delete,
-                class: 'btn btn-outline-danger btn--rounded pull-right',
-                data: { confirm: t('dashboard.form.actions.destroy.confirm') } %>
+    <%= render DeleteResourceButtonComponent.new(
+          resource: form.object,
+          html_class: 'btn btn-outline-danger btn--rounded pull-right',
+          hide_if_published: true
+        ) %>
   <% end %>
 </footer>

--- a/app/views/dashboard/works/edit.html.erb
+++ b/app/views/dashboard/works/edit.html.erb
@@ -23,9 +23,11 @@
           <li class="nav-item">
             <%= link_to t('dashboard.shared.editors_form.heading'), "##{t('dashboard.shared.editors_form.heading').parameterize}", class: 'nav-link' %>
           </li>
+          <% if current_user.admin? && policy(@work.latest_version).destroy? %>
           <li class="nav-item">
             <a class="nav-link" href="#<%= t('.danger.heading').parameterize %>"><%= t('.danger.heading') %></a>
           </li>
+        <% end %>
         </ul>
       </aside>
     </div>
@@ -99,7 +101,7 @@
         <%= render 'dashboard/shared/editors_form', editors_form: @editors_form, url: dashboard_work_path(@work) %>
       </div>
 
-      <% if policy(@work.latest_version).destroy? %>
+      <% if current_user.admin? && policy(@work.latest_version).destroy? %>
         <div class="keyline keyline--left">
           <h2 id="<%= t('.danger.heading').parameterize %>" class="h4"><%= t('.danger.heading') %></h2>
         </div>
@@ -111,11 +113,11 @@
                 <p><%= t('.danger.explanation') %></p>
               </div>
               <div>
-                <%= link_to t('dashboard.form.actions.destroy.button'),
-                            dashboard_work_version_path(@work.latest_version),
-                            class: 'btn btn-danger btn--squish mr-lg-2',
-                            method: :delete,
-                            data: { confirm: t('dashboard.form.actions.destroy.confirm') } %>
+                <%= render DeleteResourceButtonComponent.new(
+                      resource: @work.latest_version,
+                      html_class: 'btn btn-outline-danger text-nowrap mr-lg-2',
+                      hide_if_published: false
+                    ) %>
               </div>
           </div>
         </div>

--- a/app/views/dashboard/works/edit.html.erb
+++ b/app/views/dashboard/works/edit.html.erb
@@ -23,6 +23,9 @@
           <li class="nav-item">
             <%= link_to t('dashboard.shared.editors_form.heading'), "##{t('dashboard.shared.editors_form.heading').parameterize}", class: 'nav-link' %>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#<%= t('.danger.heading').parameterize %>"><%= t('.danger.heading') %></a>
+          </li>
         </ul>
       </aside>
     </div>
@@ -95,6 +98,28 @@
       <div class="actions mb-3">
         <%= render 'dashboard/shared/editors_form', editors_form: @editors_form, url: dashboard_work_path(@work) %>
       </div>
+
+      <% if policy(@work.latest_version).destroy? %>
+        <div class="keyline keyline--left">
+          <h2 id="<%= t('.danger.heading').parameterize %>" class="h4"><%= t('.danger.heading') %></h2>
+        </div>
+
+        <div class="border border-danger rounded p-2">
+          <div class="actions">
+            <div class="d-flex">
+              <div class="mr-auto">
+                <p><%= t('.danger.explanation') %></p>
+              </div>
+              <div>
+                <%= link_to t('dashboard.form.actions.destroy.button'),
+                            dashboard_work_version_path(@work.latest_version),
+                            class: 'btn btn-danger btn--squish mr-lg-2',
+                            method: :delete,
+                            data: { confirm: t('dashboard.form.actions.destroy.confirm') } %>
+              </div>
+          </div>
+        </div>
+      <% end %>
     </div>
   </article>
 </div>

--- a/app/views/resources/_collection.html.erb
+++ b/app/views/resources/_collection.html.erb
@@ -22,14 +22,6 @@
                   class: 'btn btn-outline-light btn--squish mr-lg-2' %>
     </li>
   <% end %>
-
-  <% if policy(collection).destroy? %>
-    <%= link_to t('resources.collection.delete_button'),
-                dashboard_form_collection_details_path(collection),
-                class: 'btn btn-danger btn--squish mr-lg-2',
-                method: :delete,
-                data: { confirm: t('resources.collection.delete_confirm') } %>
-  <% end %>
 <% end %>
 
 <div class="container-fluid">

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -43,15 +43,6 @@
     </li>
 
   <% end %>
-
-  <% if policy(work_version).destroy? %>
-    <%= link_to t('dashboard.form.actions.destroy.button'),
-                dashboard_work_version_path(work_version),
-                class: 'btn btn-danger btn--squish mr-lg-2',
-                method: :delete,
-                data: { confirm: t('dashboard.form.actions.destroy.confirm') } %>
-  <% end %>
-
 <% end %>
 
 <div class="container-fluid">

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -43,6 +43,15 @@
     </li>
 
   <% end %>
+
+  <% if policy(work_version).destroy? %>
+    <%= link_to t('dashboard.form.actions.destroy.button'),
+                dashboard_work_version_path(work_version),
+                class: 'btn btn-danger btn--squish mr-lg-2',
+                method: :delete,
+                data: { confirm: t('dashboard.form.actions.destroy.confirm') } %>
+  <% end %>
+
 <% end %>
 
 <div class="container-fluid">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -312,6 +312,9 @@ en:
           collection: Save and Exit
           work_version: Save as Draft & Exit
           admin_save: Save and Exit
+        destroy:
+          button: Delete
+          confirm: "Are you sure you want to delete this version? This cannot be undone."
       details:
         about_collections: 
           label: About Collections

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -231,6 +231,9 @@ en:
           heading: DOI
           explanation: A Digital Object Identifier (DOI) is a persistent identifier that can be used in print or on the web.
           not_allowed: A DOI cannot be created for this collection.
+        danger:
+          heading: Danger
+          explanation: Deleting a collection cannot be undone.
       update:
         success: Collection settings successfully updated.
       destroy:
@@ -284,6 +287,9 @@ en:
           heading: DOI
           explanation: A Digital Object Identifier (DOI) is a persistent identifier that can be used in print or on the web.
           not_allowed: A DOI may only be created on published works. Since this work is a draft, you'll need to wait until it's published to create a DOI for it.
+        danger:
+          heading: Danger
+          explanation: This line of text can be fleshed out depending on whether the latest version is a draft, a non-draft, and explain that deleting the only version will also delete the work.
       update:
         success: "Work settings successfully updated."
     form: 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -289,7 +289,7 @@ en:
           not_allowed: A DOI may only be created on published works. Since this work is a draft, you'll need to wait until it's published to create a DOI for it.
         danger:
           heading: Danger
-          explanation: This line of text can be fleshed out depending on whether the latest version is a draft, a non-draft, and explain that deleting the only version will also delete the work.
+          explanation: Admins can delete a draft or a published version, but can only delete the most recent version at any given time.
       update:
         success: "Work settings successfully updated."
     form: 
@@ -320,7 +320,10 @@ en:
           admin_save: Save and Exit
         destroy:
           button: Delete
-          confirm: "Are you sure you want to delete this version? This cannot be undone."
+          collection: Collection
+          draft: Draft
+          work_version: Version
+          confirm: "Are you sure you want to delete this %{type}? This cannot be undone."
       details:
         about_collections: 
           label: About Collections

--- a/spec/components/delete_resource_button_component_spec.rb
+++ b/spec/components/delete_resource_button_component_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeleteResourceButtonComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:node) { render_inline(described_class.new(resource: resource, html_class: 'btn my-class')) }
+  let(:link) { node.css('a').first }
+
+  context 'when given a collection' do
+    let(:resource) { build_stubbed :collection }
+
+    it 'renders a delete button for the collection' do
+      text = I18n.t!('dashboard.form.actions.destroy.button')
+      subtitle = I18n.t!('dashboard.form.actions.destroy.collection')
+      confirm = I18n.t!('dashboard.form.actions.destroy.confirm', type: subtitle)
+
+      expect(link.text.strip).to eq "#{text} #{subtitle}"
+
+      expect(link.attributes['href'].value).to eq dashboard_collection_path(resource)
+      expect(link.attributes['data-method'].value).to eq 'delete'
+      expect(link.attributes['data-confirm'].value).to eq confirm
+      expect(link.attributes['class'].value).to eq 'btn my-class'
+    end
+  end
+
+  context 'when given a draft version' do
+    let(:resource) { build_stubbed :work_version }
+
+    before { allow(resource).to receive(:draft?).and_return(true) }
+
+    it 'renders a delete button for the work version' do
+      text = I18n.t!('dashboard.form.actions.destroy.button')
+      subtitle = I18n.t!('dashboard.form.actions.destroy.draft')
+      confirm = I18n.t!('dashboard.form.actions.destroy.confirm', type: subtitle)
+
+      expect(link.text.strip).to eq "#{text} #{subtitle}"
+
+      expect(link.attributes['href'].value).to eq dashboard_work_version_path(resource)
+      expect(link.attributes['data-method'].value).to eq 'delete'
+      expect(link.attributes['data-confirm'].value).to eq confirm
+    end
+  end
+
+  context 'when given a published version' do
+    let(:resource) { build_stubbed :work_version }
+    let(:instance) do
+      described_class.new(resource: resource,
+                          html_class: 'btn my-class',
+                          hide_if_published: hide_if_published)
+    end
+    let(:node) { render_inline(instance) }
+
+    before { allow(resource).to receive(:draft?).and_return(false) }
+
+    context 'when hide_if_published is TRUE' do
+      let(:hide_if_published) { true }
+
+      it 'is not rendered' do
+        expect(instance.render?).to eq false
+      end
+    end
+
+    context 'when hide_if_published is FALSE' do
+      let(:hide_if_published) { false }
+
+      it 'renders a delete button for the work version' do
+        text = I18n.t!('dashboard.form.actions.destroy.button')
+        subtitle = I18n.t!('dashboard.form.actions.destroy.work_version')
+        confirm = I18n.t!('dashboard.form.actions.destroy.confirm', type: subtitle)
+
+        expect(link.text.strip).to eq "#{text} #{subtitle}"
+
+        expect(link.attributes['href'].value).to eq dashboard_work_version_path(resource)
+        expect(link.attributes['data-confirm'].value).to eq confirm
+      end
+    end
+  end
+end

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -609,4 +609,30 @@ RSpec.describe 'Publishing a work', with_user: :user do
       expect(work_version.rights).to eq(different_metadata[:rights])
     end
   end
+
+  describe 'Deleting a version' do
+    context 'when logged in as a regular user' do
+      let(:work_version) { create :work_version, :draft }
+      let(:user) { work_version.work.depositor.user }
+
+      it 'allows a user to delete a draft' do
+        visit dashboard_form_work_version_details_path(work_version)
+        FeatureHelpers::DashboardForm.delete
+
+        expect { work_version.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'when logged in as an admin' do
+      let(:work_version) { create :work_version, :published }
+      let(:user) { create(:user, :admin) }
+
+      it 'allows an admin to delete a published version' do
+        visit dashboard_form_work_version_details_path(work_version)
+        FeatureHelpers::DashboardForm.delete
+
+        expect { work_version.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -627,11 +627,11 @@ RSpec.describe 'Publishing a work', with_user: :user do
       let(:work_version) { create :work_version, :published }
       let(:user) { create(:user, :admin) }
 
-      it 'allows an admin to delete a published version' do
+      it 'hides the delete button on published versions' do
         visit dashboard_form_work_version_details_path(work_version)
-        FeatureHelpers::DashboardForm.delete
-
-        expect { work_version.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          FeatureHelpers::DashboardForm.delete
+        }.to raise_error(Capybara::ElementNotFound)
       end
     end
   end

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -160,18 +160,14 @@ RSpec.describe 'Public Resources', type: :feature do
       let(:collection) { create :collection }
       let(:user) { collection.depositor.user }
 
-      it 'displays edit controls on the resource page and allows the user to delete the collection' do
+      it 'displays edit controls on the resource page' do
         visit resource_path(collection.uuid)
 
         expect(page.title).to include(collection.title)
 
         within('header') do
           expect(page).to have_content(I18n.t('resources.collection.edit_button'))
-          click_on I18n.t('resources.collection.delete_button')
         end
-
-        expect(page).to have_current_path(dashboard_root_path)
-        expect(page).to have_content('Collection was successfully deleted.')
       end
     end
   end

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -384,24 +384,40 @@ RSpec.describe WorkVersion, type: :model do
     end
   end
 
+  describe '#force_destroy' do
+    it { is_expected.to respond_to(:force_destroy).and respond_to(:force_destroy=) }
+  end
+
   describe '#destroy' do
     context 'with a published version' do
       let(:work_version) { create(:work_version, :published) }
 
-      it 'raises an error' do
-        expect {
-          work_version.destroy
-        }.to raise_error(ArgumentError, 'cannot delete published versions')
+      context 'when force_destroy is false' do
+        it 'raises an error' do
+          expect {
+            work_version.destroy
+          }.to raise_error(ArgumentError, 'cannot delete published versions')
+        end
+      end
+
+      context 'when force_destroy is true' do
+        before { work_version.force_destroy = true } # get off my lawn
+
+        it 'raises an error' do
+          expect {
+            work_version.destroy
+          }.to change(described_class, :count).by(-1)
+        end
       end
     end
 
     context 'with a draft version' do
-      let(:work_version) { create(:work_version, :draft) }
+      let!(:work_version) { create(:work_version, :draft) }
 
       it 'deletes the version' do
         expect {
           work_version.destroy
-        }.to change(described_class, :count).by(1)
+        }.to change(described_class, :count).by(-1)
       end
     end
   end

--- a/spec/services/destroy_work_version_spec.rb
+++ b/spec/services/destroy_work_version_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe DestroyWorkVersion, type: :model do
+  before do
+    allow(IndexingService).to receive(:delete_document)
+    allow(WorkIndexer).to receive(:call)
+  end
+
   context 'when the work has more than one version' do
     let(:work) { create :work, versions_count: 2, has_draft: true }
     let(:work_version) { work.draft_version }
@@ -15,6 +20,54 @@ RSpec.describe DestroyWorkVersion, type: :model do
       }.by(-1)
 
       expect { work_version.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'returns the parent work reloaded' do
+      return_val = described_class.call(work_version)
+
+      expect(return_val).to eq work
+      expect(return_val.versions.length).to eq 1
+    end
+
+    it 'reindexes solr' do
+      described_class.call(work_version)
+      expect(IndexingService).to have_received(:delete_document).with(
+        work_version.uuid,
+        commit: false
+      )
+      expect(WorkIndexer).to have_received(:call).with(work, commit: true)
+    end
+
+    context 'when the given version is published' do
+      let(:work) { create :work, versions_count: 2, has_draft: false }
+      let(:work_version) { work.versions.first }
+
+      context 'when force: false' do
+        specify do
+          expect {
+            described_class.call(work_version, force: false)
+          }.to raise_error(ArgumentError)
+
+          expect {
+            described_class.call(work_version) # force: false is default
+          }.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'when force: true' do
+        it 'deletes the given work version, etc' do
+          expect {
+            described_class.call(work_version, force: true)
+          }.to change {
+            work.versions.count
+          }.by(-1)
+
+          expect { work_version.reload }.to raise_error(ActiveRecord::RecordNotFound)
+
+          expect(IndexingService).to have_received(:delete_document)
+          expect(WorkIndexer).to have_received(:call)
+        end
+      end
     end
   end
 
@@ -31,40 +84,48 @@ RSpec.describe DestroyWorkVersion, type: :model do
     it 'returns nil' do
       expect(described_class.call(work_version)).to be_nil
     end
-  end
 
-  context 'when the given version is published' do
-    let(:work) { create :work, versions_count: 2, has_draft: false }
-    let(:work_version) { work.versions.first }
-
-    context 'when force: false' do
-      specify do
-        expect {
-          described_class.call(work_version, force: false)
-        }.to raise_error(ArgumentError)
-
-        expect {
-          described_class.call(work_version) # force: false is default
-        }.to raise_error(ArgumentError)
-      end
+    it 'reindexes solr' do
+      described_class.call(work_version)
+      expect(IndexingService).to have_received(:delete_document).with(
+        work_version.uuid,
+        commit: false
+      )
+      expect(IndexingService).to have_received(:delete_document).with(
+        work.uuid,
+        commit: true
+      )
     end
 
-    context 'when force: true' do
-      it 'deletes the given work version' do
-        expect {
-          described_class.call(work_version, force: true)
-        }.to change {
-          work.versions.count
-        }.by(-1)
+    context 'when that version is published' do
+      let(:work) { create :work, versions_count: 1, has_draft: false }
+      let(:work_version) { work.latest_version }
 
-        expect { work_version.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      context 'when force: false' do
+        specify do
+          expect {
+            described_class.call(work_version, force: false)
+          }.to raise_error(ArgumentError)
+        end
       end
 
-      it 'returns the parent work, reloaded' do
-        return_val = described_class.call(work_version, force: true)
+      context 'when force: true' do
+        it 'deletes the entire work, etc' do
+          described_class.call(work_version, force: true)
+          expect { work_version.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          expect { work.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          expect(IndexingService).to have_received(:delete_document).twice
+        end
+      end
 
-        expect(return_val).to eq work
-        expect(return_val.versions.count).to eq 1
+      context "when force: true and the specs aren't artificially loading things from the db weirdly" do
+        it 'deletes the entire work, etc' do
+          loaded_from_db = WorkVersion.find(work_version.id)
+          described_class.call(loaded_from_db, force: true)
+          expect { work_version.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          expect { work.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          expect(IndexingService).to have_received(:delete_document).twice
+        end
       end
     end
   end

--- a/spec/services/destroy_work_version_spec.rb
+++ b/spec/services/destroy_work_version_spec.rb
@@ -27,5 +27,45 @@ RSpec.describe DestroyWorkVersion, type: :model do
       expect { work_version.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { work.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
+
+    it 'returns nil' do
+      expect(described_class.call(work_version)).to be_nil
+    end
+  end
+
+  context 'when the given version is published' do
+    let(:work) { create :work, versions_count: 2, has_draft: false }
+    let(:work_version) { work.versions.first }
+
+    context 'when force: false' do
+      specify do
+        expect {
+          described_class.call(work_version, force: false)
+        }.to raise_error(ArgumentError)
+
+        expect {
+          described_class.call(work_version) # force: false is default
+        }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when force: true' do
+      it 'deletes the given work version' do
+        expect {
+          described_class.call(work_version, force: true)
+        }.to change {
+          work.versions.count
+        }.by(-1)
+
+        expect { work_version.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'returns the parent work, reloaded' do
+        return_val = described_class.call(work_version, force: true)
+
+        expect(return_val).to eq work
+        expect(return_val.versions.count).to eq 1
+      end
+    end
   end
 end

--- a/spec/support/feature_helpers/dashboard_form.rb
+++ b/spec/support/feature_helpers/dashboard_form.rb
@@ -108,6 +108,11 @@ module FeatureHelpers
       click_on I18n.t('dashboard.form.actions.finish')
     end
 
+    def self.delete
+      fix_sticky_footer
+      click_on I18n.t('dashboard.form.actions.destroy.button')
+    end
+
     def self.fix_sticky_footer
       Capybara.current_session.current_window.resize_to(1000, 1000)
     rescue Capybara::NotSupportedByDriverError


### PR DESCRIPTION
Users can delete draft works and collections from the edit form.

Admins can delete them from the edit form, too. They also have a special section of the work/collection settings page that allows them to delete published versions too. 

At the moment there's a minor bug where:
1. If the user is an admin
2. They delete a second version from the work settings page
3. They are redirected to the resource page for that work, but not back to the settings page

"Fixing" number 3 above will be rather annoying so I'm not sure it's worth the effort.


There's also a neato feature on the edit form, where large screen sizes the button says "Delete Draft" and at smaller screen sizes where there's not enough room, it automagically just says "Delete"

Closes #867 