### PR TITLE
Require a md5 checksum for presigned urls

### DIFF
--- a/app/controllers/api/v1/uploads_controller.rb
+++ b/app/controllers/api/v1/uploads_controller.rb
@@ -2,9 +2,12 @@
 
 module Api::V1
   class UploadsController < RestController
+    # @return [String] json response sent to the client
+    # @note The content_md5 parameter is required because we always want our clients to include an md5 checksum of the
+    # files they are sending.
     def create
       render json: {
-        url: signer.presigned_url(:put_object, bucket: ENV['AWS_BUCKET'], key: key),
+        url: signer.presigned_url(:put_object, bucket: ENV['AWS_BUCKET'], key: key, content_md5: content_md5),
         id: id,
         prefix: prefix
       }
@@ -48,6 +51,10 @@ module Api::V1
 
       def extension
         params.require(:extension).gsub('.', '')
+      end
+
+      def content_md5
+        params.require(:content_md5)
       end
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -152,7 +152,14 @@ paths:
   /uploads:
     post:
       summary: "Requests a pre-signed URL to upload a file into ScholarSphere's S3 instance"
-
+      security:
+        - APIKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/uploads"
 
 # Array of Schema Objects used to define the concepts/models (see https://swagger.io/specification/#schemaObject)
 components:
@@ -354,6 +361,22 @@ components:
             active account in Penn State's identity management system.
         permissions:
           $ref: "#/components/schemas/permissions" 
+    uploads:
+      type: "object"
+      required:
+        - "extension"
+        - "content_md5"
+      properties:
+        extension:
+          type: "string"
+          description: >-
+            Three-letter file extension of the file your are requesting to upload into S3. This is used to created a
+            unique filename for the file in S3.
+        content_md5:
+          type: "string"
+          description: >-
+            Binary encoded md5 checksum of the file you are requesting to upload into S3. This is required so that we
+            can verify the integrity of the file when it is uploaded into S3.
     uploadedFile:
       type: "object"
     permissions:


### PR DESCRIPTION
Our client gem will automatically calculate checksums for files that we upload into S3, but our API must include the checksum when requesting the presigned URL. Instead of making the parameter optional, which would affect the behavior of the client, the parameter should just be required. This is better overall for data preservation and ensuring files make it into S3 correctly.

Fixes https://github.com/psu-stewardship/scholarsphere-client/issues/24