### PR TITLE
Index works async when saved

### DIFF
--- a/app/controllers/dashboard/works_controller.rb
+++ b/app/controllers/dashboard/works_controller.rb
@@ -4,8 +4,6 @@ module Dashboard
   class WorksController < BaseController
     layout 'frontend'
 
-    after_action :update_index, only: [:update]
-
     def edit
       @undecorated_work = Work.find(params[:id])
       authorize(@undecorated_work)
@@ -27,12 +25,6 @@ module Dashboard
     end
 
     private
-
-      # @note Work indexing is largely handled via the WorkVersion and not the actual work. Placing a callback on the
-      # Work could interfere with that process, so instead we reindex the work directly here in the controller.
-      def update_index
-        WorkIndexer.call(@undecorated_work, commit: true)
-      end
 
       def initialize_forms
         @work = WorkDecorator.new(@undecorated_work)

--- a/app/models/concerns/indexing.rb
+++ b/app/models/concerns/indexing.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Indexing
+  extend ActiveSupport::Concern
+
+  included do
+    attr_writer :indexing_source
+
+    after_save :perform_update_index
+  end
+
+  def indexing_source
+    @indexing_source ||= SolrIndexingJob.public_method(:perform_later)
+  end
+
+  private
+
+    def perform_update_index
+      indexing_source.call(self)
+    end
+end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -4,6 +4,7 @@ class Work < ApplicationRecord
   include Permissions
   include DepositedAtTimestamp
   include AllDois
+  include Indexing
 
   fields_with_dois :doi
 

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -475,7 +475,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         FeatureHelpers::DashboardForm.publish
 
         expect(SolrIndexingJob).not_to have_received(:perform_now)
-        expect(SolrIndexingJob).not_to have_received(:perform_later)
+        expect(SolrIndexingJob).to have_received(:perform_later).once
 
         expect(page).to have_current_path(dashboard_form_publish_path(work_version))
 

--- a/spec/fixtures/vcr_cassettes/Work_Settings_Page/Updating_Editors/when_the_user_does_not_exist/does_NOT_add_the_user_as_an_editor.yml
+++ b/spec/fixtures/vcr_cassettes/Work_Settings_Page/Updating_Editors/when_the_user_does_not_exist/does_NOT_add_the_user_as_an_editor.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Thu, 25 Feb 2021 19:38:45 GMT
+      - Fri, 09 Apr 2021 18:12:42 GMT
       Content-Type:
       - application/vnd-psu.edu-v1+json
       Content-Length:
@@ -29,21 +29,21 @@ http_interactions:
       X-Content-Security-Policy:
       - frame-ancestors 'none'
       Set-Cookie:
-      - JSESSIONID=vGOYICLf4X3qumKeJbhlDKsPXXGFOX36b1YMR3Er.search-service-7cbccc979b-6n9bd;
+      - JSESSIONID=VAq6dtZVwtAmVCbLKWaeGhHSF1Cvc-p8KfPK6MVa.search-service-7cbccc979b-rzz4b;
         path=/search-service
       X-Request-Id:
-      - 3f1edefecea3592eb6f7533353dd640a
+      - c1d25f9d6ef5e0455afcd6b78e0b6de9
       X-Frame-Options:
       - DENY
       Content-Security-Policy:
       - frame-ancestors 'none'
       Uniqueid:
-      - bf57ead5-2a12-411d-8c59-5054af45cc22
+      - 01c783f9-5a80-4c2b-9094-cc5c01f125d5
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"status":{"code":404,"message":"NOT_FOUND"},"errorMessage":["No person
         matched the input userid: iamnotpennstate"],"link":null}'
-  recorded_at: Thu, 25 Feb 2021 19:38:45 GMT
+  recorded_at: Fri, 09 Apr 2021 18:12:42 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
Works will always index into Solr when they are saved. This makes it consistent with work versions and collections.