### PR TITLE
Update Dois when works are updated

### DIFF
--- a/app/controllers/dashboard/form/base_controller.rb
+++ b/app/controllers/dashboard/form/base_controller.rb
@@ -80,6 +80,7 @@ module Dashboard
 
         def save_resource(index: true)
           @resource.indexing_source = null_indexer if !index
+          @resource.update_doi = (publish? || finish? || save_and_exit?)
           @resource.save
         end
 

--- a/app/controllers/dashboard/form/base_controller.rb
+++ b/app/controllers/dashboard/form/base_controller.rb
@@ -79,16 +79,7 @@ module Dashboard
         end
 
         def save_resource(index: true)
-          index_synchronously = (create? || publish? || finish? || save_and_exit?)
-
-          @resource.indexing_source = case
-                                      when !index
-                                        null_indexer
-                                      when index_synchronously
-                                        SolrIndexingJob.public_method(:perform_now)
-                                      else
-                                        SolrIndexingJob.public_method(:perform_later)
-                                      end
+          @resource.indexing_source = null_indexer if !index
           @resource.save
         end
 

--- a/app/jobs/doi_updating_job.rb
+++ b/app/jobs/doi_updating_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DoiUpdatingJob < ApplicationJob
+  queue_as :doi
+
+  def perform(resource)
+    DoiService.call(resource)
+  end
+end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -6,6 +6,7 @@ class Collection < ApplicationRecord
   include ViewStatistics
   include AllDois
   include GeneratedUuids
+  include UpdatingDois
 
   fields_with_dois :doi, :identifier
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -5,6 +5,7 @@ class Collection < ApplicationRecord
   include DepositedAtTimestamp
   include ViewStatistics
   include AllDois
+  include GeneratedUuids
 
   fields_with_dois :doi, :identifier
 
@@ -124,13 +125,7 @@ class Collection < ApplicationRecord
     document_builder.generate(resource: self)
   end
 
-  # @note Postgres mints uuids, but they are not present until the record is reloaded from the database.  In most cases,
-  # this won't present a problem because we only index published versions, and at that point, the version will have
-  # already been saved and reloaded from the database. However, there could be edge cases or other unforseen siutations
-  # where the uuid is nil and the version needs to be indexed. Reloading it from Postgres will avoid those problems.
   def update_index(commit: true)
-    reload if uuid.nil?
-
     CollectionIndexer.call(self, commit: commit)
   end
 

--- a/app/models/concerns/generated_uuids.rb
+++ b/app/models/concerns/generated_uuids.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GeneratedUuids
+  extend ActiveSupport::Concern
+
+  # @note Postgres mints uuids, but they are not present until the record is reloaded from the database. For models that
+  # have uuids, they should never be nil, so reloading them from the database will fix the issue.
+  def uuid
+    reload if persisted? && super.nil?
+
+    super
+  end
+end

--- a/app/models/concerns/updating_dois.rb
+++ b/app/models/concerns/updating_dois.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module UpdatingDois
+  extend ActiveSupport::Concern
+
+  included do
+    attr_writer :update_doi
+
+    after_save :perform_update_doi
+  end
+
+  def update_doi?
+    update_doi && resource_with_doi.doi.present?
+  end
+
+  private
+
+    def update_doi
+      @update_doi ||= false
+    end
+
+    def perform_update_doi
+      return unless update_doi?
+
+      DoiUpdatingJob.perform_later(resource_with_doi)
+    end
+end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -4,6 +4,7 @@ class Work < ApplicationRecord
   include Permissions
   include DepositedAtTimestamp
   include AllDois
+  include GeneratedUuids
 
   fields_with_dois :doi
 

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -4,6 +4,7 @@ class WorkVersion < ApplicationRecord
   include AASM
   include ViewStatistics
   include AllDois
+  include GeneratedUuids
 
   fields_with_dois :doi, :identifier
 
