### PR TITLE
Release 4.6.1: Query for S3 etags using our Graphql endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,6 +74,7 @@ RSpec/LeakyConstantDeclaration:
     - 'spec/lib/healthchecks/queue_latency_check_spec.rb'
     - 'spec/system/active_job_system_spec.rb'
     - 'spec/models/concerns/all_dois_spec.rb'
+    - 'spec/models/concerns/null_object_pattern_spec.rb'
 
 RSpec/ExpectActual:
   Exclude:
@@ -111,7 +112,7 @@ Style/EmptyMethod:
 
 Style/MethodMissingSuper:
   Exclude:
-   - 'app/models/null_work_version.rb'
+   - 'app/models/concerns/null_object_pattern.rb'
 
 Style/EmptyCaseCondition:
   Exclude:

--- a/app/graphql/types/file.rb
+++ b/app/graphql/types/file.rb
@@ -5,6 +5,7 @@ module Types
     field :filename, String, null: false
     field :mime_type, String, null: false
     field :size, Int, null: false
+    field :etag, String, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -9,6 +9,11 @@ module Types
       argument :id, Uuid, required: true
     end
 
+    field :file, File, null: true do
+      description 'Find a file using its legacy identifier from Scholarsphere 3 (available to administrators ONLY)'
+      argument :pid, String, required: true
+    end
+
     def work(id:)
       resource = FindResource.call(id)
 
@@ -18,5 +23,17 @@ module Types
         resource.latest_version
       end
     end
+
+    def file(pid:)
+      return unless user.admin?
+
+      LegacyIdentifier.find_by(old_id: pid).try(:resource)
+    end
+
+    private
+
+      def user
+        @user ||= context.fetch(:user, User.guest)
+      end
   end
 end

--- a/app/models/concerns/null_object_pattern.rb
+++ b/app/models/concerns/null_object_pattern.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module NullObjectPattern
+  extend ActiveSupport::Concern
+
+  def respond_to_missing?(_name, _include_private)
+    nil
+  end
+
+  def method_missing(_name, *_args)
+    nil
+  end
+
+  def nil?
+    true
+  end
+  alias :blank? :nil?
+  alias :empty? :nil?
+end

--- a/app/models/external_app.rb
+++ b/app/models/external_app.rb
@@ -13,6 +13,8 @@ class ExternalApp < ApplicationRecord
   validates :contact_email,
             presence: true
 
+  alias_attribute :access_id, :name
+
   class MetadataListener
     NAME = 'Metadata Listener'
 
@@ -32,15 +34,19 @@ class ExternalApp < ApplicationRecord
     api_tokens.first.token
   end
 
-  # @note This is used in work histories, which (typically) display the names of users who have made changes to a work.
-  # If this pattern goes beyond here, it would be a good idea to refactor it into a decorator.
-  def access_id
-    name
-  end
-
-  # @note ExternalApp and User need to behave in similar ways. This could be extracted into a decorator. See above note
-  # for #access_id.
   def guest?
     false
+  end
+
+  # @note For all intensive purposes, external applications have admin rights: they aren't limited in what they can do.
+  # This may change later, giving them access controls or other mechanisms, which is a more involved process.
+  def admin?
+    true
+  end
+
+  # @note External applications cannot have associated actors. They are neither depositors nor proxies. However,
+  # they due behave like users, so they need a method that respond accordingly.
+  def actor
+    @actor ||= NullActor.new
   end
 end

--- a/app/models/file_resource.rb
+++ b/app/models/file_resource.rb
@@ -11,4 +11,20 @@ class FileResource < ApplicationRecord
   has_many :legacy_identifiers,
            as: :resource,
            dependent: :destroy
+
+  # @note Using `head_object` will retrieve the metadata without retriving the entire object.
+  def etag
+    @etag ||= client
+      .head_object(bucket: ENV['AWS_BUCKET'], key: "#{file_data['storage']}/#{file_data['id']}")
+      .etag
+      .gsub('"', '')
+  rescue Aws::S3::Errors::Forbidden
+    '[unavailable]'
+  end
+
+  private
+
+    def client
+      @client ||= Aws::S3::Client.new
+    end
 end

--- a/app/models/null_actor.rb
+++ b/app/models/null_actor.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class NullWorkVersion
+class NullActor
   include NullObjectPattern
 end

--- a/spec/controllers/api/public_controller_spec.rb
+++ b/spec/controllers/api/public_controller_spec.rb
@@ -39,6 +39,31 @@ RSpec.describe Api::PublicController, type: :controller do
       end
     end
 
