### PR TITLE
Add extracted text derivatives

### DIFF
--- a/app/controllers/api/v1/files_controller.rb
+++ b/app/controllers/api/v1/files_controller.rb
@@ -18,8 +18,18 @@ module Api::V1
 
       def update_metadata
         file_resource.file_attacher.add_metadata(metadata_params)
+        add_extracted_text
         file_resource.file_attacher.write
         file_resource.save
+      end
+
+      def add_extracted_text
+        file_params = derivatives_params[:text]
+        return if file_params.nil?
+
+        file_resource.file_attacher.merge_derivatives(
+          text: Shrine.uploaded_file(file_params.to_h)
+        )
       end
 
       def updated_response
@@ -49,12 +59,18 @@ module Api::V1
 
       def fits_params
         metadata
-          .fetch('fits', {})
+          .fetch(:fits, {})
+          .permit!
+      end
+
+      def derivatives_params
+        params
+          .fetch(:derivatives, {})
           .permit!
       end
 
       def metadata
-        @metadata ||= params.require(:metadata)
+        @metadata ||= params.fetch(:metadata, {})
       end
   end
 end

--- a/app/models/file_resource.rb
+++ b/app/models/file_resource.rb
@@ -22,6 +22,10 @@ class FileResource < ApplicationRecord
     '[unavailable]'
   end
 
+  def extracted_text
+    file_derivatives[:text]
+  end
+
   private
 
     def client

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -3,6 +3,7 @@
 class FileUploader < Shrine
   plugin :backgrounding
   plugin :add_metadata
+  plugin :derivatives
 
   def self.api_endpoint(record)
     File.join(
@@ -34,7 +35,8 @@ class FileUploader < Shrine
     MetadataListener::Job.perform_later(
       path: [file_data['storage'], file_data['id']].join('/'),
       endpoint: FileUploader.api_endpoint(record),
-      api_token: ExternalApp.metadata_listener.token
+      api_token: ExternalApp.metadata_listener.token,
+      services: [:virus, :extracted_text]
     )
   end
 

--- a/spec/controllers/api/v1/files_controller_spec.rb
+++ b/spec/controllers/api/v1/files_controller_spec.rb
@@ -64,6 +64,27 @@ RSpec.describe Api::V1::FilesController, type: :controller do
       end
     end
 
+    context 'when adding derivatives' do
+      let(:upload) do
+        S3Helpers.shrine_upload(file: text_file, storage: Scholarsphere::ShrineConfig::DERIVATIVES_PREFIX)
+      end
+
+      before do
+        patch :update, params: {
+          id: file.id,
+          derivatives: {
+            text: upload
+          }
+        }
+      end
+
+      it 'adds the extracted text file to the record' do
+        expect(response).to be_ok
+        file.reload
+        expect(file.extracted_text.id).to eq(upload[:id])
+      end
+    end
+
     context 'when saving fails' do
       before do
         file.errors.add(:metadata, 'bad')

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Api::V1::IngestController, type: :controller do
 
     context 'when uploading files from S3', vcr: VCRHelpers.depositor_cassette do
       let(:s3_file) do
-        S3Helpers.shrine_upload(Pathname.new(fixture_path).join('image.png'))
+        S3Helpers.shrine_upload(file: Pathname.new(fixture_path).join('image.png'))
       end
 
       before do
@@ -141,7 +141,7 @@ RSpec.describe Api::V1::IngestController, type: :controller do
 
     context 'with missing parameters' do
       let(:s3_file) do
-        S3Helpers.shrine_upload(Pathname.new(fixture_path).join('image.png'))
+        S3Helpers.shrine_upload(file: Pathname.new(fixture_path).join('image.png'))
       end
 
       before do

--- a/spec/support/fixture_file.rb
+++ b/spec/support/fixture_file.rb
@@ -3,3 +3,10 @@
 def fixture_file(filename)
   Pathname.new(RSpec.configuration.fixture_path).join(filename)
 end
+
+def text_file
+  file = Tempfile.new(['', '.txt'])
+  file.write(Faker::Lorem.paragraph)
+  file.close
+  Pathname.new(file)
+end

--- a/spec/support/s3_helpers.rb
+++ b/spec/support/s3_helpers.rb
@@ -8,10 +8,10 @@ class S3Helpers
   # well as some additional metadata that Shrine will use. Here, we are creating a component part of that last request
   # by uploading the file directly into S3 (bypassing the pre-signed url + post process) and returning a hash which can
   # be incorporated into the ingest request to Scholarsphere.
-  def self.shrine_upload(file)
+  def self.shrine_upload(file:, storage: Scholarsphere::ShrineConfig::CACHE_PREFIX)
     path = Pathname.new(file)
     id = "#{SecureRandom.uuid}#{path.extname}"
-    key = "#{Scholarsphere::ShrineConfig::CACHE_PREFIX}/#{id}"
+    key = "#{storage}/#{id}"
     options = Api::V1::UploadsController.new.send(:s3_options)
     client = Aws::S3::Client.new(options)
 
@@ -19,7 +19,7 @@ class S3Helpers
 
     {
       id: id,
-      storage: Scholarsphere::ShrineConfig::CACHE_PREFIX,
+      storage: storage,
       metadata: {
         size: file.size,
         filename: file.basename.to_s,


### PR DESCRIPTION
Adds a derivative file, as defined according to Shrine, to an existing file resource containing the extracted text found in the original file. The derivative is created and uploaded via an external applicaiton, in this case, the metadata-listener, and then the resulting file is added to the file resource with an API call.

Fixes #1023 