@@ -245,13 +246,7 @@ class WorkVersion < ApplicationRecord
     work.latest_version.try(:id) == id
   end
 
-  # @note Postgres mints uuids, but they are not present until the record is reloaded from the database.  In most cases,
-  # this won't present a problem because we only index published versions, and at that point, the version will have
-  # already been saved and reloaded from the database. However, there could be edge cases or other unforseen siutations
-  # where the uuid is nil and the version needs to be indexed. Reloading it from Postgres will avoid those problems.
   def update_index(commit: true)
-    reload if uuid.nil?
-
     WorkIndexer.call(work, commit: commit, reload: reload_on_index)
   end
 

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -5,6 +5,7 @@ class WorkVersion < ApplicationRecord
   include ViewStatistics
   include AllDois
   include GeneratedUuids
+  include UpdatingDois
 
   fields_with_dois :doi, :identifier
 
@@ -256,6 +257,10 @@ class WorkVersion < ApplicationRecord
 
   def reload_on_index
     @reload_on_index ||= false
+  end
+
+  def update_doi?
+    super && latest_published_version?
   end
 
   delegate :deposited_at,

--- a/app/services/doi_service.rb
+++ b/app/services/doi_service.rb
@@ -60,7 +60,7 @@ module DoiService
       @work_version = if resource.is_a? WorkVersion
                         resource
                       elsif resource.is_a? Work
-                        resource.latest_version
+                        resource.latest_published_version
                       end
     end
 
@@ -69,6 +69,8 @@ module DoiService
       is_draft = work_version.draft?
 
       case
+      when work_version.is_a?(NullWorkVersion)
+        # No-op
       when !has_doi_already && is_draft
         doi = register_new_doi
         resource.update_attribute(:doi, doi)

--- a/spec/features/dashboard/collection_form_spec.rb
+++ b/spec/features/dashboard/collection_form_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe 'Creating and editing collections', :inline_jobs, with_user: :use
   def mock_solr_indexing_job
     RSpec::Mocks.space.proxy_for(SolrIndexingJob)&.reset
 
-    allow(SolrIndexingJob).to receive(:perform_now).and_call_original
     allow(SolrIndexingJob).to receive(:perform_later).and_call_original
   end
 
@@ -45,7 +44,7 @@ RSpec.describe 'Creating and editing collections', :inline_jobs, with_user: :use
       expect(new_collection.works).to be_empty
 
       expect(page).to have_current_path(resource_path(new_collection.uuid))
-      expect(SolrIndexingJob).to have_received(:perform_now).once
+      expect(SolrIndexingJob).to have_received(:perform_later).once
     end
   end
 
@@ -72,8 +71,7 @@ RSpec.describe 'Creating and editing collections', :inline_jobs, with_user: :use
       FeatureHelpers::DashboardForm.fill_in_collection_details(metadata)
       FeatureHelpers::DashboardForm.save_and_continue
 
-      expect(SolrIndexingJob).to have_received(:perform_now).once
-      expect(SolrIndexingJob).not_to have_received(:perform_later)
+      expect(SolrIndexingJob).to have_received(:perform_later).once
 
       expect(Collection.count).to eq(initial_collection_count + 1)
 
@@ -129,8 +127,7 @@ RSpec.describe 'Creating and editing collections', :inline_jobs, with_user: :use
       mock_solr_indexing_job
       FeatureHelpers::DashboardForm.save_and_continue
 
-      expect(SolrIndexingJob).not_to have_received(:perform_now)
-      expect(SolrIndexingJob).to have_received(:perform_later)
+      expect(SolrIndexingJob).to have_received(:perform_later).once
 
       expect(new_collection.creators.map(&:surname)).to contain_exactly('Wead', actor.surname)
       expect(new_collection.works).to be_empty
@@ -153,8 +150,7 @@ RSpec.describe 'Creating and editing collections', :inline_jobs, with_user: :use
       mock_solr_indexing_job
       FeatureHelpers::DashboardForm.select_work(published_work.latest_published_version.title)
       FeatureHelpers::DashboardForm.finish
