### PR TITLE
Add Publisher's Statement

### DIFF
--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -70,6 +70,7 @@ module Api::V1
             :published_date,
             :deposited_at,
             :description,
+            :publisher_statement,
             :doi,
             keyword: [],
             resource_type: [],

--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -62,6 +62,7 @@ module Dashboard
             .permit(
               :title,
               :description,
+              :publisher_statement,
               :subtitle,
               :rights,
               :version_name,

--- a/app/controllers/dashboard/form/work_version_details_controller.rb
+++ b/app/controllers/dashboard/form/work_version_details_controller.rb
@@ -36,6 +36,7 @@ module Dashboard
             .permit(
               :title,
               :description,
+              :publisher_statement,
               :subtitle,
               :rights,
               :version_name,

--- a/app/decorators/resource_decorator.rb
+++ b/app/decorators/resource_decorator.rb
@@ -34,10 +34,9 @@ class ResourceDecorator < SimpleDelegator
   end
 
   def description_html
-    return unless respond_to?(:description)
-    return '' if description.blank?
+    return '' if combined_description.blank?
 
-    @description_html ||= render_markdown(description)
+    @description_html ||= render_markdown(combined_description)
   end
 
   def description_plain_text
@@ -76,6 +75,10 @@ class ResourceDecorator < SimpleDelegator
   end
 
   private
+
+    def combined_description
+      [try(:description), try(:publisher_statement)].join(' ')
+    end
 
     def render_markdown(str)
       markdown = Redcarpet::Markdown.new(

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -21,6 +21,7 @@ class WorkVersion < ApplicationRecord
                  keyword: [:string, array: true, default: []],
                  rights: :string,
                  description: :string,
+                 publisher_statement: :string,
                  resource_type: [:string, array: true, default: []],
                  contributor: [:string, array: true, default: []],
                  publisher: [:string, array: true, default: []],
@@ -199,6 +200,7 @@ class WorkVersion < ApplicationRecord
   %i[
     description
     published_date
+    publisher_statement
     rights
     subtitle
     version_name

--- a/app/views/dashboard/form/details/_work_version_fields.html.erb
+++ b/app/views/dashboard/form/details/_work_version_fields.html.erb
@@ -21,7 +21,6 @@
 <div class="form-wrapper">
   <%= render 'form_fields/text_area', form: form, attribute: :description %>
   <%= render 'form_fields/text', form: form, attribute: :published_date %>
-  <%= render 'form_fields/multi_text', form: form, attribute: :keyword %>
 </div>
 
 <div class="form-wrapper form-wrapper--wide">
@@ -32,6 +31,8 @@
 
 <div class="form-wrapper">
   <%= render 'form_fields/text', form: form, attribute: :subtitle %>
+  <%= render 'form_fields/text_area', form: form, attribute: :publisher_statement %>
+  <%= render 'form_fields/multi_text', form: form, attribute: :keyword %>
   <%= render 'form_fields/multi_text', form: form, attribute: :publisher %>
   <%= render 'form_fields/multi_text', form: form, attribute: :identifier %>
   <%= render 'form_fields/multi_text', form: form, attribute: :related_url %>

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -59,7 +59,8 @@
   <article class="row">
     <div class="col-lg-7">
       <h1 class="h2 mb-3"><%= work_version.title %></h1>
-      <p><%= work_version.description_html %></p>
+
+      <%= work_version.description_html %>
 
       <div class="keyline keyline--left mb-3">
         <h2 class="h4"><%= t('resources.files') %></h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,7 @@ en:
         rights: License
         display_rights: License
         description: Description
+        publisher_statement: Publisher's Statement
         creators: Creators
         first_creators: Creators
         resource_type: Resource Type
@@ -184,6 +185,7 @@ en:
       work_version:
         title: The title as would appear in a bibliographic reference to the work (not a filename).
         description: Include the work abstract if available.
+        publisher_statement: If the original publisher requires a set statement to upload this work to ScholarSphere, include it here
         published_date: The publication date can be specific to the year (2020), month (2020-11), or day (2020-11-22).
         version_name: For datasets or software using semantic versioning (e.g., x.y.z)
         rights: The license you select determines how your work can be used by others.

--- a/openapi.yml
+++ b/openapi.yml
@@ -300,6 +300,12 @@ components:
           example: "2020-10-31"
           description: >-
             EDTF date formats are also supported. See https://www.loc.gov/standards/datetime/
+        publisher_statement:
+          type: "string"
+          example: >-
+            This is a pre-print from Joe Publisher, Inc. We are not responsible for anything.
+          description: >-
+            This is also referred to as a "set statement" and is often a required part for Open Access articles.
         keyword:
           type: "array"
           items:

--- a/spec/decorators/resource_decorator_spec.rb
+++ b/spec/decorators/resource_decorator_spec.rb
@@ -193,12 +193,18 @@ RSpec.describe ResourceDecorator do
 
         This paragraph has <h1>sneaky html</h1>
       MARKDOWN
+
+      allow(resource).to receive(:publisher_statement).and_return(<<-MARKDOWN.strip_heredoc)
+        ## Publisher's Statement
+
+        Here's some important stuff that you need to know.
+      MARKDOWN
     end
 
     it 'renders the description into markdown' do
       expect(description_html).to be_html_safe
 
-      expect(parsed.css('p').length).to eq 4
+      expect(parsed.css('p').length).to eq 5
 
       parsed.css('p').first.tap do |first_paragraph|
         expect(first_paragraph.css('em').text).to eq 'emphasized'
@@ -228,6 +234,7 @@ RSpec.describe ResourceDecorator do
     context 'when given nil' do
       before do
         allow(resource).to receive(:description).and_return(nil)
+        allow(resource).to receive(:publisher_statement).and_return(nil)
       end
 
       it { is_expected.to eq '' }
@@ -238,8 +245,12 @@ RSpec.describe ResourceDecorator do
         allow(Redcarpet::Markdown).to receive(:new).and_raise
       end
 
+      let(:combined_description) do
+        [resource.description, resource.publisher_statement].join(' ')
+      end
+
       it 'traps the error and returns the original string' do
-        expect(description_html).to eq resource.description
+        expect(description_html).to eq(combined_description)
         expect(description_html).not_to be_html_safe
       end
     end
@@ -254,16 +265,20 @@ RSpec.describe ResourceDecorator do
       allow(resource).to receive(:description).and_return(
         'This *is* _marked_ [down](http://psu.edu)'
       )
+      allow(resource).to receive(:publisher_statement).and_return(
+        '##Publisher Statement'
+      )
     end
 
     it 'returns plain text, without any markdown or html formatting' do
-      expect(description_plain_text).to eq 'This is marked down'
+      expect(description_plain_text).to eq 'This is marked down ##Publisher Statement'
       expect(description_plain_text).not_to be_html_safe
     end
 
     context 'when given nil' do
       before do
         allow(resource).to receive(:description).and_return(nil)
+        allow(resource).to receive(:publisher_statement).and_return(nil)
       end
 
       it { is_expected.to eq '' }

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -66,6 +66,7 @@ FactoryBot.define do
       subtitle { FactoryBotHelpers.work_title }
       keyword { Faker::Science.element }
       description { Faker::Lorem.paragraph }
+      publisher_statement { Faker::Lorem.paragraph }
       resource_type { Faker::House.furniture }
       contributor { Faker::Artist.name }
       publisher { Faker::Book.publisher }

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(new_work_version.version_number).to eq 1
         expect(new_work_version.title).to eq metadata[:title]
         expect(new_work_version.description).to eq metadata[:description]
+        expect(new_work_version.publisher_statement).to eq metadata[:publisher_statement]
         expect(new_work_version.published_date).to eq metadata[:published_date]
         expect(new_work_version.keyword).to eq [metadata[:keyword]]
         expect(new_work_version.subtitle).to eq metadata[:subtitle]
@@ -119,6 +120,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(work_version.version_number).to eq 2
         expect(work_version.title).to eq metadata[:title]
         expect(work_version.description).to eq metadata[:description]
+        expect(work_version.publisher_statement).to eq metadata[:publisher_statement]
         expect(work_version.published_date).to eq metadata[:published_date]
         expect(work_version.keyword).to eq [metadata[:keyword]]
         expect(work_version.subtitle).to eq metadata[:subtitle]
@@ -531,6 +533,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
       expect(version.version_number).to eq 1
       expect(version.title).to eq different_metadata[:title]
       expect(version.description).to eq different_metadata[:description]
+      expect(version.publisher_statement).to eq different_metadata[:publisher_statement]
       expect(version.published_date).to eq different_metadata[:published_date]
       expect(version.keyword).to eq [different_metadata[:keyword]]
       expect(version.publisher).to eq [different_metadata[:publisher]]
@@ -587,6 +590,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
       expect(version.version_number).to eq 1
       expect(version.title).to eq different_metadata[:title]
       expect(version.description).to eq different_metadata[:description]
+      expect(version.publisher_statement).to eq different_metadata[:publisher_statement]
       expect(version.published_date).to eq different_metadata[:published_date]
       expect(version.keyword).to eq [different_metadata[:keyword]]
       expect(version.publisher).to eq [different_metadata[:publisher]]

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -24,7 +24,10 @@ RSpec.describe 'Public Resources', type: :feature do
 
         # Spot check meta tags
         expect(page.find('meta[property="og:title"]', visible: false)[:content]).to eq v2.title
-        expect(page.find('meta[property="og:description"]', visible: false)[:content]).to eq 'This has markdown'
+        expect(page.find('meta[property="og:description"]', visible: false)[:content]).to include(
+          'This has markdown',
+          v2.publisher_statement
+        )
         # Below was failing in CI due to hostnames getting weird
         expect(page.find('meta[property="og:url"]', visible: false)[:content])
           .to match(resource_path(work.uuid)).and match(/^https?:/)

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -329,8 +329,8 @@ RSpec.describe Work, type: :model do
           based_near_tesim
           contributor_tesim
           created_at_dtsi
-          creators_tesim
           creators_sim
+          creators_tesim
           deposit_agreed_at_dtsi
           deposit_agreement_version_tesim
           deposited_at_dtsi
@@ -353,6 +353,7 @@ RSpec.describe Work, type: :model do
           published_date_dtrsi
           published_date_tesim
           publisher_tesim
+          publisher_statement_tesim
           read_groups_ssim
           read_users_ssim
           related_url_tesim

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe WorkVersion, type: :model do
     it { is_expected.to have_jsonb_accessor(:keyword).of_type(:string).is_array.with_default([]) }
     it { is_expected.to have_jsonb_accessor(:rights).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:description).of_type(:string) }
+    it { is_expected.to have_jsonb_accessor(:publisher_statement).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:resource_type).of_type(:string).is_array.with_default([]) }
     it { is_expected.to have_jsonb_accessor(:contributor).of_type(:string).is_array.with_default([]) }
     it { is_expected.to have_jsonb_accessor(:publisher).of_type(:string).is_array.with_default([]) }
@@ -171,6 +172,7 @@ RSpec.describe WorkVersion, type: :model do
 
   describe 'singlevalued fields' do
     it_behaves_like 'a singlevalued json field', :description
+    it_behaves_like 'a singlevalued json field', :publisher_statement
     it_behaves_like 'a singlevalued json field', :published_date
     it_behaves_like 'a singlevalued json field', :rights
     it_behaves_like 'a singlevalued json field', :subtitle

--- a/spec/support/feature_helpers/dashboard_form.rb
+++ b/spec/support/feature_helpers/dashboard_form.rb
@@ -13,6 +13,7 @@ module FeatureHelpers
       fill_in_minimal_work_details_for_draft(work_version_metadata)
 
       fill_in 'work_version_description', with: work_version_metadata[:description]
+      fill_in 'work_version_publisher_statement', with: work_version_metadata[:publisher_statement]
       fill_in 'work_version_published_date', with: work_version_metadata[:published_date]
       fill_in 'work_version_keyword', with: work_version_metadata[:keyword]
 


### PR DESCRIPTION
Adds a publishers_statement field to the work version, and moves the keyword field down to "Optional Metadata" because it was never required before.

Fixes #960