### PR TITLE
Ignore first 'and' when sorting titles

### DIFF
--- a/app/schemas/title_schema.rb
+++ b/app/schemas/title_schema.rb
@@ -4,6 +4,7 @@ class TitleSchema < BaseSchema
   STOPWORDS = %w[
     a
     an
+    and
     the
   ].freeze
 


### PR DESCRIPTION
Adds 'and' to the list of leading stopwords to ignore when alphabetizing titles.