### PR TITLE
Resource description supports markdown

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,7 @@ Rails/SkipsModelValidations:
 Rails/OutputSafety:
   Exclude:
     - 'app/components/base_metadata_component.rb'
+    - 'app/decorators/resource_decorator.rb'
 
 RSpec/DescribeClass:
   Exclude:

--- a/app/decorators/resource_decorator.rb
+++ b/app/decorators/resource_decorator.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ResourceDecorator < SimpleDelegator
+  include ActionView::Helpers::SanitizeHelper
+
   # @returns an appropriately-decorated object. This is a factory method
   def self.decorate(resource)
     return WorkVersionDecorator.new(resource) if resource.is_a? WorkVersion
@@ -29,6 +31,30 @@ class ResourceDecorator < SimpleDelegator
 
   def partial_name
     model_name.singular
+  end
+
+  def description_html
+    return unless respond_to?(:description)
+    return '' if description.blank?
+
+    markdown = Redcarpet::Markdown.new(
+      Redcarpet::Render::HTML.new(
+        with_toc_data: false,
+        filter_html: true,
+        no_styles: true,
+        safe_links_only: true,
+        prettify: false,
+        no_images: true
+      ),
+      autolink: true,
+      tables: false
+    )
+    markdown.render(description).html_safe
+  end
+
+  def description_plain_text
+    strip_tags(description_html)
+      .strip # Remove any leading or trailing whitspace
   end
 
   def display_work_type

--- a/app/decorators/resource_decorator.rb
+++ b/app/decorators/resource_decorator.rb
@@ -37,19 +37,7 @@ class ResourceDecorator < SimpleDelegator
     return unless respond_to?(:description)
     return '' if description.blank?
 
-    markdown = Redcarpet::Markdown.new(
-      Redcarpet::Render::HTML.new(
-        with_toc_data: false,
-        filter_html: true,
-        no_styles: true,
-        safe_links_only: true,
-        prettify: false,
-        no_images: true
-      ),
-      autolink: true,
-      tables: false
-    )
-    markdown.render(description).html_safe
+    @description_html ||= render_markdown(description)
   end
 
   def description_plain_text
@@ -86,4 +74,24 @@ class ResourceDecorator < SimpleDelegator
       creators.take(3)
     end
   end
+
+  private
+
+    def render_markdown(str)
+      markdown = Redcarpet::Markdown.new(
+        Redcarpet::Render::HTML.new(
+          with_toc_data: false,
+          filter_html: true,
+          no_styles: true,
+          safe_links_only: true,
+          prettify: false,
+          no_images: true
+        ),
+        autolink: true,
+        tables: false
+      )
+      markdown.render(str).html_safe
+    rescue StandardError
+      str
+    end
 end

--- a/app/views/resources/_collection.html.erb
+++ b/app/views/resources/_collection.html.erb
@@ -28,7 +28,7 @@
   <article class="row">
     <div class="col-lg-7">
       <h1 class="h2 mb-3"><%= collection.title %></h1>
-      <p><%= collection.description %></p>
+      <p><%= collection.description_html %></p>
 
       <div class="keyline keyline--left mb-3">
         <h2 class="h4"><%= t('resources.works') %></h2>

--- a/app/views/resources/_meta_tags.html.erb
+++ b/app/views/resources/_meta_tags.html.erb
@@ -5,7 +5,7 @@
 <meta property="og:site_name" content="ScholarSphere">
 <meta property="og:type" content="object">
 <meta property="og:title" content="<%= resource.title %>">
-<meta property="og:description" content="<%= resource.description %>">
+<meta property="og:description" content="<%= resource.description_plain_text %>">
 <meta property="og:url" content="<%= resource_url(uuid) %>">
 
 <%= render GoogleScholarMetadataComponent.new(resource: resource, policy: policy(resource)) %>

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -59,7 +59,7 @@
   <article class="row">
     <div class="col-lg-7">
       <h1 class="h2 mb-3"><%= work_version.title %></h1>
-      <p><%= work_version.description %></p>
+      <p><%= work_version.description_html %></p>
 
       <div class="keyline keyline--left mb-3">
         <h2 class="h4"><%= t('resources.files') %></h2>

--- a/spec/decorators/resource_decorator_spec.rb
+++ b/spec/decorators/resource_decorator_spec.rb
@@ -232,6 +232,17 @@ RSpec.describe ResourceDecorator do
 
       it { is_expected.to eq '' }
     end
