### PR TITLE
Correct field searching

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -182,23 +182,11 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('author') do |field|
+    config.add_search_field('creator') do |field|
       field.solr_parameters = {
-        'spellcheck.dictionary': 'author',
-        qf: '${author_qf}',
-        pf: '${author_pf}'
-      }
-    end
-
-    # Specifying a :qt only to show it's possible, and so our internal automated
-    # tests can test it. In this case it's the same as
-    # config[:default_solr_parameters][:qt], so isn't actually neccesary.
-    config.add_search_field('subject') do |field|
-      field.qt = 'search'
-      field.solr_parameters = {
-        'spellcheck.dictionary': 'subject',
-        qf: '${subject_qf}',
-        pf: '${subject_pf}'
+        'spellcheck.dictionary': 'creator',
+        qf: '${creator_qf}',
+        pf: '${creator_pf}'
       }
     end
 

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -6,36 +6,26 @@
 
     <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
 
-    <% if search_fields.length > 1 %>
-      <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
-    <% end %>
+    <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
 
     <div class="input-group input-group--icon">
-      <% if search_fields.length > 1 %>
-        <%= select_tag(:search_field,
-                       options_for_select(search_fields, h(params[:search_field])),
-                       title: t('blacklight.search.form.search_field.title'),
-                       id: 'search_field',
-                       class: 'custom-select') %>
-      <% elsif search_fields.length == 1 %>
-          <%= hidden_field_tag :search_field, search_fields.first.last %>
-      <% end %>
+      <%= select_tag(:search_field,
+                     options_for_select(search_fields, h(params[:search_field])),
+                     title: t('blacklight.search.form.search_field.title'),
+                     id: 'search_field',
+                     class: 'custom-select') %>
 
       <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
 
       <%= text_field_tag :q, params[:q],
                          placeholder: t('blacklight.search.form.search.placeholder'),
                          class: 'form-control',
-                         id: 'q',
-                         autocomplete: presenter.autocomplete_enabled? ? 'off' : '',
-                         autofocus: presenter.autofocus?,
-                         data: {
-                           autocomplete_enabled: presenter.autocomplete_enabled?,
-                           autocomplete_path: search_action_path(action: :suggest)
-                         } %>
+                         id: 'q' %>
 
       <div class="input-group-append">
-        <button class="btn btn-primary" type="button"><i class="material-icons">search</i></button>
+        <%= button_tag type: 'submit', class: 'btn btn-primary' do %>
+          <i class="material-icons">search</i>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <config>
   <!-- NOTE: various comments and unused configuration possibilities have been purged
-     from this file.  Please refer to http://wiki.apache.org/solr/SolrConfigXml,
-     as well as the default solrconfig file included with Solr -->
+    from this file.  Please refer to http://wiki.apache.org/solr/SolrConfigXml,
+  as well as the default solrconfig file included with Solr -->
 
   <abortOnConfigurationError>${solr.abortOnConfigurationError:true}</abortOnConfigurationError>
 
@@ -24,76 +24,76 @@
 
   <requestHandler name="search" class="solr.SearchHandler" default="true">
     <!-- default values for query parameters can be specified, these
-         will be overridden by parameters in the request
+      will be overridden by parameters in the request
+    -->
+    <lst name="defaults">
+      <str name="defType">edismax</str>
+      <str name="echoParams">explicit</str>
+      <str name="q.alt">*:*</str>
+      <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+      <int name="qs">1</int>
+      <int name="ps">2</int>
+      <float name="tie">0.01</float>
+      <!-- this qf and pf are used by default, if not otherwise specified by
+        client. The default blacklight_config will use these for the
+        "keywords" search. See the creator_qf/creator_pf, title_qf, etc
+        below, which the default blacklight_config will specify for
+        those searches. You may also be interested in:
+        http://wiki.apache.org/solr/LocalParams
       -->
-     <lst name="defaults">
-       <str name="defType">edismax</str>
-       <str name="echoParams">explicit</str>
-       <str name="q.alt">*:*</str>
-       <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
-       <int name="qs">1</int>
-       <int name="ps">2</int>
-       <float name="tie">0.01</float>
-       <!-- this qf and pf are used by default, if not otherwise specified by
-            client. The default blacklight_config will use these for the
-            "keywords" search. See the author_qf/author_pf, title_qf, etc
-            below, which the default blacklight_config will specify for
-            those searches. You may also be interested in:
-            http://wiki.apache.org/solr/LocalParams
-       -->
-        <str name="qf">
-          id
-          full_title_tsim
-          short_title_tsim
-          alternative_title_tsim
-          active_fedora_model_ssi
-          title_tsim
-          author_tsim
-          subject_tsim
-          all_text_timv
-        </str>
-        <str name="pf">
-          all_text_timv^10
-        </str>
+      <str name="qf">
+        all_dois_ssim
+        based_near_tesim
+        contributor_tesim
+        creators_tesim
+        id
+        identifier_tesim
+        keyword_tesim
+        language_tesim
+        published_date_tesim
+        publisher_tesim
+        rights_tesim
+        source_tesim
+        subject_tesim
+        subtitle_tesim
+        title_tesim
+        work_type_ss
+      </str>
+      <str name="pf">
+        all_text_timv^10
+      </str>
 
