### PR TITLE
Validate work versions for uniqueness

### DIFF
--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -139,6 +139,9 @@ class WorkVersion < ApplicationRecord
             presence: true,
             if: :published?
 
+  validates_with ChangedWorkVersionValidator,
+                 if: :published?
+
   after_save :perform_update_index
 
   attr_accessor :force_destroy

--- a/app/validators/changed_work_version_validator.rb
+++ b/app/validators/changed_work_version_validator.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# @abstract Determines if a given work version is different from its previous version. A work version is different if
+# it has different values for any of its metadata attributes, or has different file resources.
+
+class ChangedWorkVersionValidator < ActiveModel::Validator
+  attr_reader :work_version
+
+  def validate(record)
+    @work_version = record
+
+    if identical?
+      record.errors.add(:work_version, 'is the same as the previous version')
+    end
+  end
+
+  private
+
+    def identical?
+      return false if previous_version.nil?
+
+      (work_version.file_resources == previous_version.file_resources) &&
+        (metadata_token == metadata_token(previous_version))
+    end
+
+    def previous_version
+      WorkVersion.find_by(
+        work_id: work_version.work_id,
+        version_number: work_version.version_number - 1
+      )
+    end
+
+    def metadata_token(version = nil)
+      version ||= work_version
+
+      Digest::MD5.hexdigest(
+        version
+          .metadata
+          .values
+          .flatten
+          .compact
+          .sort
+          .join
+      )
+    end
+end

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -114,6 +114,28 @@ RSpec.describe WorkVersion, type: :model do
         expect(work_version).to allow_value('1999-uu-uu').for(:published_date)
         expect(work_version).not_to allow_value('not an EDTF formatted date').for(:published_date)
       end
+
+      context 'when publishing an idential work version' do
+        subject(:work_version) { BuildNewWorkVersion.call(work.versions[0]) }
+
+        let(:work) { create(:work, has_draft: false) }
+
+        it 'validates if the new version is identical to the previous one' do
+          work_version.validate
+          expect(work_version.errors[:work_version]).to eq(['is the same as the previous version'])
+        end
+      end
+
+      context 'when publishing an idential third work version' do
+        subject(:work_version) { BuildNewWorkVersion.call(work.versions[1]) }
+
+        let(:work) { create(:work, has_draft: false, versions_count: 2) }
+
+        it 'validates if the new version is identical to the previous one' do
+          work_version.validate
+          expect(work_version.errors[:work_version]).to eq(['is the same as the previous version'])
+        end
+      end
     end
 
     context 'with the version number' do

--- a/spec/validators/changed_work_version_validator_spec.rb
+++ b/spec/validators/changed_work_version_validator_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ChangedWorkVersionValidator, type: :validator do
+  let(:work) { create(:work, has_draft: false) }
+  let(:old_version) { work.versions[0] }
+  let(:new_version) { BuildNewWorkVersion.call(work.versions[0]) }
+  let(:validator) { described_class.new }
+
+  context 'when the versions are identical' do
+    before do
+      new_version.save
+      new_version.reload
+      validator.validate(new_version)
+    end
+
+    specify do
+      expect(new_version.errors.full_messages).to include('Work version is the same as the previous version')
+    end
+  end
+
+  context 'when the versions have the same files and different metadata' do
+    before do
+      new_version.save
+      new_version.reload
+      new_version.title = FactoryBotHelpers.work_title
+      validator.validate(new_version)
+    end
+
+    specify do
+      expect(old_version.title).not_to eq(new_version.title)
+      expect(old_version.file_resources).to eq(new_version.file_resources)
+      expect(new_version.errors).to be_empty
+    end
+  end
+
+  context 'when the versions have different files and the same metadata' do
+    before do
+      new_version.save
+      new_version.reload
+      new_version.file_resources = build_list(:file_resource, 1)
+      validator.validate(new_version)
+    end
+
+    specify do
+      expect(old_version.title).to eq(new_version.title)
+      expect(old_version.file_resources).not_to eq(new_version.file_resources)
+      expect(new_version.errors).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
A work version is identical to another if it has the same metadata and the same files. We want to prevent users from publishing new versions of works that don't have any perceptible changes to them. This validation will happen when publishing, and unless the user has changed something in the new version, they won't be able to publish it.

Fixes #721 