-      expect(SolrIndexingJob).to have_received(:perform_now).once
-      expect(SolrIndexingJob).not_to have_received(:perform_later)
+      expect(SolrIndexingJob).to have_received(:perform_later).once
 
       expect(new_collection.works).to contain_exactly(published_work)
     end
@@ -169,7 +165,7 @@ RSpec.describe 'Creating and editing collections', :inline_jobs, with_user: :use
       mock_solr_indexing_job
       FeatureHelpers::DashboardForm.fill_in_collection_details(metadata)
       FeatureHelpers::DashboardForm.save_and_exit
-      expect(SolrIndexingJob).to have_received(:perform_now).once
+      expect(SolrIndexingJob).to have_received(:perform_later).once
 
       collection.reload
       expect(collection.title).to eq metadata[:title]
@@ -199,7 +195,7 @@ RSpec.describe 'Creating and editing collections', :inline_jobs, with_user: :use
 
       mock_solr_indexing_job
       FeatureHelpers::DashboardForm.finish
-      expect(SolrIndexingJob).to have_received(:perform_now).once
+      expect(SolrIndexingJob).to have_received(:perform_later).once
 
       expect(page).to have_content('Collection was successfully updated')
       expect(collection.works).to be_empty

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'Publishing a work', with_user: :user do
   let(:metadata) { attributes_for(:work_version, :with_complete_metadata) }
 
   before do
-    allow(SolrIndexingJob).to receive(:perform_now).and_call_original
     allow(SolrIndexingJob).to receive(:perform_later)
   end
 
@@ -34,7 +33,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(new_work_version.version_number).to eq 1
 
         expect(page).to have_current_path(resource_path(new_work_version.uuid))
-        expect(SolrIndexingJob).to have_received(:perform_now).at_least(:once)
+        expect(SolrIndexingJob).to have_received(:perform_later).at_least(:once)
       end
     end
 
@@ -69,20 +68,18 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(new_work_version.source).to eq [metadata[:source]]
 
         expect(page).to have_current_path(dashboard_form_contributors_path('work_version', new_work_version))
-        expect(SolrIndexingJob).to have_received(:perform_now).at_least(:once)
+        expect(SolrIndexingJob).to have_received(:perform_later).at_least(:once)
       end
     end
 
     context 'when saving-and-continuing, then hitting cancel' do
-      it 'indexes the work the initial time' do
+      it 'returns to the resource page' do
         visit dashboard_form_work_versions_path
 
         FeatureHelpers::DashboardForm.fill_in_work_details(metadata)
         FeatureHelpers::DashboardForm.save_and_continue
 
         FeatureHelpers::DashboardForm.cancel
-
-        visit dashboard_root_path
 
         expect(page).to have_content metadata[:title]
       end
@@ -107,7 +104,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         work_version.reload
         expect(work_version.title).to eq metadata[:title]
-        expect(SolrIndexingJob).to have_received(:perform_now).once
+        expect(SolrIndexingJob).to have_received(:perform_later).once
       end
     end
 
@@ -135,8 +132,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(work_version.source).to eq [metadata[:source]]
 
         expect(page).to have_current_path(dashboard_form_contributors_path('work_version', work_version))
-        expect(SolrIndexingJob).not_to have_received(:perform_now)
-        expect(SolrIndexingJob).to have_received(:perform_later)
+        expect(SolrIndexingJob).to have_received(:perform_later).once
       end
     end
 
@@ -157,7 +153,6 @@ RSpec.describe 'Publishing a work', with_user: :user do
         end
 
         expect(page).to have_current_path(dashboard_form_contributors_path('work_version', work_version))
-        expect(SolrIndexingJob).not_to have_received(:perform_now)
         expect(SolrIndexingJob).not_to have_received(:perform_later)
       end
     end
