### PR TITLE
Action Footer UX Improvements

### DIFF
--- a/app/javascript/frontend/styles/_common.scss
+++ b/app/javascript/frontend/styles/_common.scss
@@ -623,10 +623,18 @@ h4,
     }
 
     @include media-breakpoint-down(sm) {
+      display: block !important;
+
       .btn {
         font-size: $font-size-sm;
         padding-left: $spacer;
         padding-right: $spacer;
+        float: none;
+        display: block;
+        margin-bottom: .5rem;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+        width: 100%;
       }
 
       .responsive-hide {

--- a/app/views/dashboard/form/shared/_action_footer.html.erb
+++ b/app/views/dashboard/form/shared/_action_footer.html.erb
@@ -2,12 +2,12 @@
 <% secondary_action = current_user.admin? ? :admin_save : param_key %>
 
 <footer class="footer footer--actions footer--fixed d-flex justify-content-center">
-  <%= form.button t("dashboard.form.actions.save_and_exit.#{secondary_action}"), name: 'save_and_exit', class: 'btn btn-outline-primary btn--rounded pull-left' %>
-
   <div>
-    <%= link_to t('dashboard.form.actions.cancel'), cancel_path, class: 'btn btn-outline-dark btn--rounded' %>
-    <%= form.submit t("dashboard.form.actions.#{primary_action}"), name: primary_action, class: 'btn btn-primary btn--rounded ml-2' %>
+    <%= form.submit t("dashboard.form.actions.#{primary_action}"), name: primary_action, class: 'btn btn-primary btn--rounded' %>
+    <%= link_to t('dashboard.form.actions.cancel'), cancel_path, class: 'btn btn-outline-dark btn--rounded ml-2' %>
   </div>
+
+  <%= form.button t("dashboard.form.actions.save_and_exit.#{secondary_action}"), name: 'save_and_exit', class: 'btn btn-outline-primary btn--rounded pull-left' %>
 
   <% if form.object.persisted? && policy(form.object).destroy? %>
     <%= render DeleteResourceButtonComponent.new(


### PR DESCRIPTION
Fixes #997.

- reverse visual order of 'Save and Continue' and 'Cancel' buttons
- default form action is now 'Save and Continue' rather than 'Save as Draft'
- improve mobile/small device rendering of action footer buttons

### New Button Order
<img width="1207" alt="Screen Shot 2021-04-27 at 2 01 01 PM" src="https://user-images.githubusercontent.com/639920/116294953-8d0eeb00-a766-11eb-9375-4436cfbc3ecd.png">

### Mobile Before
<img width="479" alt="Screen Shot 2021-04-27 at 2 04 09 PM" src="https://user-images.githubusercontent.com/639920/116291010-1bcd3900-a762-11eb-97b2-9ada43a998a7.png">

### Mobile After
<img width="670" alt="Screen Shot 2021-04-27 at 2 03 31 PM" src="https://user-images.githubusercontent.com/639920/116291027-22f44700-a762-11eb-903f-c7419c44c3e9.png">