### PR TITLE
Collections can't be deleted by regular users if it has a DOI

### DIFF
--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -16,8 +16,13 @@ class CollectionPolicy < ApplicationPolicy
   end
   alias_method :create?, :edit?
   alias_method :update?, :edit?
-  alias_method :destroy?, :edit?
   alias_method :mint_doi?, :edit?
+
+  def destroy?
+    return true if user.admin?
+
+    edit? && record.doi.blank?
+  end
 
   private
 

--- a/app/views/dashboard/collections/edit.html.erb
+++ b/app/views/dashboard/collections/edit.html.erb
@@ -65,7 +65,7 @@
               <div>
                 <%= render DeleteResourceButtonComponent.new(
                       resource: @collection,
-                      html_class: 'btn btn-outline-danger text-nowrap mr-lg-2',
+                      html_class: 'btn btn-outline-danger text-nowrap ml-lg-2',
                       hide_if_published: false
                     ) %>
               </div>

--- a/app/views/dashboard/works/edit.html.erb
+++ b/app/views/dashboard/works/edit.html.erb
@@ -50,7 +50,7 @@
 
         <%= render 'dashboard/form/publish/visibility_field', form: visibility_form %>
 
-        <div class="actions mt-4 mb-3">
+        <div class="actions mt-5 mb-3">
           <%= visibility_form.submit t('.visibility.submit_button'), class: 'btn btn-primary' %>
         </div>
       <% end %>
@@ -115,7 +115,7 @@
               <div>
                 <%= render DeleteResourceButtonComponent.new(
                       resource: @work.latest_version,
-                      html_class: 'btn btn-outline-danger text-nowrap mr-lg-2',
+                      html_class: 'btn btn-outline-danger text-nowrap ml-lg-2',
                       hide_if_published: false
                     ) %>
               </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -233,7 +233,7 @@ en:
           not_allowed: A DOI cannot be created for this collection.
         danger:
           heading: Danger
-          explanation: Deleting a collection cannot be undone.
+          explanation: Deleting a collection cannot be undone. When a collection is deleted, the works in the collection are not deleted. If the collection has a DOI, it will no longer resolve; you are responsible for updating the DOI to a new URI.
       update:
         success: Collection settings successfully updated.
       destroy:
@@ -289,7 +289,7 @@ en:
           not_allowed: A DOI may only be created on published works. Since this work is a draft, you'll need to wait until it's published to create a DOI for it.
         danger:
           heading: Danger
-          explanation: Admins can delete a draft or a published version, but can only delete the most recent version at any given time.
+          explanation: Only the most recent version can be deleted. Deleting a version cannot be undone. If the most recent version is the only version of the work, the work itself will be deleted (regardless of publication status). If the work has a DOI, it will no longer resolve; you are responsible for updating the DOI to a new URI.
       update:
         success: "Work settings successfully updated."
     form: 

--- a/spec/features/dashboard/collection_settings_spec.rb
+++ b/spec/features/dashboard/collection_settings_spec.rb
@@ -87,4 +87,26 @@ RSpec.describe 'Collection Settings Page', with_user: :user do
       end
     end
   end
+
+  describe 'Deleting a collection' do
+    context 'when a regular user' do
+      it 'does not allow a regular user to delete a collection' do
+        visit edit_dashboard_collection_path(collection)
+        expect(page).not_to have_content(I18n.t!('dashboard.collections.edit.danger.explanation'))
+        expect(page).not_to have_link(I18n.t!('dashboard.form.actions.destroy.button'))
+      end
+    end
+
+    context 'when an admin user' do
+      let(:user) { create :user, :admin }
+
+      before { collection.update!(doi: FactoryBotHelpers.valid_doi) }
+
+      it 'allows a collection to be deleted' do
+        visit edit_dashboard_collection_path(collection)
+        click_on(I18n.t!('dashboard.form.actions.destroy.button'))
+        expect { collection.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end

--- a/spec/features/dashboard/work_settings_spec.rb
+++ b/spec/features/dashboard/work_settings_spec.rb
@@ -145,4 +145,24 @@ RSpec.describe 'Work Settings Page', with_user: :user do
       end
     end
   end
+
+  describe 'Deleting a work' do
+    context 'when a regular user' do
+      it 'does not allow a regular user to delete a work version' do
+        visit edit_dashboard_work_path(work)
+        expect(page).not_to have_content(I18n.t!('dashboard.works.edit.danger.explanation'))
+        expect(page).not_to have_link(I18n.t!('dashboard.form.actions.destroy.button'))
+      end
+    end
+
+    context 'when an admin user' do
+      let(:user) { create :user, :admin }
+
+      it 'allows a work version to be deleted' do
+        visit edit_dashboard_work_path(work)
+        click_on(I18n.t!('dashboard.form.actions.destroy.button'))
+        expect { work.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end

--- a/spec/policies/collection_policy_spec.rb
+++ b/spec/policies/collection_policy_spec.rb
@@ -83,4 +83,34 @@ RSpec.describe CollectionPolicy, type: :policy do
     it { is_expected.not_to permit(public, collection) }
     it { is_expected.to permit(admin, collection) }
   end
+
+  permissions :destroy? do
+    let(:collection) do
+      create :collection,
+             depositor: depositor_actor,
+             edit_users: [edit_user]
+    end
+
+    context 'when the collection does NOT have a doi' do
+      before { collection.doi = nil }
+
+      it { is_expected.to permit(depositor, collection) }
+      it { is_expected.to permit(edit_user, collection) }
+      it { is_expected.not_to permit(discover_user, collection) }
+      it { is_expected.not_to permit(other_user, collection) }
+      it { is_expected.not_to permit(public, collection) }
+      it { is_expected.to permit(admin, collection) }
+    end
+
+    context 'when the collection DOES have a doi' do
+      before { collection.doi = FactoryBotHelpers.valid_doi }
+
+      it { is_expected.not_to permit(depositor, collection) }
+      it { is_expected.not_to permit(edit_user, collection) }
+      it { is_expected.not_to permit(discover_user, collection) }
+      it { is_expected.not_to permit(other_user, collection) }
+      it { is_expected.not_to permit(public, collection) }
+      it { is_expected.to permit(admin, collection) }
+    end
+  end
 end


### PR DESCRIPTION
Per @srerickson's last comment on #867 

* Updated language in Danger Zone
* Regular users's can't delete a collection (from the edit form) if that collection has a DOI. Admins can [do anything](https://html5zombo.com)
* Fixed #894 while I was there