### PR TITLE
Remove time from deposited date display in metadata component

### DIFF
--- a/app/components/base_metadata_component.rb
+++ b/app/components/base_metadata_component.rb
@@ -35,7 +35,7 @@ class BaseMetadataComponent < ApplicationComponent
       if value.is_a? Enumerable
         format_multi_value(value: value, attr: attr)
       elsif value.respond_to?(:strftime) # Date/Time/DateTime/TimeWithZone etc
-        value.to_formatted_s(:long)
+        value.to_formatted_s(:long_without_time)
       elsif value.is_a? Authorship
         value.display_name
       elsif value.is_a? ApplicationComponent

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 Time::DATE_FORMATS[:short_date] = '%Y-%m-%d'
+Time::DATE_FORMATS[:long_without_time] = '%B %d, %Y'

--- a/spec/components/collection_metadata_component_spec.rb
+++ b/spec/components/collection_metadata_component_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe CollectionMetadataComponent, type: :component do
     end
 
     it 'renders a date with a nice format' do
-      expect(result.css('td.collection-deposited-at').text).to eq 'January 15, 2020 16:07'
+      expect(result.css('td.collection-deposited-at').text).to eq 'January 15, 2020'
     end
 
     it 'renders a multi-value field' do

--- a/spec/components/work_version_metadata_component_spec.rb
+++ b/spec/components/work_version_metadata_component_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
     end
 
     it 'renders a date with a nice format' do
-      expect(result.css('td.work-version-deposited-at').text).to eq 'January 15, 2020 16:07'
+      expect(result.css('td.work-version-deposited-at').text).to eq 'January 15, 2020'
     end
 
     it 'renders a multi-value field' do

--- a/spec/features/catalog/catalog_spec.rb
+++ b/spec/features/catalog/catalog_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'Blacklight catalog page', :inline_jobs do
         end
 
         within('.meta-table') do
-          expect(page).to have_content(resource.deposited_at.to_formatted_s(:long))
+          expect(page).to have_content(resource.deposited_at.to_formatted_s(:long_without_time))
         end
       end
     end


### PR DESCRIPTION
Closes #1030.

### Before
<img width="987" alt="Screen Shot 2021-05-17 at 3 28 39 PM" src="https://user-images.githubusercontent.com/639920/118545444-99aeaf80-b724-11eb-8455-04545e888800.png">

### After
<img width="1009" alt="Screen Shot 2021-05-18 at 11 48 20 AM" src="https://user-images.githubusercontent.com/639920/118683024-0088a300-b7cf-11eb-98d2-d052fd3e4fa8.png">

