### PR TITLE
Creators search UX improvements

### DIFF
--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -7,13 +7,21 @@ export default class extends Controller {
   static targets = ['field', 'suggestionTemplate', 'emptyResultTemplate', 'lastOptionTemplate']
 
   connect () {
+    // Prevent Enter key from submitting the form
+    this.fieldTarget.addEventListener('keypress', function (e) {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+      }
+    })
+
     const url = this.data.get('search')
     this.ac = autocomplete(
       this.fieldTarget,
       {
         hint: false,
         clearOnSelected: true,
-        openOnFocus: true
+        openOnFocus: true,
+        autoselect: true
       },
       [
         {

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
           expect(page).to have_content('Nathan Andrew Weader')
         end
 
-        find_all('.aa-suggestion').first.click
+        find('#search-creators').set("\n")
 
         within('#creators') do
           expect(page).to have_content('CREATOR 1')


### PR DESCRIPTION
Fixes #891.

- hitting the Enter key in the creators search field no longer submits the form
- the first search result is automatically selected