@@ -193,8 +188,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(work_version.contributor).to eq [metadata[:contributor]]
 
         expect(page).to have_current_path(dashboard_form_files_path(work_version))
-        expect(SolrIndexingJob).not_to have_received(:perform_now)
-        expect(SolrIndexingJob).to have_received(:perform_later)
+        expect(SolrIndexingJob).to have_received(:perform_later).once
       end
     end
 
@@ -235,7 +229,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(work_version.creators[1].display_name).to eq('Adam Wead')
 
         expect(page).to have_current_path(dashboard_form_files_path(work_version))
-        expect(SolrIndexingJob).not_to have_received(:perform_now)
+        expect(SolrIndexingJob).to have_received(:perform_later).once
       end
     end
 
@@ -274,8 +268,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(work_version.creators[1].display_name).to eq('Dr. Adam Wead')
 
         expect(page).to have_current_path(dashboard_form_files_path(work_version))
-        expect(SolrIndexingJob).not_to have_received(:perform_now)
-        expect(SolrIndexingJob).to have_received(:perform_later)
+        expect(SolrIndexingJob).to have_received(:perform_later).once
       end
     end
 
@@ -316,8 +309,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(work_version.creators[1].display_name).to eq(existing_actor.display_name)
 
         expect(page).to have_current_path(dashboard_form_files_path(work_version))
-        expect(SolrIndexingJob).not_to have_received(:perform_now)
-        expect(SolrIndexingJob).to have_received(:perform_later)
+        expect(SolrIndexingJob).to have_received(:perform_later).once
       end
     end
 
@@ -366,8 +358,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(work_version.creators[1].surname).to eq(metadata[:surname])
 
         expect(page).to have_current_path(dashboard_form_files_path(work_version))
-        expect(SolrIndexingJob).not_to have_received(:perform_now)
-        expect(SolrIndexingJob).to have_received(:perform_later)
+        expect(SolrIndexingJob).to have_received(:perform_later).once
       end
     end
 
@@ -396,8 +387,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         expect(work_version.reload.creators.map(&:surname)).to contain_exactly(creators.last.surname)
         expect(page).to have_current_path(dashboard_form_files_path(work_version))
-        expect(SolrIndexingJob).not_to have_received(:perform_now)
-        expect(SolrIndexingJob).to have_received(:perform_later)
+        expect(SolrIndexingJob).to have_received(:perform_later).once
       end
     end
 
@@ -421,7 +411,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         FeatureHelpers::DashboardForm.save_as_draft_and_exit
 
         expect(work_version.reload.creators.map(&:display_name)).to eq(['Creator B', 'Creator A'])
-        expect(SolrIndexingJob).to have_received(:perform_now).once
+        expect(SolrIndexingJob).to have_received(:perform_later).once
       end
     end
   end
@@ -441,7 +431,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
       # Save, reload the page, and ensure that it's now in the files table
       FeatureHelpers::DashboardForm.save_as_draft_and_exit
-      expect(SolrIndexingJob).to have_received(:perform_now).once
+      expect(SolrIndexingJob).to have_received(:perform_later).once
       visit dashboard_form_files_path(work_version)
 
       within('.table') do
@@ -475,7 +465,6 @@ RSpec.describe 'Publishing a work', with_user: :user do
         fill_in 'work_version_published_date', with: 'this is not a valid date'
         FeatureHelpers::DashboardForm.publish
 
-        expect(SolrIndexingJob).not_to have_received(:perform_now)
         expect(SolrIndexingJob).not_to have_received(:perform_later)
 
         expect(page).to have_current_path(dashboard_form_publish_path(work_version))
@@ -616,12 +605,22 @@ RSpec.describe 'Publishing a work', with_user: :user do
     let(:different_metadata) { attributes_for(:work_version, :with_complete_metadata) }
     let(:user) { create(:user, :admin) }
 
