### PR TITLE
Update files with metadata from Fits

### DIFF
--- a/app/controllers/api/v1/files_controller.rb
+++ b/app/controllers/api/v1/files_controller.rb
@@ -36,9 +36,25 @@ module Api::V1
       end
 
       def metadata_params
-        params
-          .require(:metadata)
+        {
+          **virus_params,
+          fits: fits_params
+        }
+      end
+
+      def virus_params
+        metadata
           .permit(virus: [:status, :scanned_at])
+      end
+
+      def fits_params
+        metadata
+          .fetch('fits', {})
+          .permit!
+      end
+
+      def metadata
+        @metadata ||= params.require(:metadata)
       end
   end
 end

--- a/spec/controllers/api/v1/files_controller_spec.rb
+++ b/spec/controllers/api/v1/files_controller_spec.rb
@@ -10,20 +10,57 @@ RSpec.describe Api::V1::FilesController, type: :controller do
   describe 'PATCH #update' do
     let(:file) { create(:file_resource) }
     let(:scan_time) { Time.zone.now.iso8601 }
+    let(:metadata) do
+      {
+        virus: { status: 'false', scanned_at: scan_time },
+        fits: {
+          foo: 'bar',
+          crankstations: 'true'
+        }
+      }
+    end
+
+    def file_data
+      HashWithIndifferentAccess.new(file.reload.file_data['metadata'])
+    end
 
     context 'with valid input' do
       before do
         patch :update, params: {
           id: file.id,
-          metadata: { virus: { status: false, scanned_at: scan_time } }
+          metadata: metadata
         }
       end
 
       it "updates the file's metadata" do
         expect(response).to be_ok
-        expect(file.reload.file_data['metadata']).to include(
-          'virus' => { 'status' => 'false', 'scanned_at' => scan_time }
-        )
+        expect(file_data).to include(metadata)
+      end
+    end
+
+    context 'when updating existing metadata' do
+      let(:updated_metadata) do
+        {
+          fits: {
+            foo: 'baz',
+            crankerstationer: 'false'
+          }
+        }
+      end
+
+      before do
+        file.file_attacher.add_metadata(metadata)
+        file.file_attacher.write
+        file.save
+      end
+
+      it 'only updates the given values' do
+        expect(file_data).to include(metadata)
+        patch :update, params: { id: file.id, metadata: updated_metadata }
+        expect(response).to be_ok
+        expect(file_data).to include(updated_metadata)
+        expect(file_data.dig('virus', 'status')).to eq('false')
+        expect(file_data.dig('virus', 'scanned_at')).to eq(scan_time)
       end
     end
 

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DownloadsController, type: :controller do
         }.to change {
           ViewStatistic.where(
             resource_type: 'FileResource',
-            resource_id: work_version.file_version_memberships[0].id
+            resource_id: work_version.file_version_memberships[0].file_resource.id
           ).count
         }.from(0).to(1)
       end
@@ -75,7 +75,7 @@ RSpec.describe DownloadsController, type: :controller do
           change {
             ViewStatistic.where(
               resource_type: 'FileResource',
-              resource_id: work_version.file_version_memberships[0].id
+              resource_id: work_version.file_version_memberships[0].file_resource.id
             ).count
           }
         )


### PR DESCRIPTION
Adds a :fits parameter to the files API endpoint used by our metadata-listener application. It can now post metadata extracted from Fits and have it persisted to the file's metadata field.

Note: Any parameters from the fits hash are permitted. When posting updated information, the entire hash is replaced. There are no differential updates to Fits's data. Virus, and other metadata *outside* the fits hash key is retained.

Fixes #122 