### PR TITLE
Analytics: use a custom formatting function to fix overlapping tick labels on analytics chart

### DIFF
--- a/app/javascript/frontend/scripts/view_statistics_chart.js
+++ b/app/javascript/frontend/scripts/view_statistics_chart.js
@@ -42,6 +42,7 @@ function drawChart (selection, data) {
     .ticks(5)
     .tickSizeOuter(0)
     .tickSizeInner(4)
+    .tickFormat(multiFormat)
 
   const line = d3.line()
     .x(d => x(d[0]))
@@ -149,4 +150,32 @@ function hideOverflowingTickLabels (svg, tickTextSelection) {
       return (tickLeft < svgLeft || svgRight < tickRight)
     })
     .style('visibility', 'hidden')
+}
+
+/**
+ * Custom multi-format override for the x-axis (time/date) tick labels.
+ *
+ * This is used to fix some rendering issues encountered when using the default tick formatter.
+ *
+ * Based on example from https://github.com/d3/d3-time-format#d3-time-format
+ * @param {Date} date
+ * @returns {String} Formatted string representation of the date
+ */
+export default function multiFormat (date) {
+  const formatMillisecond = d3.timeFormat('.%L')
+  const formatSecond = d3.timeFormat(':%S')
+  const formatMinute = d3.timeFormat('%I:%M')
+  const formatHour = d3.timeFormat('%I %p')
+  const formatDay = d3.timeFormat('%a %d')
+  const formatWeek = d3.timeFormat('%b %d')
+  const formatMonth = d3.timeFormat('%b')
+  const formatYear = d3.timeFormat('%Y')
+
+  return (d3.timeSecond(date) < date ? formatMillisecond
+    : d3.timeMinute(date) < date ? formatSecond
+      : d3.timeHour(date) < date ? formatMinute
+        : d3.timeDay(date) < date ? formatHour
+          : d3.timeMonth(date) < date ? (d3.timeWeek(date) < date ? formatDay : formatWeek)
+            : d3.timeYear(date) < date ? formatMonth
+              : formatYear)(date)
 }

--- a/spec/javascript/view_statistics_chart.test.js
+++ b/spec/javascript/view_statistics_chart.test.js
@@ -1,0 +1,21 @@
+import multiFormat from '../../app/javascript/frontend/scripts/view_statistics_chart'
+
+describe('ViewStatisticsChart', () => {
+  it('formats a day tick properly', () => {
+    const formattedDate = multiFormat(new Date('2021-04-13 00:00:00'))
+
+    expect(formattedDate).toBe('Tue 13')
+  })
+
+  it('formats a month tick properly', () => {
+    const formattedDate = multiFormat(new Date('2020-12-01 00:00:00'))
+
+    expect(formattedDate).toBe('Dec')
+  })
+
+  it('formats a year tick properly', () => {
+    const formattedDate = multiFormat(new Date('2021-01-01 00:00:00'))
+
+    expect(formattedDate).toBe('2021')
+  })
+})


### PR DESCRIPTION
Fixes #648.

This PR adds a custom `tickFormat` function to render the tick labels for the analytics chart. It fixes a rendering issue where in certain circumstances, full month names would overlap each other.

The formatting code is based on an example in the **d3-time-format** repo (https://github.com/d3/d3-time-format#d3-time-format) with a slight modification to abbreviate the month names.

**Before:**
![image](https://user-images.githubusercontent.com/639920/115281226-c2885880-a116-11eb-9cc8-40b8db3d174f.png)

**After:**
<img width="561" alt="Screen Shot 2021-04-16 at 4 10 22 PM" src="https://user-images.githubusercontent.com/639920/115281244-c916d000-a116-11eb-80fa-6ac3dca08931.png">