### PR TITLE
Enable searching of extracted text

### DIFF
--- a/app/models/dashboard/search_builder.rb
+++ b/app/models/dashboard/search_builder.rb
@@ -9,6 +9,7 @@ module Dashboard
     include CatalogSearchBehavior
 
     self.default_processor_chain += %i(
+      search_related_files
       restrict_search_to_works_and_collections
       apply_gated_edit
       log_solr_parameters

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -8,6 +8,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   include CatalogSearchBehavior
 
   self.default_processor_chain += %i(
+    search_related_files
     restrict_search_to_works_and_collections
     apply_gated_discovery
     limit_to_public_resources

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -291,7 +291,8 @@ class WorkVersion < ApplicationRecord
         PublishedDateSchema,
         FacetSchema,
         DoiSchema,
-        TitleSchema
+        TitleSchema,
+        MemberFilesSchema
       )
     end
 end

--- a/app/schemas/member_files_schema.rb
+++ b/app/schemas/member_files_schema.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class MemberFilesSchema < BaseSchema
+  def document
+    return {} unless resource.respond_to?(:file_resources)
+
+    {
+      file_resource_ids_ssim: file_uuids,
+      file_version_titles_ssim: resource.file_version_memberships.pluck(:title)
+    }
+  end
+
+  private
+
+    # @note In the case where the file resources have just been created, we need to reload them from the database to the
+    # get the generated UUIDs.
+    def file_uuids
+      uuids = resource.file_resources.pluck(:uuid)
+
+      return uuids unless uuids.include?(nil)
+
+      resource.file_resources.reload.pluck(:uuid)
+    end
+end

--- a/app/schemas/representative_version_schema.rb
+++ b/app/schemas/representative_version_schema.rb
@@ -10,6 +10,7 @@ class RepresentativeVersionSchema < BaseSchema
       .merge(published_date_schema.document)
       .merge(facet_schema.document)
       .merge(title_schema.document)
+      .merge(member_files_schema.document)
   end
 
   private
@@ -28,5 +29,9 @@ class RepresentativeVersionSchema < BaseSchema
 
     def title_schema
       TitleSchema.new(resource: resource.representative_version)
+    end
+
+    def member_files_schema
+      MemberFilesSchema.new(resource: resource.representative_version)
     end
 end

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -213,6 +213,7 @@
       copyField also supports a maxChars to copy setting.  -->
 
   <copyField source="*_tsim" dest="all_text_timv" maxChars="3000"/>
+  <copyField source="*_tei" dest="all_text_timv" maxChars="3000"/>
   <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/>
   <copyField source="*_ssim" dest="all_text_timv" maxChars="3000"/>
   <copyField source="*_si" dest="all_text_timv" maxChars="3000"/>

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -46,6 +46,7 @@
         based_near_tesim
         contributor_tesim
         creators_tesim
+        extracted_text_tei
         id
         identifier_tesim
         keyword_tesim

--- a/spec/models/dashboard/search_builder_spec.rb
+++ b/spec/models/dashboard/search_builder_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Dashboard::SearchBuilder do
     its(:default_processor_chain) do
       is_expected.to include(
         :log_solr_parameters,
+        :search_related_files,
         :restrict_search_to_works_and_collections,
         :apply_gated_edit
       )
@@ -22,17 +23,47 @@ RSpec.describe Dashboard::SearchBuilder do
   describe '#processed_parameters' do
     let(:parameters) { builder.processed_parameters }
 
-    it 'searches works and collections' do
-      expect(parameters['fq']).to include('{!terms f=model_ssi}Work,Collection')
+    context 'with no user input' do
+      it 'searches works and collections' do
+        expect(parameters['fq']).to include('{!terms f=model_ssi}Work,Collection')
+      end
+
+      it "restricts search based on the users' permissions" do
+        expect(parameters['fq']).to include(
+          "({!terms f=edit_groups_ssim}#{Group::PUBLIC_AGENT_NAME},#{Group::AUTHORIZED_AGENT_NAME}) " \
+          "OR edit_users_ssim:#{user.access_id} " \
+          "OR {!terms f=depositor_id_isi}#{user.actor.id} " \
+          "OR {!terms f=proxy_id_isi}#{user.actor.id}"
+        )
+      end
     end
 
-    it "restricts search based on the users' permissions" do
-      expect(parameters['fq']).to include(
-        "({!terms f=edit_groups_ssim}#{Group::PUBLIC_AGENT_NAME},#{Group::AUTHORIZED_AGENT_NAME}) " \
-        "OR edit_users_ssim:#{user.access_id} " \
-        "OR {!terms f=depositor_id_isi}#{user.actor.id} " \
-        "OR {!terms f=proxy_id_isi}#{user.actor.id}"
-      )
+    context 'with user input _explicitly_ on all fields' do
+      let(:parameters) { builder.with({ search_field: 'all_fields' }).where('user query').processed_parameters }
+
+      it 'searches related files' do
+        expect(parameters['q']).to eq(
+          '{!lucene}{!dismax v=user query} {!join from=id to=file_resource_ids_ssim}{!dismax v=user query}'
+        )
+      end
+    end
+
+    context 'with user input _implicitly_ on all fields' do
+      let(:parameters) { builder.with({}).where('user query').processed_parameters }
+
+      it 'searches related files' do
+        expect(parameters['q']).to eq(
+          '{!lucene}{!dismax v=user query} {!join from=id to=file_resource_ids_ssim}{!dismax v=user query}'
+        )
+      end
+    end
+
+    context 'with user input on _specificly_ on a given field' do
+      let(:parameters) { builder.with({ search_field: 'my_field' }).where('user query').processed_parameters }
+
+      it 'does NOT search related fields' do
+        expect(parameters['q']).to eq('user query')
+      end
     end
 
     context 'with an admin user' do

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe SearchBuilder do
   describe '.default_processor_chain' do
     its(:default_processor_chain) do
       is_expected.to include(
+        :search_related_files,
         :restrict_search_to_works_and_collections,
         :apply_gated_discovery,
         :limit_to_public_resources,
@@ -57,6 +58,34 @@ RSpec.describe SearchBuilder do
         expect(parameters['fq']).to include(
           '-embargoed_until_dtsi:[NOW TO *]'
         )
+      end
+    end
+
+    context 'with user input _explicitly_ on all fields' do
+      let(:parameters) { builder.with({ search_field: 'all_fields' }).where('user query').processed_parameters }
+
+      it 'searches related files' do
+        expect(parameters['q']).to eq(
+          '{!lucene}{!dismax v=user query} {!join from=id to=file_resource_ids_ssim}{!dismax v=user query}'
+        )
+      end
+    end
+
+    context 'with user input _implicitly_ on all fields' do
+      let(:parameters) { builder.with({}).where('user query').processed_parameters }
+
+      it 'searches related files' do
+        expect(parameters['q']).to eq(
+          '{!lucene}{!dismax v=user query} {!join from=id to=file_resource_ids_ssim}{!dismax v=user query}'
+        )
+      end
+    end
+
+    context 'with user input on _specificly_ on a given field' do
+      let(:parameters) { builder.with({ search_field: 'my_field' }).where('user query').processed_parameters }
+
+      it 'does NOT search related fields' do
+        expect(parameters['q']).to eq('user query')
       end
     end
   end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -374,6 +374,8 @@ RSpec.describe Work, type: :model do
           edit_groups_ssim
           edit_users_ssim
           embargoed_until_dtsi
+          file_resource_ids_ssim
+          file_version_titles_ssim
           id
           identifier_tesim
           keyword_sim
@@ -383,8 +385,8 @@ RSpec.describe Work, type: :model do
           proxy_id_isi
           published_date_dtrsi
           published_date_tesim
-          publisher_tesim
           publisher_statement_tesim
+          publisher_tesim
           read_groups_ssim
           read_users_ssim
           related_url_tesim

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -326,23 +326,27 @@ RSpec.describe WorkVersion, type: :model do
   end
 
   describe '#to_solr' do
-    subject(:work_version) { create(:work_version, published_date: '1999-uu-uu') }
+    subject(:work_version) { create(:work_version, :with_files, published_date: '1999-uu-uu') }
+
+    before { work_version.file_resources.reload }
 
     its(:to_solr) do
       is_expected.to include(
         all_dois_ssim: an_instance_of(Array),
+        depositor_id_isi: work_version.work.depositor.id,
+        discover_groups_ssim: [Group::PUBLIC_AGENT_NAME],
+        discover_users_ssim: [],
+        display_work_type_ssi: Work::Types.display(work_version.work_type),
+        embargoed_until_dtsi: nil,
+        file_resource_ids_ssim: [work_version.file_resources.first.uuid],
+        file_version_titles_ssim: [work_version.file_version_memberships.first.title],
+        latest_version_bsi: false,
+        proxy_id_isi: nil,
+        published_date_dtrsi: '1999',
         title_ssort: kind_of(String),
         title_tesim: [work_version.title],
-        latest_version_bsi: false,
-        display_work_type_ssi: Work::Types.display(work_version.work_type),
-        work_type_ss: work_version.work_type,
-        published_date_dtrsi: '1999',
-        embargoed_until_dtsi: nil,
-        depositor_id_isi: work_version.work.depositor.id,
-        proxy_id_isi: nil,
-        discover_users_ssim: [],
-        discover_groups_ssim: [Group::PUBLIC_AGENT_NAME],
-        visibility_ssi: Permissions::Visibility::OPEN
+        visibility_ssi: Permissions::Visibility::OPEN,
+        work_type_ss: work_version.work_type
       )
     end
   end

--- a/spec/schemas/member_files_schema_spec.rb
+++ b/spec/schemas/member_files_schema_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MemberFilesSchema, type: :schema do
+  subject { described_class.new(resource: resource) }
+
+  describe '#document' do
+    context 'when the resource has files' do
+      let(:resource) { create(:work_version, :with_files) }
+
+      its(:document) do
+        is_expected.to eq({
+                            file_resource_ids_ssim: [resource.file_resources.first.uuid],
+                            file_version_titles_ssim: [resource.file_version_memberships.first.title]
+                          })
+      end
+    end
+
+    context 'when the resource has NO files' do
+      let(:resource) { create(:work_version) }
+
+      its(:document) do
+        is_expected.to eq({
+                            file_resource_ids_ssim: [],
+                            file_version_titles_ssim: []
+                          })
+      end
+    end
+
+    context 'with an unsupported resource' do
+      let(:resource) { Struct.new('UnsupportedResource').new }
+
+      its(:document) { is_expected.to be_empty }
+    end
+  end
+end


### PR DESCRIPTION
Returns a work if any of its associated files contain text that matches the user's query. It uses a Solr join to link the work to the file resource in Solr, which uses the Lucene query parser and not the default edismax one.

Fixes #1025 