+    context 'when querying for authenticated-only content' do
+      let!(:api_key) { create :api_token }
+      let(:resource) { create(:work, :with_authorized_access, has_draft: false) }
+      let(:query) do
+        <<-QUERY
+          {
+            work(id: "#{resource.uuid}") {
+              files {
+                filename
+              }
+            }
+          }
+        QUERY
+      end
+
+      before do
+        request.headers[:'X-API-Key'] = api_key.token
+        post :execute, params: { query: query }
+      end
+
+      it 'returns a list of files' do
+        expect(json_response.dig('data', 'work', 'files')).not_to be_empty
+      end
+    end
+
     context 'when using variables' do
       let(:resource) { create(:work) }
       let(:query) do

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Schema do
-  subject(:result) { described_class.execute(query_string) }
+  describe 'work query' do
+    subject(:result) { described_class.execute(query_string) }
 
-  let(:query_string) do
-    <<-QUERY
+    let(:query_string) do
+      <<-QUERY
       {
         work(id: "#{resource.uuid}") {
           title
@@ -18,51 +19,97 @@ RSpec.describe Schema do
           }
         }
       }
-    QUERY
-  end
+      QUERY
+    end
 
-  context 'when querying with a work uuid' do
-    let(:resource) { create(:work) }
+    context 'with a work uuid' do
+      let(:resource) { create(:work) }
 
-    specify do
-      expect(result.dig('data', 'work', 'title')).to eq(resource.versions[0].title)
+      specify do
+        expect(result.dig('data', 'work', 'title')).to eq(resource.versions[0].title)
+      end
+    end
+
+    context 'when the resources has available files' do
+      let(:work_version) { create(:work_version, :with_files, :published) }
+      let(:file_name) { work_version.file_resources[0].file_data.dig('metadata', 'filename') }
+      let(:resource) { work_version.work }
+
+      specify do
+        expect(result.dig('data', 'work', 'files')).to include(
+          'filename' => file_name.to_s, 'mimeType' => 'image/png', 'size' => 63960
+        )
+      end
+    end
+
+    context 'when policy prevents downloading files' do
+      let(:work_version) { create(:work_version, :with_files) }
+      let(:resource) { work_version.work }
+
+      specify do
+        expect(result.dig('data', 'work', 'files')).to be_empty
+      end
+    end
+
+    context 'with a work version uuid' do
+      let(:resource) { create(:work_version, :published) }
+
+      specify do
+        expect(result.dig('data', 'work', 'title')).to eq(resource.title)
+      end
+    end
+
+    context 'with a collection uuid' do
+      let(:resource) { create(:collection) }
+
+      specify do
+        expect(result.dig('data', 'work', 'title')).to be_nil
+      end
     end
   end
 
-  context 'when the resources has available files' do
-    let(:work_version) { create(:work_version, :with_files, :published) }
-    let(:file_name) { work_version.file_resources[0].file_data.dig('metadata', 'filename') }
-    let(:resource) { work_version.work }
+  describe 'file query' do
+    subject(:result) { described_class.execute(query_string, context: { user: user }) }
 
-    specify do
-      expect(result.dig('data', 'work', 'files')).to include(
-        'filename' => file_name.to_s, 'mimeType' => 'image/png', 'size' => 63960
-      )
+    let(:user) { create(:user, :admin) }
+    let(:identifier) { create(:legacy_identifier, :with_file) }
+
+    let(:query_string) do
+      <<-QUERY
+      {
+        file(pid: "#{pid}") {
+          filename
+        }
+      }
+      QUERY
     end
-  end
 
-  context 'when policy prevents downloading files' do
-    let(:work_version) { create(:work_version, :with_files) }
-    let(:resource) { work_version.work }
+    context 'when querying with a legacy identifier' do
+      let(:pid) { identifier.old_id }
 
-    specify do
-      expect(result.dig('data', 'work', 'files')).to be_empty
+      specify do
+        expect(result.dig('errors')).to be_nil
+        expect(result.dig('data', 'file', 'filename')).to eq(identifier.resource.file_data.dig('metadata', 'filename'))
+      end
     end
-  end
 
-  context 'when querying with a work version uuid' do
-    let(:resource) { create(:work_version, :published) }
+    context 'when the identifier has no associated resource' do
+      let(:pid) { 'badpid' }
 
-    specify do
-      expect(result.dig('data', 'work', 'title')).to eq(resource.title)
+      specify do
+        expect(result.dig('errors')).to be_nil
+        expect(result.dig('data', 'file', 'filename')).to be_nil
+      end
     end
-  end
 
-  context 'when querying with a collection uuid' do
-    let(:resource) { create(:collection) }
+    context 'when the user is not an admin' do
+      let(:user) { create(:user) }
+      let(:pid) { identifier.old_id }
 
