### PR TITLE
Reindex works when updating

### DIFF
--- a/app/controllers/dashboard/works_controller.rb
+++ b/app/controllers/dashboard/works_controller.rb
@@ -4,6 +4,8 @@ module Dashboard
   class WorksController < BaseController
     layout 'frontend'
 
+    after_action :update_index, only: [:update]
+
     def edit
       @undecorated_work = Work.find(params[:id])
       authorize(@undecorated_work)
@@ -24,18 +26,13 @@ module Dashboard
       end
     end
 
-    # DELETE /works/1
-    # DELETE /works/1.json
-    def destroy
-      @work = current_user.works.find(params[:id])
-      @work.destroy
-      respond_to do |format|
-        format.html { redirect_to dashboard_root_path, notice: 'Work was successfully destroyed.' }
-        format.json { head :no_content }
-      end
-    end
-
     private
+
+      # @note Work indexing is largely handled via the WorkVersion and not the actual work. Placing a callback on the
+      # Work could interfere with that process, so instead we reindex the work directly here in the controller.
+      def update_index
+        WorkIndexer.call(@undecorated_work, commit: true)
+      end
 
       def initialize_forms
         @work = WorkDecorator.new(@undecorated_work)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,7 +81,7 @@ Rails.application.routes.draw do
 
     resource :profile, only: %i[edit update]
 
-    resources :works, only: %i[edit update destroy] do
+    resources :works, only: %i[edit update] do
       resources :work_versions, except: [:new], shallow: true do
         get 'file_list', to: 'file_lists#edit'
         put 'file_list', to: 'file_lists#update'

--- a/spec/controllers/dashboard/works_controller_spec.rb
+++ b/spec/controllers/dashboard/works_controller_spec.rb
@@ -90,48 +90,4 @@ RSpec.describe Dashboard::WorksController, type: :controller do
       it { is_expected.to redirect_to root_path }
     end
   end
-
-  describe 'DELETE #destroy' do
-    let(:users_work) { create :work, depositor: user.actor }
-    let(:someone_elses_work) { create :work }
-
-    context 'when signed in' do
-      before { sign_in user }
-
-      context 'when the user owns the work' do
-        let!(:work) { users_work }
-
-        it 'destroys the requested work' do
-          expect {
-            delete :destroy, params: { id: work.to_param }
-          }.to change(Work, :count).by(-1)
-        end
-
-        it 'redirects to the works list' do
-          delete :destroy, params: { id: work.to_param }
-          expect(response).to redirect_to(dashboard_root_path)
-        end
-      end
-
-      context 'when the user does not own the work' do
-        let!(:work) { someone_elses_work }
-
-        it '404s' do
-          expect {
-            delete :destroy, params: { id: work.to_param }
-          }.to raise_error(ActiveRecord::RecordNotFound)
-        end
-      end
-    end
-
-    context 'when not signed in' do
-      subject { response }
-
-      let!(:work) { users_work }
-
-      before { delete :destroy, params: { id: work.to_param } }
-
-      it { is_expected.to redirect_to root_path }
-    end
-  end
 end

--- a/spec/features/dashboard/work_settings_spec.rb
+++ b/spec/features/dashboard/work_settings_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe 'Work Settings Page', with_user: :user do
   let(:user) { create :user }
   let(:work) { create :work, versions_count: 1, has_draft: false, depositor: user.actor }
 
+  before do
+    allow(WorkIndexer).to receive(:call).and_call_original
+  end
+
   it 'is available from the resource page' do
     visit resource_path(work.uuid)
     click_on I18n.t('resources.settings_button.text', type: 'Work')
@@ -30,6 +34,7 @@ RSpec.describe 'Work Settings Page', with_user: :user do
 
       work.reload
       expect(work.visibility).to eq Permissions::Visibility::AUTHORIZED
+      expect(WorkIndexer).to have_received(:call)
     end
   end
 
@@ -52,6 +57,7 @@ RSpec.describe 'Work Settings Page', with_user: :user do
 
       work.reload
       expect(work.embargoed_until).to be_nil
+      expect(WorkIndexer).to have_received(:call).twice
     end
   end
 
@@ -95,6 +101,7 @@ RSpec.describe 'Work Settings Page', with_user: :user do
 
         work.reload
         expect(work.edit_users.map(&:uid)).to contain_exactly('agw13')
+        expect(WorkIndexer).to have_received(:call)
       end
     end
 
@@ -111,6 +118,7 @@ RSpec.describe 'Work Settings Page', with_user: :user do
 
         work.reload
         expect(work.edit_users).to be_empty
+        expect(WorkIndexer).to have_received(:call)
       end
     end
 
@@ -125,6 +133,7 @@ RSpec.describe 'Work Settings Page', with_user: :user do
 
         work.reload
         expect(work.edit_users).to be_empty
+        expect(WorkIndexer).to have_received(:call)
       end
     end
 
@@ -142,6 +151,7 @@ RSpec.describe 'Work Settings Page', with_user: :user do
 
         work.reload
         expect(work.edit_groups).to contain_exactly(group)
+        expect(WorkIndexer).to have_received(:call)
       end
     end
   end


### PR DESCRIPTION
Adds a callback to Dashboard::WorksController so that works are reindexed when they are updated. Note that the callback is not added to the Work model because this could cause unintended side effect when reindexing work versions, which also reindex their associated works.

The #destroy endpoint is removed from the controller as well since it is not used. Works are removed via calls to their work version.

Fixes #957
Fixes #955 
Fixes #940
