### PR TITLE
Always show works and work versions

### DIFF
--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -8,7 +8,7 @@ class WorkPolicy < ApplicationPolicy
   end
 
   def show?
-    published? || editable?
+    true
   end
 
   def edit?

--- a/app/policies/work_version_policy.rb
+++ b/app/policies/work_version_policy.rb
@@ -8,9 +8,12 @@ class WorkVersionPolicy < ApplicationPolicy
   end
 
   def show?
-    Pundit.policy(user, record.work).show? || editable?
+    true
   end
-  alias_method :diff?, :show?
+
+  def diff?
+    record.published? || editable?
+  end
 
   def edit?
     return false if record.published? && !user.admin?

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -60,10 +60,9 @@ RSpec.describe ResourcesController, type: :controller do
     context 'when requesting a draft WorkVersion' do
       let(:work_version) { create :work_version, :draft }
 
-      it do
-        expect {
-          get :show, params: { id: work_version.uuid }
-        }.to raise_error(Pundit::NotAuthorizedError)
+      it 'loads the WorkVersion' do
+        get :show, params: { id: work_version.uuid }
+        expect(assigns[:resource]).to eq work_version
       end
     end
 
@@ -84,13 +83,12 @@ RSpec.describe ResourcesController, type: :controller do
       end
     end
 
-    context 'when the resource is valid, but not publicly accessible' do
+    context 'when the resource is valid with no access' do
       let(:work) { create(:work, :with_no_access) }
 
-      it do
-        expect {
-          get :show, params: { id: work.uuid }
-        }.to raise_error(Pundit::NotAuthorizedError)
+      it 'loads the resource' do
+        get :show, params: { id: work.uuid }
+        expect(assigns[:resource]).to eq work
       end
     end
 

--- a/spec/policies/work_policy_spec.rb
+++ b/spec/policies/work_policy_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe WorkPolicy, type: :policy do
       it { is_expected.to permit(depositor, work) }
       it { is_expected.to permit(proxy, work) }
       it { is_expected.to permit(edit_user, work) }
-      it { is_expected.not_to permit(discover_user, work) }
-      it { is_expected.not_to permit(other_user, work) }
-      it { is_expected.not_to permit(public, work) }
+      it { is_expected.to permit(discover_user, work) }
+      it { is_expected.to permit(other_user, work) }
+      it { is_expected.to permit(public, work) }
       it { is_expected.to permit(admin, work) }
       it { is_expected.to permit(application, work) }
     end
@@ -67,9 +67,9 @@ RSpec.describe WorkPolicy, type: :policy do
       it { is_expected.to permit(depositor, work) }
       it { is_expected.to permit(proxy, work) }
       it { is_expected.to permit(edit_user, work) }
-      it { is_expected.not_to permit(discover_user, work) }
-      it { is_expected.not_to permit(other_user, work) }
-      it { is_expected.not_to permit(public, work) }
+      it { is_expected.to permit(discover_user, work) }
+      it { is_expected.to permit(other_user, work) }
+      it { is_expected.to permit(public, work) }
       it { is_expected.to permit(admin, work) }
       it { is_expected.to permit(application, work) }
     end


### PR DESCRIPTION
Draft works and withdrawn works should always resolve. However, their files are still inaccessible, and draft works are not discoverable when navigating existing versions in the resource page.

This ensures that any user who has a url for a draft or withdrawn work will be able to see it, but not discover it via search or browsing other existing versions.

Fixes #1022 
Fixes #970 