### PR TITLE
Fix spacing issues with status badge within document card

### DIFF
--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -5,13 +5,15 @@
   <%= render ThumbnailComponent.new(resource: document) %>
   <div class="card-body">
     <div class="row no-gutters">
-      <div class="col-10">
+      <div class="col-md-8">
         <h3 class="card-title">
           <%= link_to document.title, resource_path(document.id) %>
         </h3>
       </div>
-      <div class="col-2">
-        <%= render WorkVersions::VersionStatusBadgeComponent.new(work_version: document) %>
+      <div class="col-md-4">
+        <div class="float-md-right">
+          <%= render WorkVersions::VersionStatusBadgeComponent.new(work_version: document) %>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
Fixes #1040.

- status badge no longer overlaps right side of card
- status badge collapses to its own row on smaller screens

### Before
<img width="724" alt="Screen Shot 2021-05-19 at 12 49 37 PM" src="https://user-images.githubusercontent.com/639920/118852435-cab3ef00-b8a0-11eb-9f02-ed6f15f4156a.png">

### After
<img width="708" alt="Screen Shot 2021-05-19 at 12 49 53 PM" src="https://user-images.githubusercontent.com/639920/118852456-cee00c80-b8a0-11eb-8fff-8d051cffcb06.png">

### Small Screens Before
<img width="467" alt="Screen Shot 2021-05-19 at 12 50 13 PM" src="https://user-images.githubusercontent.com/639920/118852488-d6071a80-b8a0-11eb-9059-b600261e6707.png">

### Small Screens After
<img width="452" alt="Screen Shot 2021-05-19 at 12 49 59 PM" src="https://user-images.githubusercontent.com/639920/118852508-dbfcfb80-b8a0-11eb-8c4d-c2fd7d000e03.png">
