### PR TITLE
Redirect to resource page on save and publish

### DIFF
--- a/app/controllers/dashboard/form/base_controller.rb
+++ b/app/controllers/dashboard/form/base_controller.rb
@@ -49,8 +49,12 @@ module Dashboard
         end
 
         def redirect_upon_success
-          if save_and_exit?
-            redirect_to resource_path(@resource.uuid), notice: "#{@resource.model_name.human} was successfully updated."
+          if save_and_exit? || finish?
+            redirect_to resource_path(@resource.uuid),
+                        notice: I18n.t('dashboard.form.notices.success', resource: @resource.model_name.human)
+          elsif publish?
+            redirect_to resource_path(@resource.work.uuid),
+                        notice: I18n.t('dashboard.form.notices.publish')
           else
             redirect_to next_page_path
           end

--- a/app/controllers/dashboard/form/members_controller.rb
+++ b/app/controllers/dashboard/form/members_controller.rb
@@ -43,10 +43,6 @@ module Dashboard
             max_documents: 10_000
           )
         end
-
-        def redirect_upon_success
-          redirect_to dashboard_root_path, notice: 'Collection was updated successfully'
-        end
     end
   end
 end

--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -56,15 +56,6 @@ module Dashboard
           resource.aasm_state = initial_state
         end
 
-        def redirect_upon_success
-          notice = if publish?
-                     'Successfully published work!'
-                   else
-                     'Work version was successfully updated.'
-                   end
-          redirect_to dashboard_root_path, notice: notice
-        end
-
         def work_version_params
           params
             .require(:work_version)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -324,11 +324,15 @@ en:
           draft: Draft
           work_version: Version
           confirm: "Are you sure you want to delete this %{type}? This cannot be undone."
+      notices:
+        success: "%{resource} was successfully updated."
+        publish: Successfully published work!
       details:
         about_collections: 
           label: About Collections
           message: >
-            Collections provide additional context for your related work. For example, a research group can use a collection to organize published reports and datasets.
+            Collections provide additional context for your related work. For example, a research group can use a
+            collection to organize published reports and datasets.
         required_metadata: Required Metadata
         required_to_publish_metadata: Needed to Publish
         additional_metadata: Optional Metadata

--- a/spec/features/dashboard/collection_form_spec.rb
+++ b/spec/features/dashboard/collection_form_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe 'Creating and editing collections', :inline_jobs, with_user: :use
       FeatureHelpers::DashboardForm.finish
       expect(SolrIndexingJob).to have_received(:perform_now).once
 
-      expect(page).to have_content('Collection was updated successfully')
+      expect(page).to have_content('Collection was successfully updated')
       expect(collection.works).to be_empty
     end
   end

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -533,8 +533,8 @@ RSpec.describe 'Publishing a work', with_user: :user do
       work = Work.last
       version = work.versions.first
 
-      expect(page).to have_selector('h3', text: version.title)
-      expect(page).to have_selector('span.badge--content', text: 'PUBLISHED')
+      expect(page).to have_current_path(resource_path(work.uuid))
+      expect(page).to have_selector('h1', text: version.title)
 
       expect(version).to be_published
       expect(work.visibility).to eq(Permissions::Visibility::OPEN)
@@ -589,8 +589,8 @@ RSpec.describe 'Publishing a work', with_user: :user do
       work = Work.last
       version = work.versions.first
 
-      expect(page).to have_selector('h3', text: version.title)
-      expect(page).to have_selector('span.badge--content', text: 'PUBLISHED')
+      expect(page).to have_current_path(resource_path(work.uuid))
+      expect(page).to have_selector('h1', text: version.title)
 
       expect(version).to be_published
       expect(work.visibility).to eq(Permissions::Visibility::AUTHORIZED)


### PR DESCRIPTION
This changes the redirect path from the dashboard root to the resource's display page. Now, when either saving/exiting or publishing, the user will be redirected to the resource's display page.

Fixes #914 