+    # RSpec mocks _cumulatively_ record the number of times they've been called,
+    # we need a way to say "from this exact point, you should have been called
+    # once." We accomplish this by tearing down the mock and setting it back up.
+    def mock_solr_indexing_job
+      RSpec::Mocks.space.proxy_for(SolrIndexingJob)&.reset
+
+      allow(SolrIndexingJob).to receive(:perform_later).and_call_original
+    end
+
     it 'allows an administrator to update the metadata' do
       visit dashboard_form_publish_path(work_version)
 
+      mock_solr_indexing_job
       FeatureHelpers::DashboardForm.fill_in_publishing_details(different_metadata)
       FeatureHelpers::DashboardForm.finish
-      expect(SolrIndexingJob).to have_received(:perform_now)
+      expect(SolrIndexingJob).to have_received(:perform_later).once
 
       work_version.reload
       expect(work_version.rights).to eq(different_metadata[:rights])

--- a/spec/jobs/doi_updating_job_spec.rb
+++ b/spec/jobs/doi_updating_job_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DoiUpdatingJob, type: :job do
+  describe '#perform' do
+    before { allow(DoiService).to receive(:call) }
+
+    it 'calls DoiService' do
+      described_class.perform_now('resource')
+      expect(DoiService).to have_received(:call).with('resource')
+    end
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Collection, type: :model do
     let(:resource) { create(:collection) }
   end
 
+  it_behaves_like 'a resource with a generated uuid' do
+    let(:resource) { build(:collection) }
+  end
+
   it_behaves_like 'a resource with a deposited at timestamp'
 
   it_behaves_like 'a resource that can provide all DOIs in', [:doi, :identifier]
@@ -18,7 +22,6 @@ RSpec.describe Collection, type: :model do
   describe 'table' do
     it { is_expected.to have_db_column(:depositor_id) }
     it { is_expected.to have_db_column(:metadata).of_type(:jsonb) }
-    it { is_expected.to have_db_column(:uuid).of_type(:uuid) }
     it { is_expected.to have_db_column(:doi).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:title).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:subtitle).of_type(:string) }
@@ -257,27 +260,11 @@ RSpec.describe Collection, type: :model do
 
     before do
       allow(CollectionIndexer).to receive(:call)
-      allow(collection).to receive(:reload)
     end
 
-    context 'when the uuid is nil' do
-      before { allow(collection).to receive(:uuid).and_return(nil) }
-
-      it 'reloads the version and calls the CollectionIndexer' do
-        collection.update_index
-        expect(collection).to have_received(:reload)
-        expect(CollectionIndexer).to have_received(:call)
-      end
-    end
-
-    context 'when the uuid is present' do
-      before { allow(collection).to receive(:uuid).and_return(SecureRandom.uuid) }
-
-      it 'does NOT reload the version and calls the CollectionIndexer' do
-        collection.update_index
-        expect(collection).not_to have_received(:reload)
-        expect(CollectionIndexer).to have_received(:call)
-      end
+    it 'calls the CollectionIndexer' do
+      collection.update_index
+      expect(CollectionIndexer).to have_received(:call)
     end
   end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Work, type: :model do
     let(:factory_name) { :work }
   end
 
+  it_behaves_like 'a resource with a generated uuid' do
+    let(:resource) { build(:work) }
+  end
+
   it_behaves_like 'a resource with a deposited at timestamp'
 
   it_behaves_like 'a resource that can provide all DOIs in', [:doi]
@@ -15,7 +19,6 @@ RSpec.describe Work, type: :model do
     it { is_expected.to have_db_column(:work_type).of_type(:string) }
     it { is_expected.to have_db_column(:depositor_id) }
     it { is_expected.to have_db_column(:proxy_id) }
-    it { is_expected.to have_db_column(:uuid).of_type(:uuid) }
     it { is_expected.to have_db_column(:doi).of_type(:string) }
     it { is_expected.to have_db_column(:embargoed_until).of_type(:datetime) }
     it { is_expected.to have_db_column(:deposit_agreed_at).of_type(:datetime) }
