### PR TITLE
Update Solr index when minting DOIs for works

### DIFF
--- a/app/services/doi_service.rb
+++ b/app/services/doi_service.rb
@@ -72,15 +72,23 @@ module DoiService
       when !has_doi_already && is_draft
         doi = register_new_doi
         resource.update_attribute(:doi, doi)
+        update_index
       when !has_doi_already && !is_draft
         doi = publish_doi(doi: nil)
         resource.update_attribute(:doi, doi)
+        update_index
       when has_doi_already && is_draft
         # No-op
       when has_doi_already && !is_draft
         publish_doi(doi: resource.doi)
         # No need to update resource
       end
+    end
+
+    def update_index
+      return unless resource.is_a? Work
+
+      resource.update_index
     end
 
     def client_source

--- a/spec/services/doi_service_spec.rb
+++ b/spec/services/doi_service_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe DoiService do
         allow(work).to receive(:latest_version).and_return(latest_work_version)
         allow(work).to receive(:update_attribute)
         allow(work).to receive(:valid?).and_return(true)
+        allow(work).to receive(:update_index)
       end
 
       context "when the Work's doi field is empty" do
@@ -131,12 +132,14 @@ RSpec.describe DoiService do
           it 'registers a new doi' do
             call_service
             expect(client_mock).to have_received(:register)
+            expect(work).to have_received(:update_index)
           end
 
           it 'saves the doi on the Work db record' do
             allow(client_mock).to receive(:register).and_return(['new/doi', { some: :metadata }])
             call_service
             expect(work).to have_received(:update_attribute).with(:doi, 'new/doi')
+            expect(work).to have_received(:update_index)
           end
         end
 
@@ -157,12 +160,14 @@ RSpec.describe DoiService do
               doi: nil,
               metadata: { mocked: :metadata }
             )
+            expect(work).to have_received(:update_index)
           end
 
           it 'saves the doi on the Work db record' do
             allow(client_mock).to receive(:publish).and_return(['new/doi', { some: :metadata }])
             call_service
             expect(work).to have_received(:update_attribute).with(:doi, 'new/doi')
+            expect(work).to have_received(:update_index)
           end
         end
       end
@@ -177,6 +182,7 @@ RSpec.describe DoiService do
             call_service
             expect(client_mock).not_to have_received(:register)
             expect(client_mock).not_to have_received(:publish)
+            expect(work).not_to have_received(:update_index)
           end
         end
 
@@ -202,6 +208,7 @@ RSpec.describe DoiService do
           it 'does not update the Work db record' do
             call_service
             expect(work).not_to have_received(:update_attribute)
+            expect(work).not_to have_received(:update_index)
           end
         end
       end


### PR DESCRIPTION
Because DOIs are minted async, reindexing via WorksController does not work. Instead, the DoiService can reindex the work immediately after the DOI is minted or published.

Fixes #962 