### PR TITLE
Sortable title field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -195,7 +195,7 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     config.add_sort_field 'score desc, deposited_at_dtsi desc', label: 'relevance'
-    config.add_sort_field 'title_tesim asc', label: 'title'
+    config.add_sort_field 'title_ssort asc', label: 'title'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/controllers/dashboard/catalog_controller.rb
+++ b/app/controllers/dashboard/catalog_controller.rb
@@ -59,7 +59,7 @@ module Dashboard
 
       config.add_sort_field 'updated_at_dtsi desc', label: 'most recent'
       config.add_sort_field 'score desc', label: 'relevance'
-      config.add_sort_field 'title_tesim asc', label: 'title'
+      config.add_sort_field 'title_ssort asc', label: 'title'
     end
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -164,7 +164,8 @@ class Collection < ApplicationRecord
         PublishedDateSchema,
         FacetSchema,
         WorkTypeSchema,
-        DoiSchema
+        DoiSchema,
+        TitleSchema
       )
     end
 end

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -279,7 +279,8 @@ class WorkVersion < ApplicationRecord
         CreatorSchema,
         PublishedDateSchema,
         FacetSchema,
-        DoiSchema
+        DoiSchema,
+        TitleSchema
       )
     end
 end

--- a/app/schemas/latest_published_version_schema.rb
+++ b/app/schemas/latest_published_version_schema.rb
@@ -9,6 +9,7 @@ class LatestPublishedVersionSchema < BaseSchema
       .merge(creator_schema.document)
       .merge(published_date_schema.document)
       .merge(facet_schema.document)
+      .merge(title_schema.document)
   end
 
   private
@@ -23,5 +24,9 @@ class LatestPublishedVersionSchema < BaseSchema
 
     def facet_schema
       FacetSchema.new(resource: resource.latest_published_version)
+    end
+
+    def title_schema
+      TitleSchema.new(resource: resource.latest_published_version)
     end
 end

--- a/app/schemas/title_schema.rb
+++ b/app/schemas/title_schema.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class TitleSchema < BaseSchema
+  STOPWORDS = %w[
+    a
+    an
+    the
+  ].freeze
+
+  def document
+    return {} unless resource.respond_to?(:title)
+
+    words = resource.title.downcase.gsub(/[^a-z0-9 ]/, '').split(' ')
+    words.rotate!(1) if STOPWORDS.include?(words[0])
+
+    {
+      title_ssort: words.join(' ')
+    }
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -215,6 +215,7 @@ RSpec.describe Collection, type: :model do
         subject_sim
         subject_tesim
         subtitle_tesim
+        title_ssort
         title_tesim
         updated_at_dtsi
         uuid_ssi

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -358,6 +358,7 @@ RSpec.describe Work, type: :model do
           subject_sim
           subject_tesim
           subtitle_tesim
+          title_ssort
           title_tesim
           updated_at_dtsi
           uuid_ssi

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -311,6 +311,7 @@ RSpec.describe WorkVersion, type: :model do
     its(:to_solr) do
       is_expected.to include(
         all_dois_ssim: an_instance_of(Array),
+        title_ssort: kind_of(String),
         title_tesim: [work_version.title],
         latest_version_bsi: false,
         display_work_type_ssi: Work::Types.display(work_version.work_type),

--- a/spec/schemas/title_schema_spec.rb
+++ b/spec/schemas/title_schema_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TitleSchema, type: :schema do
+  let(:schema) { described_class.new(resource: resource) }
+
+  describe '#document' do
+    context 'when the title has stopwords' do
+      subject { schema.document[:title_ssort] }
+
+      let(:resource) { create(:work_version, title: 'The Curious Case of Benjamin Button') }
+
+      it { is_expected.to eq('curious case of benjamin button the') }
+    end
+
+    context 'when the title has punctuation' do
+      subject { schema.document[:title_ssort] }
+
+      let(:resource) { create(:work_version, title: "\"...The play's the thing.\": Shakespeare's 1601 Hamlet") }
+
+      it { is_expected.to eq('plays the thing shakespeares 1601 hamlet the') }
+    end
+  end
+end


### PR DESCRIPTION
Creates a special title field for sorting. Punctuation is removed and stopwords are moved to the end of the title.

Fixes #771 