+
+    context 'when given something that explodes' do
+      before do
+        allow(Redcarpet::Markdown).to receive(:new).and_raise
+      end
+
+      it 'traps the error and returns the original string' do
+        expect(description_html).to eq resource.description
+        expect(description_html).not_to be_html_safe
+      end
+    end
   end
 
   describe '#description_plain_text' do
@@ -247,6 +258,7 @@ RSpec.describe ResourceDecorator do
 
     it 'returns plain text, without any markdown or html formatting' do
       expect(description_plain_text).to eq 'This is marked down'
+      expect(description_plain_text).not_to be_html_safe
     end
 
     context 'when given nil' do

--- a/spec/decorators/resource_decorator_spec.rb
+++ b/spec/decorators/resource_decorator_spec.rb
@@ -176,4 +176,85 @@ RSpec.describe ResourceDecorator do
       its(:first_creators) { is_expected.to eq(resource.creators.take(3) + ['&hellip;']) }
     end
   end
+
+  describe '#description_html' do
+    subject(:description_html) { decorator.description_html }
+
+    let(:parsed) { Nokogiri::HTML(description_html) }
+    let(:resource) { instance_spy('WorkVersion') }
+
+    before do
+      allow(resource).to receive(:description).and_return(<<-MARKDOWN.strip_heredoc)
+        This is my first paragraph, which is *emphasized*.
+
+        This is my second paragraph with has a [link](https://scholarsphere.psu.edu)
+
+        And this is my third paragraph which has an autolink to https://google.com
+
+        This paragraph has <h1>sneaky html</h1>
+      MARKDOWN
+    end
+
+    it 'renders the description into markdown' do
+      expect(description_html).to be_html_safe
+
+      expect(parsed.css('p').length).to eq 4
+
+      parsed.css('p').first.tap do |first_paragraph|
+        expect(first_paragraph.css('em').text).to eq 'emphasized'
+      end
+    end
+
+    it 'supports explicit links' do
+      parsed.css('p')[1].tap do |second_paragraph|
+        expect(second_paragraph.css('a').text).to eq 'link'
+        expect(second_paragraph.css('a')[0]['href']).to eq 'https://scholarsphere.psu.edu'
+      end
+    end
+
+    it 'supports autolinks' do
+      parsed.css('p')[2].tap do |third_paragraph|
+        expect(third_paragraph.css('a').text).to eq 'https://google.com'
+        expect(third_paragraph.css('a')[0]['href']).to eq 'https://google.com'
+      end
+    end
+
+    it 'does not allow html' do
+      parsed.css('p')[3].tap do |fourth_paragraph|
+        expect(fourth_paragraph.css('h1').text).to be_empty
+      end
+    end
+
+    context 'when given nil' do
+      before do
+        allow(resource).to receive(:description).and_return(nil)
+      end
+
+      it { is_expected.to eq '' }
+    end
+  end
+
+  describe '#description_plain_text' do
+    subject(:description_plain_text) { decorator.description_plain_text }
+
+    let(:resource) { instance_spy('WorkVersion') }
+
+    before do
+      allow(resource).to receive(:description).and_return(
+        'This *is* _marked_ [down](http://psu.edu)'
+      )
+    end
+
+    it 'returns plain text, without any markdown or html formatting' do
+      expect(description_plain_text).to eq 'This is marked down'
+    end
+
+    context 'when given nil' do
+      before do
+        allow(resource).to receive(:description).and_return(nil)
+      end
+
+      it { is_expected.to eq '' }
+    end
+  end
 end


### PR DESCRIPTION
I'm not sure if this is exactly what @awead had in mind regarding the decorators

Closes #959 

![Screen Shot 2021-03-31 at 2 08 25 PM](https://user-images.githubusercontent.com/14730/113207248-62507600-923e-11eb-9912-ce43f81585b1.png)
![Screen Shot 2021-03-31 at 2 08 45 PM](https://user-images.githubusercontent.com/14730/113207254-62e90c80-923e-11eb-8499-c3b9768ba73f.png)

## Plain-texterization

`og:description` should maybe be plain text? There's a plain text method in the decorator to do this:

![Screen Shot 2021-04-02 at 11 03 40 AM](https://user-images.githubusercontent.com/14730/113427565-40bccf00-93a3-11eb-8f41-c48e9e461aa4.png)
---
![Screen Shot 2021-04-02 at 11 03 46 AM](https://user-images.githubusercontent.com/14730/113427570-431f2900-93a3-11eb-9510-6226186ada94.png)
---
![Screen Shot 2021-04-02 at 11 04 00 AM](https://user-images.githubusercontent.com/14730/113427573-44e8ec80-93a3-11eb-9779-ce11042a97e8.png)