-    specify do
-      expect(result.dig('data', 'work', 'title')).to be_nil
+      specify do
+        expect(result.dig('errors')).to be_nil
+        expect(result.dig('data', 'file', 'filename')).to be_nil
+      end
     end
   end
 end

--- a/spec/models/concerns/null_object_pattern_spec.rb
+++ b/spec/models/concerns/null_object_pattern_spec.rb
@@ -2,7 +2,19 @@
 
 require 'spec_helper'
 
-RSpec.describe NullWorkVersion do
+RSpec.describe NullObjectPattern do
+  subject { NullTest.new }
+
+  before(:all) do
+    class NullTest
+      include NullObjectPattern
+    end
+  end
+
+  after(:all) do
+    ActiveSupport::Dependencies.remove_constant('NullTest')
+  end
+
   it { is_expected.to be_nil }
   it { is_expected.to be_empty }
   it { is_expected.to be_blank }

--- a/spec/models/external_app_spec.rb
+++ b/spec/models/external_app_spec.rb
@@ -31,4 +31,22 @@ RSpec.describe ExternalApp, type: :model do
     its(:token) { is_expected.to eq(app.api_tokens.first.token) }
     its(:contact_email) { is_expected.to eq(Rails.configuration.no_reply_email) }
   end
+
+  describe '#access_id' do
+    subject(:application) { build(:external_app) }
+
+    its(:access_id) { is_expected.to eq(application.name) }
+  end
+
+  describe '#guest?' do
+    it { is_expected.not_to be_guest }
+  end
+
+  describe '#admin?' do
+    it { is_expected.to be_admin }
+  end
+
+  describe '#actor' do
+    its(:actor) { is_expected.to be_a(NullActor) }
+  end
 end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe ApplicationPolicy, type: :policy do
       it { is_expected.to permit(user, record) }
     end
 
+    context 'with an external application' do
+      let(:user) { build(:external_app) }
+
+      it { is_expected.to permit(user, record) }
+    end
+
     context 'with an authenticated user' do
       let(:user) { build(:user) }
 
@@ -34,6 +40,12 @@ RSpec.describe ApplicationPolicy, type: :policy do
       let(:user) { UserDecorator.new(build(:user)) }
 
       its(:user) { is_expected.to be_a(User) }
+    end
+
+    context 'with an ExternalApp' do
+      let(:user) { build(:external_app) }
+
+      its(:user) { is_expected.to be_an(ExternalApp) }
     end
   end
 

--- a/spec/policies/collection_policy_spec.rb
+++ b/spec/policies/collection_policy_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe CollectionPolicy, type: :policy do
   let(:other_user) { build_stubbed :user }
   let(:public) { User.guest }
   let(:admin) { create(:user, :admin) }
+  let(:application) { create(:external_app) }
 
   permissions '.scope' do
     subject(:scoped_collections) { described_class::Scope.new(depositor, Collection).resolve }
@@ -36,6 +37,7 @@ RSpec.describe CollectionPolicy, type: :policy do
       it { is_expected.to permit(other_user, collection) }
       it { is_expected.to permit(public, collection) }
       it { is_expected.to permit(admin, collection) }
+      it { is_expected.to permit(application, collection) }
     end
 
     context 'with a restricted collection' do
@@ -50,6 +52,7 @@ RSpec.describe CollectionPolicy, type: :policy do
       it { is_expected.not_to permit(other_user, collection) }
       it { is_expected.not_to permit(public, collection) }
       it { is_expected.to permit(admin, collection) }
+      it { is_expected.to permit(application, collection) }
     end
 
     context 'when granting discover access to a specific user' do
@@ -66,6 +69,7 @@ RSpec.describe CollectionPolicy, type: :policy do
       it { is_expected.not_to permit(other_user, collection) }
       it { is_expected.not_to permit(public, collection) }
       it { is_expected.to permit(admin, collection) }
+      it { is_expected.to permit(application, collection) }
     end
   end
 
@@ -82,6 +86,7 @@ RSpec.describe CollectionPolicy, type: :policy do
     it { is_expected.not_to permit(other_user, collection) }
     it { is_expected.not_to permit(public, collection) }
     it { is_expected.to permit(admin, collection) }
+    it { is_expected.to permit(application, collection) }
   end
 
   permissions :destroy? do
@@ -100,6 +105,7 @@ RSpec.describe CollectionPolicy, type: :policy do
       it { is_expected.not_to permit(other_user, collection) }
       it { is_expected.not_to permit(public, collection) }
       it { is_expected.to permit(admin, collection) }
+      it { is_expected.to permit(application, collection) }
     end
 
     context 'when the collection DOES have a doi' do