@@ -372,14 +375,6 @@ RSpec.describe Work, type: :model do
 
       its(:keys) { is_expected.to contain_exactly(*keys) }
     end
-  end
-
-  describe '#uuid' do
-    subject(:work) { create(:work) }
-
-    before { work.reload }
-
-    its(:uuid) { is_expected.to match(/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/) }
   end
 
   describe '::reindex_all' do

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe WorkVersion, type: :model do
     let(:resource) { create(:work_version) }
   end
 
+  it_behaves_like 'a resource with a generated uuid' do
+    let(:resource) { build(:work_version) }
+  end
+
   it_behaves_like 'a resource that can provide all DOIs in', [:doi, :identifier]
 
   describe 'table' do
@@ -14,7 +18,6 @@ RSpec.describe WorkVersion, type: :model do
     it { is_expected.to have_db_index(:work_id) }
     it { is_expected.to have_db_column(:aasm_state) }
     it { is_expected.to have_db_column(:metadata).of_type(:jsonb) }
-    it { is_expected.to have_db_column(:uuid).of_type(:uuid) }
     it { is_expected.to have_db_column(:version_number).of_type(:integer) }
     it { is_expected.to have_db_column(:doi).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:title).of_type(:string) }
@@ -260,14 +263,6 @@ RSpec.describe WorkVersion, type: :model do
     end
   end
 
-  describe '#uuid' do
-    subject(:work_version) { create(:work_version) }
-
-    before { work_version.reload }
-
-    its(:uuid) { is_expected.to match(/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/) }
-  end
-
   describe '#resource_with_doi' do
     let(:work) { build_stubbed :work }
     let(:work_version) { described_class.new(work: work) }
@@ -366,27 +361,11 @@ RSpec.describe WorkVersion, type: :model do
 
     before do
       allow(WorkIndexer).to receive(:call)
-      allow(work_version).to receive(:reload)
     end
 
-    context 'when the uuid is nil' do
-      before { allow(work_version).to receive(:uuid).and_return(nil) }
-
-      it 'reloads the version and calls the WorkIndexer' do
-        work_version.update_index
-        expect(work_version).to have_received(:reload)
-        expect(WorkIndexer).to have_received(:call)
-      end
-    end
-
-    context 'when the uuid is present' do
-      before { allow(work_version).to receive(:uuid).and_return(SecureRandom.uuid) }
-
-      it 'does NOT reload the version and calls the WorkIndexer' do
-        work_version.update_index
-        expect(work_version).not_to have_received(:reload)
-        expect(WorkIndexer).to have_received(:call)
-      end
+    it 'calls the WorkIndexer' do
+      work_version.update_index
+      expect(WorkIndexer).to have_received(:call)
     end
   end
 

--- a/spec/support/shared/a_resource_with_a_generated_uuid.rb
+++ b/spec/support/shared/a_resource_with_a_generated_uuid.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a resource with a generated uuid' do
+  before do
+    raise 'resource must be set with `let(:resource)`' unless defined? resource
+
+    resource.uuid = nil
+  end
+
+  it { is_expected.to have_db_column(:uuid).of_type(:uuid) }
+
+  it "reloads the resource when it's first saved" do
+    expect(resource.uuid).to be_nil
+    resource.save
+    expect(resource.uuid).to match(/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/)
+  end
+end


### PR DESCRIPTION
The metadata associated with a doi in DataCite need to be updated when the work is updated in Scholarsphere.  For works, this only needs to happen when a new version is published, or an existing published version is updated via an admin. For collections, this will happen anytime the collection is updated.

In order to achieve this, we needed to stop supporting synchronous indexing. Due to the nature of the callbacks for both indexing and updating a doi, a synchronous index job was blocking an asynchronous update doi job. As a result, index job would somehow block the doi from getting the updated metadata from the database and the doi was updated with incorrect information.

Fixes #657 