### PR TITLE
Update ESLint rules to allow flat ternary expressions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,5 +16,13 @@
     "sourceType": "module"
   },
   "rules": {
+    "indent": [
+      "error",
+      2,
+      {
+        "flatTernaryExpressions": true,
+        "SwitchCase": 1
+      }
+    ]
   }
 }

--- a/app/javascript/frontend/scripts/view_statistics_chart.js
+++ b/app/javascript/frontend/scripts/view_statistics_chart.js
@@ -173,9 +173,9 @@ export default function multiFormat (date) {
 
   return (d3.timeSecond(date) < date ? formatMillisecond
     : d3.timeMinute(date) < date ? formatSecond
-      : d3.timeHour(date) < date ? formatMinute
-        : d3.timeDay(date) < date ? formatHour
-          : d3.timeMonth(date) < date ? (d3.timeWeek(date) < date ? formatDay : formatWeek)
-            : d3.timeYear(date) < date ? formatMonth
-              : formatYear)(date)
+    : d3.timeHour(date) < date ? formatMinute
+    : d3.timeDay(date) < date ? formatHour
+    : d3.timeMonth(date) < date ? (d3.timeWeek(date) < date ? formatDay : formatWeek)
+    : d3.timeYear(date) < date ? formatMonth
+    : formatYear)(date)
 }


### PR DESCRIPTION
This PR sets the `flatTernaryExpressions` option to `true` to allow us to write nested ternary expressions without nested indentation.

The `SwitchCase` option is also set to allow indenting of switch cases. If this option is not explicitly set, the `switch` statement in `app/javascript/vendor/formchanges.js` fails linting.