### PR TITLE
Allow creation of a new work version from a withdrawn work version

### DIFF
--- a/app/policies/work_version_policy.rb
+++ b/app/policies/work_version_policy.rb
@@ -51,7 +51,7 @@ class WorkVersionPolicy < ApplicationPolicy
 
   def new?
     Pundit.policy(user, record.work).create_version? &&
-      record == record.work.latest_published_version
+      record == record.work.representative_version
   end
 
   private

--- a/spec/policies/work_version_policy_spec.rb
+++ b/spec/policies/work_version_policy_spec.rb
@@ -302,17 +302,17 @@ RSpec.describe WorkVersionPolicy, type: :policy do
   permissions :new? do
     before { allow(Pundit).to receive(:policy).with(user, work).and_return(work_policy) }
 
-    context 'when the parent work is elligible to create a new version' do
+    context 'when the parent work is eligible to create a new version' do
       before { allow(work_policy).to receive(:create_version?).and_return(true) }
 
       context 'when the given work version is the latest published version' do
-        before { allow(work).to receive(:latest_published_version).and_return(work_version) }
+        before { allow(work).to receive(:representative_version).and_return(work_version) }
 
         it { is_expected.to permit(user, work_version) }
       end
 
       context 'when the given work version is NOT the latest published version' do
-        before { allow(work).to receive(:latest_published_version).and_return(instance_double('WorkVersion')) }
+        before { allow(work).to receive(:representative_version).and_return(instance_double('WorkVersion')) }
 
         it { is_expected.not_to permit(user, work_version) }
       end
@@ -322,13 +322,13 @@ RSpec.describe WorkVersionPolicy, type: :policy do
       before { allow(work_policy).to receive(:create_version?).and_return(false) }
 
       context 'when the given work version is the latest published version' do
-        before { allow(work).to receive(:latest_published_version).and_return(work_version) }
+        before { allow(work).to receive(:representative_version).and_return(work_version) }
 
         it { is_expected.not_to permit(user, work_version) }
       end
 
       context 'when the given work version is NOT the latest published version' do
-        before { allow(work).to receive(:latest_published_version).and_return(instance_double('WorkVersion')) }
+        before { allow(work).to receive(:representative_version).and_return(instance_double('WorkVersion')) }
 
         it { is_expected.not_to permit(user, work_version) }
       end


### PR DESCRIPTION
Fixes #1021.

In the case where a work only has 1 version and it is withdrawn, that version is considered the "representative version". The user can now create a new work version from that withdrawn version.

Previously, if there was only 1 work version and it was withdrawn, the user would be unable to create any new versions of that work.