### PR TITLE
Don't show drafts to the public, unless they know the UUID

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,6 +92,7 @@ RSpec/VerifiedDoubles:
   Exclude:
     - 'spec/components/mintable_doi_component_spec.rb'
     - 'spec/components/work_versions/version_navigation_dropdown_component_spec.rb'
+    - 'spec/components/work_histories/work_history_component_spec.rb'
 
 Style/ClassVars:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -91,6 +91,7 @@ RSpec/MultipleSubjects:
 RSpec/VerifiedDoubles:
   Exclude:
     - 'spec/components/mintable_doi_component_spec.rb'
+    - 'spec/components/work_versions/version_navigation_dropdown_component_spec.rb'
 
 Style/ClassVars:
   Exclude:

--- a/app/components/work_versions/version_navigation_dropdown_component.rb
+++ b/app/components/work_versions/version_navigation_dropdown_component.rb
@@ -3,6 +3,8 @@
 class WorkVersions::VersionNavigationDropdownComponent < ApplicationComponent
   include Rails.application.routes.url_helpers
 
+  attr_writer :navigable_policy_source
+
   def initialize(work:, current_version:)
     @work = work
     @current_version = current_version
@@ -14,7 +16,11 @@ class WorkVersions::VersionNavigationDropdownComponent < ApplicationComponent
                 :current_version
 
     def drop_down_menu_options
