### PR TITLE
Autopopulate display name when user adds a custom creator

### DIFF
--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -50,9 +50,11 @@ export default class extends Controller {
     return (q, callback) => {
       axios.get(url, { params: { q } }).then((response) => {
         const results = response.data
-        results.push(
-          { last_option: true, results_length: results.length }
-        )
+        results.push({
+          last_option: true,
+          results_length: results.length,
+          display_name: q
+        })
         callback(results)
       })
     }

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -345,6 +345,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
           expect(page).to have_content('CREATOR 1')
           expect(page).to have_content('CREATOR 2')
           expect(page).to have_field('Display Name', count: 2)
+          expect(page).to have_field('Display Name', with: 'nobody')
           expect(page).to have_content('UNIDENTIFIED')
         end
 


### PR DESCRIPTION
Fixes #945.

In the creators search, if the user selects one of the options to create their own creator, prepopulate the custom creator's display name with the content of the user's search query.

<img width="810" alt="Screen Shot 2021-05-03 at 3 50 28 PM" src="https://user-images.githubusercontent.com/639920/116925582-597d0680-ac27-11eb-94c0-44564be4bb53.png">

<img width="1022" alt="Screen Shot 2021-05-03 at 3 50 40 PM" src="https://user-images.githubusercontent.com/639920/116925590-5c77f700-ac27-11eb-8eed-cac3f3270be9.png">

