### PR TITLE
Update the visibility badge to indicate that a work is embargoed

### DIFF
--- a/app/components/visibility_badge_component.html.erb
+++ b/app/components/visibility_badge_component.html.erb
@@ -1,3 +1,3 @@
-<%= content_tag :div, class: html_class, data: { before: icon } do %>
+<%= content_tag :div, class: html_class, title: tooltip, data: { before: icon, toggle: 'tooltip', placement: 'right' } do %>
   <%= label %>
 <% end %>

--- a/app/components/visibility_badge_component.rb
+++ b/app/components/visibility_badge_component.rb
@@ -7,35 +7,52 @@ class VisibilityBadgeComponent < ApplicationComponent
   end
 
   def render
-    work.respond_to?(:visibility)
+    work.respond_to?(:visibility) && work.respond_to?(:embargoed?)
   end
 
   private
 
     attr_reader :work
 
+    def label
+      details[details_key][:label]
+    end
+
+    def color
+      details[details_key][:color]
+    end
+
+    def icon
+      details[details_key][:icon]
+    end
+
     def html_class
       [
         'badge',
         'badge--icon',
-        "badge--icon-#{details[visibility][:color]}"
+        "badge--icon-#{color}"
       ].join(' ')
     end
 
-    def visibility
+    def tooltip
+      return unless work.embargoed?
+
+      I18n.t('visibility_badge_component.tooltip.embargoed', date: embargo_release_date)
+    end
+
+    def details_key
+      return 'embargoed' if work.embargoed?
+
       work.visibility || Permissions::Visibility::PRIVATE
-    end
-
-    def label
-      details[visibility][:label]
-    end
-
-    def icon
-      details[visibility][:icon]
     end
 
     def details
       {
+        'embargoed' => {
+          label: i18n_label('embargoed'),
+          color: 'red',
+          icon: 'lock_clock'
+        },
         Permissions::Visibility::OPEN => {
           label: i18n_label(Permissions::Visibility::OPEN),
           color: 'orange',
@@ -56,5 +73,9 @@ class VisibilityBadgeComponent < ApplicationComponent
 
     def i18n_label(key)
       I18n.t("visibility_badge_component.label.#{key}", raise: true)
+    end
+
+    def embargo_release_date
+      work.embargoed_until.strftime('%Y-%m-%d')
     end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -56,6 +56,17 @@ class SolrDocument
     Time.zone.parse(self[:deposited_at_dtsi])
   end
 
+  def embargoed_until
+    Time.zone.parse(fetch(:embargoed_until_dtsi, ''))
+  rescue ArgumentError
+  end
+
+  def embargoed?
+    return false if embargoed_until.nil?
+
+    embargoed_until > Time.zone.now
+  end
+
   def work_id
     self[:work_id_isi].to_i
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -545,3 +545,6 @@ en:
       open: Open Access
       authenticated: Penn State
       restricted: Restricted
+      embargoed: Embargoed
+    tooltip:
+      embargoed: 'Embargoed until %{date}'

--- a/spec/components/visibility_badge_component_spec.rb
+++ b/spec/components/visibility_badge_component_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe VisibilityBadgeComponent, type: :component do
   let(:node) { render_inline(described_class.new(work: work)) }
   let(:badge) { node.css('div').first }
+  let(:embargo_date) { Time.zone.now + 6.days }
 
   context 'when a work is open access' do
     let(:work) { build(:work) }
@@ -13,6 +14,19 @@ RSpec.describe VisibilityBadgeComponent, type: :component do
       expect(badge.text).to include(I18n.t('visibility_badge_component.label.open'))
       expect(badge.attributes['data-before'].value).to eq('lock_open')
       expect(badge.classes).to contain_exactly('badge', 'badge--icon', 'badge--icon-orange')
+      expect(badge['title']).to be_nil
+    end
+
+    context 'when a work is embargoed' do
+      let(:work) { build(:work, embargoed_until: embargo_date) }
+
+      specify do
+        expect(badge.text).to include(I18n.t('visibility_badge_component.label.embargoed'))
+        expect(badge.attributes['data-before'].value).to eq('lock_clock')
+        expect(badge.classes).to contain_exactly('badge', 'badge--icon', 'badge--icon-red')
+        expect(badge['title']).to eq(I18n.t('visibility_badge_component.tooltip.embargoed',
+                                            date: embargo_date.strftime('%Y-%m-%d')))
+      end
     end
   end
 
@@ -23,6 +37,19 @@ RSpec.describe VisibilityBadgeComponent, type: :component do
       expect(badge.text).to include(I18n.t('visibility_badge_component.label.authenticated'))
       expect(badge.attributes['data-before'].value).to eq('pets')
       expect(badge.classes).to contain_exactly('badge', 'badge--icon', 'badge--icon-blue')
+      expect(badge['title']).to be_nil
+    end
+
+    context 'when a work is embargoed' do
+      let(:work) { build(:work, embargoed_until: embargo_date, visibility: Permissions::Visibility::AUTHORIZED) }
+
+      specify do
+        expect(badge.text).to include(I18n.t('visibility_badge_component.label.embargoed'))
+        expect(badge.attributes['data-before'].value).to eq('lock_clock')
+        expect(badge.classes).to contain_exactly('badge', 'badge--icon', 'badge--icon-red')
+        expect(badge['title']).to eq(I18n.t('visibility_badge_component.tooltip.embargoed',
+                                            date: embargo_date.strftime('%Y-%m-%d')))
+      end
     end
   end
 
@@ -33,6 +60,19 @@ RSpec.describe VisibilityBadgeComponent, type: :component do
       expect(badge.text).to include(I18n.t('visibility_badge_component.label.restricted'))
       expect(badge.attributes['data-before'].value).to eq('lock')
       expect(badge.classes).to contain_exactly('badge', 'badge--icon', 'badge--icon-red')
+      expect(badge['title']).to be_nil
+    end
+
+    context 'when a work is embargoed' do
+      let(:work) { build(:work, embargoed_until: embargo_date, visibility: Permissions::Visibility::PRIVATE) }
+
+      specify do
+        expect(badge.text).to include(I18n.t('visibility_badge_component.label.embargoed'))
+        expect(badge.attributes['data-before'].value).to eq('lock_clock')
+        expect(badge.classes).to contain_exactly('badge', 'badge--icon', 'badge--icon-red')
+        expect(badge['title']).to eq(I18n.t('visibility_badge_component.tooltip.embargoed',
+                                            date: embargo_date.strftime('%Y-%m-%d')))
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #441.

If a work is embargoed, we now display an embargoed badge instead of the normal access level badge.

<img width="1010" alt="Screen Shot 2021-05-13 at 10 49 05 AM" src="https://user-images.githubusercontent.com/639920/118145067-2e3ea800-b3db-11eb-91cc-dcead087a00b.png">