-      work.decorated_versions.reverse.map do |version|
+      work
+        .decorated_versions
+        .reverse
+        .filter { |version| show_version?(version) }
+        .map do |version|
         [
           version,
           path_for(version),
@@ -39,5 +45,20 @@ class WorkVersions::VersionNavigationDropdownComponent < ApplicationComponent
 
     def current?(version)
       current_version.uuid == version.uuid
+    end
+
+    def show_version?(decorated_version)
+      current?(decorated_version) || navigable?(decorated_version)
+    end
+
+    # Components can call view helpers through the `helpers` method, as is done in
+    # the body of the lambda below. However, the one below to retrieve the pundit
+    # policy relies on current_user, which also relies on having Warden up and
+    # running. This is no problem in the actual environment, but in unit tests
+    # it's not available. We can use stubbing to get around this during tests.
+    def navigable?(decorated_version)
+      undecorated_version = decorated_version.__getobj__
+
+      helpers.policy(undecorated_version).navigable?
     end
 end

--- a/app/policies/work_version_policy.rb
+++ b/app/policies/work_version_policy.rb
@@ -29,6 +29,13 @@ class WorkVersionPolicy < ApplicationPolicy
     !record.published? && editable?
   end
 
+  # Navigable means, "does this version show up in menus," which is _different_
+  # than `#show?` because we allow the public to show draft versions if they
+  # happen to know the secret uuid.
+  def navigable?
+    record.published? || editable?
+  end
+
   def publish?
     return false if record.published?
 

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -93,7 +93,10 @@
       <div class="keyline keyline--left mb-3">
         <h2 class="h4"><%= t 'resources.work_history' %></h2>
       </div>
-      <%= render WorkHistories::WorkHistoryComponent.new(work: work_version.work) %>
+      <%= render WorkHistories::WorkHistoryComponent.new(
+            work: work_version.work,
+            current_version: work_version
+          ) %>
     </div>
   </div>
 </div>

--- a/spec/components/work_histories/work_history_component_spec.rb
+++ b/spec/components/work_histories/work_history_component_spec.rb
@@ -3,6 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe WorkHistories::WorkHistoryComponent, type: :component, versioning: true do
+  let(:result) { render_inline(component) }
+  let(:component) { described_class.new(work: work) }
+
   let(:user) { create :user }
 
   let(:work) { create :work, versions: [draft, v1], depositor: user.actor }
@@ -10,19 +13,24 @@ RSpec.describe WorkHistories::WorkHistoryComponent, type: :component, versioning
   let(:draft) { build :work_version, :draft, title: 'Draft Version', work: nil, created_at: 1.day.ago }
   let(:v1) { build :work_version, :published, title: 'Published v1', work: nil, created_at: 3.days.ago }
 
-  # This is normally done automatically in the controller, but we need to do it
-  # here to get our user on the changes above
+  let(:mock_helpers) { spy 'MockHelpers', policy: mock_policy }
+  let(:mock_policy) { instance_spy 'WorkVersionPolicy', navigable?: true }
+
   before do
+    # This is normally done automatically in the controller, but we need to do it
+    # here to get our user on the changes above
     PaperTrail.request.whodunnit = editor.to_gid
+
+    # Mock out helpers, which are normally provided to us by the ActionView
+    # layer, but are not available here in a unit test
+    allow(component).to receive(:helpers).and_return(mock_helpers)
   end
 
   describe 'rendering' do
-    context 'with a standard user' do
+    context 'when the changes were performed by a standard user' do
       let(:editor) { create(:user) }
 
       it 'renders the work history' do
-        result = render_inline(described_class.new(work: work))
-
         expect(result.css('h3').text)
           .to include("Version #{draft.version_number}")
           .and include("Version #{v1.version_number}")
@@ -43,25 +51,55 @@ RSpec.describe WorkHistories::WorkHistoryComponent, type: :component, versioning
       end
     end
 
-    context 'with an external application' do
+    context 'when the changes were performed by an external application' do
       let(:editor) { create(:external_app) }
 
       it 'renders the work history using the name of the application' do
         work # Implicitly create all user records via the `let`s
 
-        result = render_inline(described_class.new(work: work))
         expect(result.css("#work_version_changes_#{v1.id}").text).to include editor.name
       end
     end
 
-    context 'when the user cannot be found' do
+    context 'when the changes were performed by a user that cannot be found' do
       let(:editor) { build(:user, id: '12345') }
 
       it 'renders a null user' do
         work # Implicitly create all user records via the `let`s
 
-        result = render_inline(described_class.new(work: work))
         expect(result.css("#work_version_changes_#{v1.id}").text).to include '[unknown user]'
+      end
+    end
+
+    context 'when some versions should be hidden via the WorkVersionPolicy' do
+      let(:editor) { create(:user) }
+
+      let(:navigable_policy) { instance_spy 'WorkVersionPolicy', navigable?: true }
+      let(:not_navigable_policy) { instance_spy 'WorkVersionPolicy', navigable?: false }
+
+      before do
+        allow(mock_helpers).to receive(:policy).with(draft)
+          .and_return(not_navigable_policy)
+
+        allow(mock_helpers).to receive(:policy).with(v1)
+          .and_return(navigable_policy)
+      end
+
+      it 'only renders changes for versions that the policy allows' do
+        expect(result.css('h3').text)
+          .to include("Version #{v1.version_number}")
+
+        expect(result.css('h3').text)
+          .not_to include("Version #{draft.version_number}")
+
+        expect(result.css('.version-timeline__list').length).to eq 1
+
+        # Draft version is not shown
+        expect(result.css("#work_version_changes_#{draft.id} .version-timeline__change--work-version"))
+          .not_to be_present
+
+        # Published version is shown
+        expect(result.css("#work_version_changes_#{v1.id} .version-timeline__change--work-version")).to be_present
       end
     end
   end

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe 'Public Resources', type: :feature do
           expect(page).not_to have_content 'draft'
         end
 
+        ## Ensure we do not see work history for draft version
+        within('.version-timeline') do
+          expect(page).not_to have_content 'Version 3'
+          expect(page).to have_content 'Version 2'
+        end
+
         ## Navigate to an old version
         within('.navbar .dropdown--versions') { click_on 'V1' }
 
@@ -59,6 +65,16 @@ RSpec.describe 'Public Resources', type: :feature do
         within('header') do
           expect(page).not_to have_content(I18n.t('resources.work_version.edit_button.text', version: 'V3'))
           expect(page).not_to have_content(I18n.t('resources.settings_button.text', type: 'Work'))
+        end
+
+        ## Does have draft in the navigation menu
+        within('.navbar .dropdown--versions') do
+          expect(page).to have_content 'V3'
+        end
+
+        ## Does have draft in work history
+        within('.version-timeline') do
+          expect(page).to have_content 'Version 3'
         end
       end
     end
@@ -107,6 +123,11 @@ RSpec.describe 'Public Resources', type: :feature do
             ## Edit and create buttons are disabled
             expect(page).to have_selector('.qa-edit-version.disabled')
             expect(page).to have_selector('.qa-create-draft.disabled')
+          end
+
+          ## Does have draft in work history
+          within('.version-timeline') do
+            expect(page).to have_content 'Version 3'
           end
 
           ## Navigate to draft version

--- a/spec/policies/work_version_policy_spec.rb
+++ b/spec/policies/work_version_policy_spec.rb
@@ -171,6 +171,39 @@ RSpec.describe WorkVersionPolicy, type: :policy do
     end
   end
 
+  permissions :navigable? do
+    let(:depositor) { work_version.depositor.user }
+    let(:proxy) { build(:user) }
+    let(:edit_user) { build(:user) }
+    let(:other) { build(:user) }
+    let(:admin) { build(:user, :admin) }
+    let(:guest) { User.guest }
+
+    let(:work_version) { work.latest_version }
+
+    context 'when the version is published' do
+      let(:work) { create(:work, has_draft: false, proxy_depositor: proxy.actor, edit_users: [edit_user]) }
+
+      it { is_expected.to permit(depositor, work_version) }
+      it { is_expected.to permit(proxy, work_version) }
+      it { is_expected.to permit(edit_user, work_version) }
+      it { is_expected.to permit(other, work_version) }
+      it { is_expected.to permit(admin, work_version) }
+      it { is_expected.to permit(guest, work_version) }
+    end
+
+    context 'when the version is draft' do
+      let(:work) { create(:work, has_draft: true, proxy_depositor: proxy.actor, edit_users: [edit_user]) }
+
+      it { is_expected.to permit(depositor, work_version) }
+      it { is_expected.to permit(proxy, work_version) }
+      it { is_expected.to permit(edit_user, work_version) }
+      it { is_expected.to permit(admin, work_version) }
+      it { is_expected.not_to permit(other, work_version) }
+      it { is_expected.not_to permit(guest, work_version) }
+    end
+  end
+
   permissions :download? do
     let(:work_version) { work.latest_version }
 


### PR DESCRIPTION
As described by #856 there is a bug that allows public users (and logged in users who are not editors) to navigate to a draft version of a work via the version dropdown menu.

Likewise #823 shows that draft versions appear in the work history to public users and non-editors. 

This PR fixes both issues by adding a new method to `WorkVersionPolicy` that I called `#navigable?` that determines whether a user should be allowed to navigate to a given version. Note that this is totally distinct from `#edit?`—which completely denies the public to drafts, and `#show?`—which _allows_ the public (if they know the draft's uuid). 

This will also automagically work for withdrawn versions, but that can be tuned via `WorkVersionPolicy#navigable?`

- First commit closes #856 
- Second commit closes #823


![owner](https://user-images.githubusercontent.com/14730/112049117-94b6f080-8b25-11eb-8e26-a00634059058.png)

![public](https://user-images.githubusercontent.com/14730/112049128-9a143b00-8b25-11eb-867b-042975208364.png)

![public-with-uuid](https://user-images.githubusercontent.com/14730/112049144-9ed8ef00-8b25-11eb-8cd1-9ebf9a3e7688.png)
