### PR TITLE
WorkVersionDetailComponent

### DIFF
--- a/app/components/work_version_detail_component.html.erb
+++ b/app/components/work_version_detail_component.html.erb
@@ -1,0 +1,7 @@
+<div class="alert alert-warning" role="alert">
+  <%= t "resources.#{i18n_key}.message" %>
+
+  <%= link_to t("resources.#{i18n_key}.link"),
+              resource_path(linked_version),
+              class: 'alert-link' %>
+</div>

--- a/app/components/work_version_detail_component.rb
+++ b/app/components/work_version_detail_component.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class WorkVersionDetailComponent < ApplicationComponent
+  attr_reader :work_version
+
+  def initialize(work_version:)
+    @work_version = work_version
+  end
+
+  def render?
+    !current_draft_version? && i18n_key.present?
+  end
+
+  def i18n_key
+    if draft_version.present?
+      'draft_version'
+    elsif representative_version.published? && (work_version.uuid != representative_version.uuid)
+      'old_version'
+    end
+  end
+
+  def linked_version
+    if draft_version.present?
+      work_version.work.draft_version.uuid
+    elsif representative_version.published?
+      work_version.work.uuid
+    end
+  end
+
+  private
+
+    def representative_version
+      @representative_version ||= work_version.work.representative_version
+    end
+
+    def draft_version
+      @draft_version ||= begin
+                           unless Pundit.policy(controller.current_user, work_version.work).edit?
+                             return NullWorkVersion.new
+                           end
+
+                           work_version.work.draft_version || NullWorkVersion.new
+                         end
+    end
+
+    def current_draft_version?
+      work_version.uuid == draft_version.uuid
+    end
+end

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -47,14 +47,7 @@
 
 <div class="container-fluid">
 
-  <% unless (work_version.latest_published_version? || work_version.draft? || work_version.withdrawn?) %>
-    <div class="alert alert-warning" role="alert">
-      <%= t 'resources.old_version.message' %>
-      <%= link_to t('resources.old_version.link'),
-                  resource_path(work_version.work.uuid),
-                  class: 'alert-link' %>
-    </div>
-  <% end %>
+  <%= render WorkVersionDetailComponent.new(work_version: work_version) %>
 
   <article class="row">
     <div class="col-lg-7">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -509,6 +509,9 @@ en:
     old_version:
       link: View the current version.
       message: This is an older version of the work.
+    draft_version:
+      link: View the draft version.
+      message: An updated draft version for this work is available.
     work_history: Work History
     works: Works
     doi:

--- a/spec/components/work_version_detail_component_spec.rb
+++ b/spec/components/work_version_detail_component_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WorkVersionDetailComponent, type: :component do
+  subject(:content) { render_inline(described_class.new(work_version: work_version)).to_s }
+
+  let(:work) { build_stubbed(:work) }
+  let(:work_version) { build_stubbed(:work_version, work: work) }
+  let(:user) { build_stubbed(:user) }
+  let(:controller_name) { 'application' }
+  let(:mock_controller) do
+    instance_double('ApplicationController', current_user: user, controller_name: controller_name)
+  end
+
+  before do
+    allow_any_instance_of(described_class).to receive(:controller).and_return(mock_controller)
+  end
+
+  context 'when a current (editable) draft version exists' do
+    let(:user) { work.depositor.user }
+
+    context 'when the work version is the current draft version' do
+      before { allow(work).to receive(:draft_version).and_return(work_version) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when another version is the draft version' do
+      let(:other_version) { build_stubbed(:work_version) }
+
+      before { allow(work).to receive(:draft_version).and_return(other_version) }
+
+      it { is_expected.to include('An updated draft version for this work is available') }
+      it { is_expected.to include(other_version.uuid) }
+    end
+  end
+
+  context 'when a current (editable) draft version does NOT exist' do
+    context 'when the work version is the current draft version' do
+      before { allow(work).to receive(:draft_version).and_return(work_version) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the work version is the current published version' do
+      before do
+        allow(work).to receive(:representative_version).and_return(work_version)
+        allow(work_version).to receive(:published?).and_return(true)
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when another version is the current published version' do
+      let(:other_version) { build_stubbed(:work_version) }
+
+      before do
+        allow(work).to receive(:representative_version).and_return(other_version)
+        allow(other_version).to receive(:published?).and_return(true)
+      end
+
+      it { is_expected.to include('This is an older version of the work') }
+      it { is_expected.to include(work.uuid) }
+    end
+  end
+end


### PR DESCRIPTION
Replaces in the in-view logic with a separate component to determine messages displayed to the user. If the user can edit the work, and a draft exists, then the message will give them a link to it.

If the user does not have edit rights, the message only appears if another published version exists.

Fixes #1058 