### PR TITLE
Index files into Solr

### DIFF
--- a/app/models/file_resource.rb
+++ b/app/models/file_resource.rb
@@ -4,6 +4,9 @@ class FileResource < ApplicationRecord
   include FileUploader::Attachment(:file)
   include DepositedAtTimestamp
   include ViewStatistics
+  include GeneratedUuids
+
+  attr_writer :indexing_source
 
   has_many :file_version_memberships, dependent: :destroy
   has_many :work_versions, through: :file_version_memberships
@@ -12,7 +15,20 @@ class FileResource < ApplicationRecord
            as: :resource,
            dependent: :destroy
 
-  # @note Using `head_object` will retrieve the metadata without retriving the entire object.
+  after_save :perform_update_index
+
+  def self.reindex_all(relation: all, async: false)
+    relation.find_each do |file|
+      if async
+        SolrIndexingJob.perform_later(file, commit: false)
+      else
+        SolrIndexingJob.perform_now(file, commit: false)
+      end
+    end
+    IndexingService.commit
+  end
+
+  # @note Using `head_object` will retrieve the metadata without retrieving the entire object.
   def etag
     @etag ||= client
       .head_object(bucket: ENV['AWS_BUCKET'], key: "#{file_data['storage']}/#{file_data['id']}")
@@ -26,9 +42,31 @@ class FileResource < ApplicationRecord
     file_derivatives[:text]
   end
 
+  def to_solr
+    document_builder.generate(resource: self)
+  end
+
+  def update_index(commit: true)
+    IndexingService.add_document(to_solr, commit: commit)
+  end
+
+  def indexing_source
+    @indexing_source ||= SolrIndexingJob.public_method(:perform_later)
+  end
+
   private
 
     def client
       @client ||= Aws::S3::Client.new
+    end
+
+    def document_builder
+      SolrDocumentBuilder.new(
+        FileResourceSchema
+      )
+    end
+
+    def perform_update_index
+      indexing_source.call(self)
     end
 end

--- a/app/schemas/file_resource_schema.rb
+++ b/app/schemas/file_resource_schema.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class FileResourceSchema < BaseSchema
+  def document
+    DefaultSchema.new(resource: resource)
+      .document
+      .merge(extracted_text_document)
+  end
+
+  def reject
+    [:file_data_tesim]
+  end
+
+  private
+
+    def extracted_text_document
+      return {} if extracted_text.nil?
+
+      {
+        extracted_text_tei: text_content
+      }
+    end
+
+    def extracted_text
+      @extracted_text ||= resource.extracted_text
+    end
+
+    def text_content
+      extracted_text.rewind
+      extracted_text.read
+    end
+end

--- a/db/migrate/20210526151833_add_uuid_to_file_resource.rb
+++ b/db/migrate/20210526151833_add_uuid_to_file_resource.rb
@@ -1,0 +1,7 @@
+class AddUuidToFileResource < ActiveRecord::Migration[6.1]
+  def change
+    enable_extension 'uuid-ossp'
+    add_column :file_resources, :uuid, :uuid, default: 'uuid_generate_v4()'
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_24_193520) do
+ActiveRecord::Schema.define(version: 2021_05_26_151833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -132,6 +132,7 @@ ActiveRecord::Schema.define(version: 2021_03_24_193520) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "deposited_at"
+    t.uuid "uuid", default: -> { "uuid_generate_v4()" }
   end
 
   create_table "file_version_memberships", force: :cascade do |t|

--- a/lib/tasks/solr.rake
+++ b/lib/tasks/solr.rake
@@ -27,7 +27,12 @@ namespace :solr do
     Collection.reindex_all
   end
 
-  desc 'Reindexes all works and collections into Solr'
-  task reindex_all: [:environment, :reindex_works, :reindex_collections] do
+  desc 'Reindexes all the files into Solr'
+  task reindex_files: :environment do
+    FileResource.reindex_all
+  end
+
+  desc 'Reindexes all works, collections, and files into Solr'
+  task reindex_all: [:environment, :reindex_works, :reindex_collections, :reindex_files] do
   end
 end

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -433,7 +433,10 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
       # Save, reload the page, and ensure that it's now in the files table
       FeatureHelpers::DashboardForm.save_as_draft_and_exit
-      expect(SolrIndexingJob).to have_received(:perform_later).once
+
+      # Once for the work version, twice for the file. The second call for the file is most likely the promotion job.
+      expect(SolrIndexingJob).to have_received(:perform_later).thrice
+
       visit dashboard_form_files_path(work_version)
 
       within('.table') do

--- a/spec/schemas/file_resource_schema_spec.rb
+++ b/spec/schemas/file_resource_schema_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FileResourceSchema do
+  subject { described_class.new(resource: resource) }
+
+  let(:resource) { instance_spy('FileResource', extracted_text: extracted_text) }
+
+  describe '#document' do
+    let(:extracted_text) { nil }
+
+    context 'when there is no extracted text' do
+      its(:document) { is_expected.to be_empty }
+    end
+
+    context 'when there is an extracted text file' do
+      let(:extracted_text_file) { text_file }
+
+      let(:extracted_text) do
+        Shrine.upload(extracted_text_file.open, :store, metadata: false)
+      end
+
+      its(:document) { is_expected.to eq({ extracted_text_tei: extracted_text_file.read }) }
+    end
+  end
+end


### PR DESCRIPTION
Adds a schema and callbacks so that file resources are indexed into Solr with their extracted text.

Note: This will also add UUIDs to existing file resources and should be deployed during the maintenance window with the application in read-only mode.

Fixes #1024 