### PR TITLE
Index async when indexing everything

### DIFF
--- a/lib/tasks/solr.rake
+++ b/lib/tasks/solr.rake
@@ -24,12 +24,12 @@ namespace :solr do
 
   desc 'Reindexes all the collections into Solr'
   task reindex_collections: :environment do
-    Collection.reindex_all
+    Collection.reindex_all(async: true)
   end
 
   desc 'Reindexes all the files into Solr'
   task reindex_files: :environment do
-    FileResource.reindex_all
+    FileResource.reindex_all(async: true)
   end
 
   desc 'Reindexes all works, collections, and files into Solr'


### PR DESCRIPTION
Ensure that all reindexing via `rake solr:reindex_all` is done asynchronously.