-       <str name="author_qf">
-          author_tsim
-       </str>
-       <str name="author_pf">
-       </str>
-       <str name="title_qf">
-          title_tsim
-          full_title_tsim
-          short_title_tsim
-          alternative_title_tsim
-       </str>
-       <str name="title_pf">
-       </str>
-       <str name="subject_qf">
-          subject_tsim
-       </str>
-       <str name="subject_pf">
-       </str>
+      <str name="creator_qf">
+        creators_tesim
+      </str>
+      <str name="creator_pf">
+      </str>
+      <str name="title_qf">
+        title_tesim^10
+        subtitle_tesim
+      </str>
+      <str name="title_pf">
+      </str>
 
-       <str name="fl">
-         *,
-         score
-       </str>
+      <str name="fl">
+        *,
+        score
+      </str>
 
-       <str name="facet">true</str>
-       <str name="facet.mincount">1</str>
-       <str name="facet.limit">10</str>
-       <str name="facet.field">active_fedora_model_ssi</str>
-       <str name="facet.field">subject_ssim</str>
+      <str name="facet">true</str>
+      <str name="facet.mincount">1</str>
+      <str name="facet.limit">10</str>
+      <str name="facet.field">active_fedora_model_ssi</str>
+      <str name="facet.field">subject_ssim</str>
 
-       <str name="spellcheck">true</str>
-       <str name="spellcheck.dictionary">default</str>
-       <str name="spellcheck.onlyMorePopular">true</str>
-       <str name="spellcheck.extendedResults">true</str>
-       <str name="spellcheck.collate">false</str>
-       <str name="spellcheck.count">5</str>
+      <str name="spellcheck">true</str>
+      <str name="spellcheck.dictionary">default</str>
+      <str name="spellcheck.onlyMorePopular">true</str>
+      <str name="spellcheck.extendedResults">true</str>
+      <str name="spellcheck.collate">false</str>
+      <str name="spellcheck.count">5</str>
 
-     </lst>
+    </lst>
     <arr name="last-components">
       <str>spellcheck</str>
     </arr>
@@ -123,10 +123,10 @@
   </requestHandler>
 
   <requestHandler name="standard" class="solr.SearchHandler">
-     <lst name="defaults">
-       <str name="echoParams">explicit</str>
-       <str name="defType">lucene</str>
-     </lst>
+    <lst name="defaults">
+      <str name="echoParams">explicit</str>
+      <str name="defType">lucene</str>
+    </lst>
   </requestHandler>
 
 
@@ -134,7 +134,7 @@
     <str name="queryAnalyzerFieldType">textSpell</str>
     <!-- Multiple "Spell Checkers" can be declared and used by this component
       (e.g. for title_spell field)
-      -->
+    -->
     <lst name="spellchecker">
       <str name="name">default</str>
       <str name="field">spell</str>
@@ -142,9 +142,9 @@
       <str name="buildOnOptimize">true</str>
     </lst>
     <lst name="spellchecker">
-      <str name="name">author</str>
-      <str name="field">author_spell</str>
-      <str name="spellcheckIndexDir">./spell_author</str>
+      <str name="name">creator</str>
+      <str name="field">creator_spell</str>
+      <str name="spellcheckIndexDir">./spell_creator</str>
       <str name="accuracy">0.7</str>
       <str name="buildOnOptimize">true</str>
     </lst>

--- a/spec/features/catalog/catalog_spec.rb
+++ b/spec/features/catalog/catalog_spec.rb
@@ -119,6 +119,26 @@ RSpec.describe 'Blacklight catalog page', :inline_jobs do
     expect(page).to have_css('td.work-version-subtitle', text: work_version.subtitle)
   end
 
+  context 'when searching specific fields' do
+    it 'searches by title' do
+      visit search_catalog_path
+      select('Title', from: 'search_field')
+      fill_in('q', with: work_version.title.split(' ').sample)
+      click_button('search')
+
+      expect(page).to have_content(work_version.title)
+    end
+
+    it 'searches by creator' do
+      visit search_catalog_path
+      select('Creator', from: 'search_field')
+      fill_in('q', with: work_version.creators[0].display_name.split(' ').sample)
+      click_button('search')
+
+      expect(page).to have_content(work_version.title)
+    end
+  end
+
   context 'when the search returns no results' do
     it 'displays no search results', with_user: :user do
       visit(search_catalog_path(q: 'asdfasdfasdfasdfasdfasdfasdf'))


### PR DESCRIPTION
Searching by title was broken due to a mis-configured Solr, and a bug in the search form. This corrects both issues, removes subject searching, and replaces an Author search with a Creator search.

This also updates the default qf parameter in the Solr config. Although, this is unlikely to have any impact since Blacklight sends qf values to Solr at query time. However, it seemed a good idea to go ahead and update these values with reasonable defaults: the _tesim field of our main metadata fields. This will ensure any queries without an explicit qf value will search our most common fields.

Fixes #965