### PR TITLE
Hotfix release 4.4.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,7 @@ Rails/SkipsModelValidations:
     - 'app/models/api_token.rb'
     - 'app/services/doi_service.rb'
     - 'spec/services/doi_service_spec.rb'
+    - 'spec/services/authorship_migration/collection_authorship_position_fix_spec.rb'
 
 RSpec/DescribeClass:
   Exclude:

--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -64,6 +64,7 @@ module Api::V1
             source: [],
             creators_attributes: [
               :display_name,
+              :position,
               actor_attributes: [
                 :email,
                 :given_name,

--- a/app/models/authorship.rb
+++ b/app/models/authorship.rb
@@ -11,6 +11,7 @@ class Authorship < ApplicationRecord
   accepts_nested_attributes_for :actor
 
   validates :display_name,
+            :position,
             presence: true
 
   after_initialize :set_defaults

--- a/app/services/authorship_migration/collection_authorship_position_fix.rb
+++ b/app/services/authorship_migration/collection_authorship_position_fix.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module AuthorshipMigration
+  class CollectionAuthorshipPositionFix
+    class << self
+      def call
+        errors = []
+
+        Collection.find_each do |collection|
+          update_collection_authorships(collection)
+        rescue StandardError => e
+          errors << "Collection##{collection.id}, #{e.message}"
+        end
+
+        errors.each { |e| puts e }
+        errors.empty?
+      end
+
+      def update_collection_authorships(collection)
+        return unless all_empty?(collection.creators)
+
+        collection.creators.sort_by(&:id).each_with_index do |authorship, index|
+          authorship.update(position: (index + 1) * 10, changed_by_system: true)
+        end
+      end
+
+      def all_empty?(authorships)
+        positions = authorships.map(&:position).uniq
+
+        if positions.length > 1 && positions.any?(nil)
+          raise StandardError, "can't be corrected"
+        else
+          positions == [nil]
+        end
+      end
+    end
+  end
+end

--- a/app/services/create_new_collection.rb
+++ b/app/services/create_new_collection.rb
@@ -33,7 +33,11 @@ class CreateNewCollection
                 Actor.find_or_create_by(actor_attributes)
               end
 
-      { display_name: attributes['display_name'], given_name: actor.given_name, surname: actor.surname, actor: actor }
+      { display_name: attributes['display_name'],
+        position: attributes['position'],
+        given_name: actor.given_name,
+        surname: actor.surname,
+        actor: actor }
     end
 
     params = metadata.to_hash.merge!(

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Api::V1::CollectionsController, type: :controller do
   let(:creator) do
     {
       display_name: "#{user.given_name} #{user.surname}",
+      position: 1,
       actor_attributes: {
         email: user.email,
         given_name: user.given_name,

--- a/spec/factories/authorships.rb
+++ b/spec/factories/authorships.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     surname { Faker::Name.last_name }
     display_name { "#{Faker::Name.prefix} #{given_name} #{surname}" }
     email { Faker::Internet.email(name: given_name) }
+    sequence(:position)
     of_work
 
     trait :of_work do

--- a/spec/models/authorship_spec.rb
+++ b/spec/models/authorship_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Authorship, type: :model do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:display_name) }
+    it { is_expected.to validate_presence_of(:position) }
   end
 
   describe 'default values' do

--- a/spec/services/authorship_migration/collection_authorship_position_fix_spec.rb
+++ b/spec/services/authorship_migration/collection_authorship_position_fix_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AuthorshipMigration::CollectionAuthorshipPositionFix, versioning: true do
+  let(:collection) { create :collection, :with_creators, creator_count: 3 }
+
+  context "when a collection's authorships are already correct" do
+    it 'does not change the positions' do
+      expect(collection.creators[0].position).to eq 0
+      expect(collection.creators[1].position).to eq 1
+      expect(collection.creators[2].position).to eq 2
+
+      return_val = nil
+      expect {
+        return_val = described_class.call
+      }.not_to change(PaperTrail::Version, :count)
+
+      expect(return_val).to eq true
+
+      collection.reload
+      expect(collection.creators[0].position).to eq 0
+      expect(collection.creators[1].position).to eq 1
+      expect(collection.creators[2].position).to eq 2
+    end
+  end
+
+  context "when a collection's authorships are all missing a position" do
+    before do
+      collection.creators.find_each do |authorship|
+        authorship.update_column(:position, nil)
+      end
+      collection.reload
+    end
+
+    it 'updates the positions' do
+      expect(collection.creators[0].position).to eq nil
+      expect(collection.creators[1].position).to eq nil
+      expect(collection.creators[2].position).to eq nil
+
+      return_val = nil
+      expect {
+        return_val = described_class.call
+      }.not_to(change {
+        PaperTrail::Version.where(changed_by_system: false).count
+      })
+
+      expect(return_val).to eq true
+
+      collection.reload
+      expect(collection.creators[0].position).to eq 10
+      expect(collection.creators[1].position).to eq 20
+      expect(collection.creators[2].position).to eq 30
+    end
+  end
+
+  context 'when something is very wrong' do
+    before do
+      collection.creators[0].update_column(:position, nil)
+      collection.reload
+    end
+
+    it 'reports the error' do
+      expect(collection.creators.map(&:position)).to match_array([nil, 1, 2])
+
+      return_val = nil
+      expect {
+        return_val = described_class.call
+      }.not_to(change {
+        PaperTrail::Version.where(changed_by_system: false).count
+      })
+
+      expect(return_val).to eq false
+
+      collection.reload
+      expect(collection.creators.map(&:position)).to match_array([nil, 1, 2])
+
+      expect { described_class.call }.to output(/Collection##{collection.id}, can't be corrected/i).to_stdout
+    end
+  end
+end

--- a/spec/services/create_new_collection_spec.rb
+++ b/spec/services/create_new_collection_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe CreateNewCollection do
                                                   creators_attributes: [
                                                     {
                                                       display_name: user.name,
+                                                      position: 1,
                                                       actor_attributes: {
                                                         email: user.email,
                                                         given_name: user.actor.given_name,
@@ -67,6 +68,7 @@ RSpec.describe CreateNewCollection do
                                                   creators_attributes: [
                                                     {
                                                       display_name: user.name,
+                                                      position: 1,
                                                       actor_attributes: {
                                                         email: user.email,
                                                         given_name: user.actor.given_name,
@@ -110,6 +112,7 @@ RSpec.describe CreateNewCollection do
                                                   creators_attributes: [
                                                     {
                                                       display_name: user.name,
+                                                      position: 1,
                                                       actor_attributes: {
                                                         email: user.email,
                                                         given_name: user.actor.given_name,
@@ -189,6 +192,7 @@ RSpec.describe CreateNewCollection do
                                                   creators_attributes: [
                                                     {
                                                       display_name: user.name,
+                                                      position: 1,
                                                       actor_attributes: {
                                                         email: user.email,
                                                         given_name: user.actor.given_name,


### PR DESCRIPTION
We need plug the nil Authorship position leak. This does so by requiring the field in the model, AND includes a script to update existing nil positions in collections. This all paves the way for #939, which can't be done until any existing nil fields are cleaned up.

We decided it's best to do this sooner rather than later. The database fix in #939 can wait until  a later release, but this initial fix which will prevent any further nil values should be pushed out now.