### PR TITLE
Always show the title of the latest work version on the work settings page

### DIFF
--- a/app/views/dashboard/works/edit.html.erb
+++ b/app/views/dashboard/works/edit.html.erb
@@ -33,7 +33,7 @@
     </div>
     <div class="col-lg-9">
       <h1 class="h2 mb-3"><%= t('.heading',
-                                work_title: (@work.latest_published_version || @work.latest_version).title) %></h1>
+                                work_title: @work.latest_version.title) %></h1>
 
       <div class="keyline keyline--left">
         <h2 id="<%= t('.visibility.heading').parameterize %>" class="h4"><%= t('.visibility.heading') %></h2>


### PR DESCRIPTION
Fixes #754.

With this change, the latest version's title will appear regardless of whether that version is a draft or published.

Fixes the issue of a work without an unpublished version having a blank title on the work settings page.