@@ -111,6 +117,7 @@ RSpec.describe CollectionPolicy, type: :policy do
       it { is_expected.not_to permit(other_user, collection) }
       it { is_expected.not_to permit(public, collection) }
       it { is_expected.to permit(admin, collection) }
+      it { is_expected.to permit(application, collection) }
     end
   end
 end

--- a/spec/policies/work_policy_spec.rb
+++ b/spec/policies/work_policy_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe WorkPolicy, type: :policy do
   let(:other_user) { build_stubbed :user }
   let(:public) { User.guest }
   let(:admin) { create(:user, :admin) }
+  let(:application) { create(:external_app) }
 
   permissions :show? do
     context 'with a public work' do
@@ -32,6 +33,7 @@ RSpec.describe WorkPolicy, type: :policy do
       it { is_expected.to permit(other_user, work) }
       it { is_expected.to permit(public, work) }
       it { is_expected.to permit(admin, work) }
+      it { is_expected.to permit(application, work) }
     end
 
     context 'with a restricted work' do
@@ -50,6 +52,7 @@ RSpec.describe WorkPolicy, type: :policy do
       it { is_expected.not_to permit(other_user, work) }
       it { is_expected.not_to permit(public, work) }
       it { is_expected.to permit(admin, work) }
+      it { is_expected.to permit(application, work) }
     end
 
     context 'with a draft work' do
@@ -68,6 +71,7 @@ RSpec.describe WorkPolicy, type: :policy do
       it { is_expected.not_to permit(other_user, work) }
       it { is_expected.not_to permit(public, work) }
       it { is_expected.not_to permit(admin, work) }
+      it { is_expected.not_to permit(application, work) }
     end
 
     context 'with a withdrawn work' do
@@ -86,6 +90,7 @@ RSpec.describe WorkPolicy, type: :policy do
       it { is_expected.not_to permit(other_user, work) }
       it { is_expected.not_to permit(public, work) }
       it { is_expected.not_to permit(admin, work) }
+      it { is_expected.not_to permit(application, work) }
     end
   end
 
@@ -105,6 +110,7 @@ RSpec.describe WorkPolicy, type: :policy do
     it { is_expected.not_to permit(other_user, work) }
     it { is_expected.not_to permit(public, work) }
     it { is_expected.to permit(admin, work) }
+    it { is_expected.to permit(application, work) }
   end
 
   permissions :create_version? do
@@ -124,6 +130,7 @@ RSpec.describe WorkPolicy, type: :policy do
       it { is_expected.not_to permit(other_user, work) }
       it { is_expected.not_to permit(public, work) }
       it { is_expected.not_to permit(admin, work) }
+      it { is_expected.not_to permit(application, work) }
     end
 
     context 'when no draft exists' do
@@ -142,6 +149,7 @@ RSpec.describe WorkPolicy, type: :policy do
       it { is_expected.not_to permit(other_user, work) }
       it { is_expected.not_to permit(public, work) }
       it { is_expected.to permit(admin, work) }
+      it { is_expected.to permit(application, work) }
     end
 
     context 'when the work is withdrawn' do
@@ -160,6 +168,7 @@ RSpec.describe WorkPolicy, type: :policy do
       it { is_expected.not_to permit(other_user, work) }
       it { is_expected.not_to permit(public, work) }
       it { is_expected.to permit(admin, work) }
+      it { is_expected.to permit(application, work) }
     end
   end
 
@@ -181,6 +190,7 @@ RSpec.describe WorkPolicy, type: :policy do
       it { is_expected.not_to permit(other_user, work) }
       it { is_expected.not_to permit(public, work) }
       it { is_expected.to permit(admin, work) }
+      it { is_expected.to permit(application, work) }
     end
 
     context 'when no published version exists' do
@@ -200,6 +210,7 @@ RSpec.describe WorkPolicy, type: :policy do
       it { is_expected.not_to permit(other_user, work) }
       it { is_expected.not_to permit(public, work) }
       it { is_expected.not_to permit(admin, work) }
+      it { is_expected.not_to permit(application, work) }
     end
   end
 end


### PR DESCRIPTION
In order to verify that files were migrated successfully, without corruption from Scholarsphere 3, we can check their integrity using the etag that Amazon calculated when it was uploaded into S3. The main advantage to doing it this way is that we don't have to calculate new checksums for each existing file right now.

To enable this, we first grant ExternalApp classes "admin" rights so they can perform file queries using graphql. Because querying for _any_ file using its old NOID could let someone view the metadata of a potentially private or embargoed file, we want to restrict this query to administrators only.

The graphql file query will return the etag for the file, which the client (i.e. Scholarsphere 3) can compare with another etag that it will calculate locally.

Fixes #995 
