### PR TITLE
Fix bug where work was not indexed when hitting cancel on form

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -110,4 +110,5 @@ Style/MethodMissingSuper:
 Style/EmptyCaseCondition:
   Exclude:
     - 'app/services/doi_service.rb'
+    - 'app/controllers/dashboard/form/base_controller.rb'
 

--- a/app/controllers/dashboard/form/base_controller.rb
+++ b/app/controllers/dashboard/form/base_controller.rb
@@ -36,6 +36,10 @@ module Dashboard
           params.key?(:save_and_exit)
         end
 
+        def create?
+          @resource.new_record?
+        end
+
         def publish?
           params.key?(:publish)
         end
@@ -71,7 +75,9 @@ module Dashboard
         end
 
         def save_resource(index: true)
-          @resource.indexing_source = if (publish? || finish? || save_and_exit?) && index
+          should_index = (create? || publish? || finish? || save_and_exit?)
+
+          @resource.indexing_source = if should_index && index
                                         SolrIndexingJob.public_method(:perform_now)
                                       else
                                         null_indexer

--- a/app/controllers/dashboard/form/base_controller.rb
+++ b/app/controllers/dashboard/form/base_controller.rb
@@ -75,12 +75,15 @@ module Dashboard
         end
 
         def save_resource(index: true)
-          should_index = (create? || publish? || finish? || save_and_exit?)
+          index_synchronously = (create? || publish? || finish? || save_and_exit?)
 
-          @resource.indexing_source = if should_index && index
+          @resource.indexing_source = case
+                                      when !index
+                                        null_indexer
+                                      when index_synchronously
                                         SolrIndexingJob.public_method(:perform_now)
                                       else
-                                        null_indexer
+                                        SolrIndexingJob.public_method(:perform_later)
                                       end
           @resource.save
         end

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
   before do
     allow(SolrIndexingJob).to receive(:perform_now).and_call_original
+    allow(SolrIndexingJob).to receive(:perform_later)
   end
 
   describe 'The Work Details tab for a new work' do
@@ -33,7 +34,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(new_work_version.version_number).to eq 1
 
         expect(page).to have_current_path(resource_path(new_work_version.uuid))
-        expect(SolrIndexingJob).to have_received(:perform_now).twice
+        expect(SolrIndexingJob).to have_received(:perform_now).at_least(:once)
       end
     end
 
@@ -68,7 +69,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(new_work_version.source).to eq [metadata[:source]]
 
         expect(page).to have_current_path(dashboard_form_contributors_path('work_version', new_work_version))
-        expect(SolrIndexingJob).to have_received(:perform_now).twice
+        expect(SolrIndexingJob).to have_received(:perform_now).at_least(:once)
       end
     end
 
@@ -135,6 +136,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         expect(page).to have_current_path(dashboard_form_contributors_path('work_version', work_version))
         expect(SolrIndexingJob).not_to have_received(:perform_now)
+        expect(SolrIndexingJob).to have_received(:perform_later)
       end
     end
 
@@ -156,6 +158,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         expect(page).to have_current_path(dashboard_form_contributors_path('work_version', work_version))
         expect(SolrIndexingJob).not_to have_received(:perform_now)
+        expect(SolrIndexingJob).not_to have_received(:perform_later)
       end
     end
   end
@@ -191,6 +194,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         expect(page).to have_current_path(dashboard_form_files_path(work_version))
         expect(SolrIndexingJob).not_to have_received(:perform_now)
+        expect(SolrIndexingJob).to have_received(:perform_later)
       end
     end
 
@@ -271,6 +275,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         expect(page).to have_current_path(dashboard_form_files_path(work_version))
         expect(SolrIndexingJob).not_to have_received(:perform_now)
+        expect(SolrIndexingJob).to have_received(:perform_later)
       end
     end
 
@@ -312,6 +317,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         expect(page).to have_current_path(dashboard_form_files_path(work_version))
         expect(SolrIndexingJob).not_to have_received(:perform_now)
+        expect(SolrIndexingJob).to have_received(:perform_later)
       end
     end
 
@@ -360,6 +366,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         expect(page).to have_current_path(dashboard_form_files_path(work_version))
         expect(SolrIndexingJob).not_to have_received(:perform_now)
+        expect(SolrIndexingJob).to have_received(:perform_later)
       end
     end
 
@@ -389,6 +396,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(work_version.reload.creators.map(&:surname)).to contain_exactly(creators.last.surname)
         expect(page).to have_current_path(dashboard_form_files_path(work_version))
         expect(SolrIndexingJob).not_to have_received(:perform_now)
+        expect(SolrIndexingJob).to have_received(:perform_later)
       end
     end
 
@@ -465,7 +473,9 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         fill_in 'work_version_published_date', with: 'this is not a valid date'
         FeatureHelpers::DashboardForm.publish
+
         expect(SolrIndexingJob).not_to have_received(:perform_now)
+        expect(SolrIndexingJob).not_to have_received(:perform_later)
 
         expect(page).to have_current_path(dashboard_form_publish_path(work_version))
 

--- a/spec/support/feature_helpers/dashboard_form.rb
+++ b/spec/support/feature_helpers/dashboard_form.rb
@@ -113,6 +113,11 @@ module FeatureHelpers
       click_on I18n.t('dashboard.form.actions.destroy.button')
     end
 
+    def self.cancel
+      fix_sticky_footer
+      click_on I18n.t!('dashboard.form.actions.cancel')
+    end
+
     def self.fix_sticky_footer
       Capybara.current_session.current_window.resize_to(1000, 1000)
     rescue Capybara::NotSupportedByDriverError


### PR DESCRIPTION
Fixes #860

This was easy but made the work form feature tests explode, specifically the end-to-end ones, which were testing the indexing at every single step. 

I ended up removing some of these expectations from the "let's test the form end to end" specs, because they were already thoroughly tested in unit tests of each individual page on the form, and it was kind of confusing because the "this method was called X times" number keeps accumulating through the test. @awead I'll let you give the 👍 or 👎 to that.