### PR TITLE
Allow markdown formatting in publisher statement

### DIFF
--- a/app/decorators/resource_decorator.rb
+++ b/app/decorators/resource_decorator.rb
@@ -77,7 +77,9 @@ class ResourceDecorator < SimpleDelegator
   private
 
     def combined_description
-      [try(:description), try(:publisher_statement)].join(' ')
+      [try(:description), try(:publisher_statement)]
+        .compact
+        .join("\r\n")
     end
 
     def render_markdown(str)

--- a/spec/decorators/resource_decorator_spec.rb
+++ b/spec/decorators/resource_decorator_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe ResourceDecorator do
       end
 
       let(:combined_description) do
-        [resource.description, resource.publisher_statement].join(' ')
+        [resource.description, resource.publisher_statement].join("\r\n")
       end
 
       it 'traps the error and returns the original string' do
@@ -271,7 +271,7 @@ RSpec.describe ResourceDecorator do
     end
 
     it 'returns plain text, without any markdown or html formatting' do
-      expect(description_plain_text).to eq 'This is marked down ##Publisher Statement'
+      expect(description_plain_text).to match(/This is marked down\n\nPublisher Statement/)
       expect(description_plain_text).not_to be_html_safe
     end
 


### PR DESCRIPTION
We need to join the two fields together with the correct combination of line feed and carriage return so that it will all parse as one string.