### PR TITLE
Google Scholar Metadata: use file_version_memberships for download URLs

### DIFF
--- a/app/components/google_scholar_metadata_component.html.erb
+++ b/app/components/google_scholar_metadata_component.html.erb
@@ -4,6 +4,6 @@
   <meta name="citation_author" content="<%= author %>">
 <%- end %>
 <meta name="citation_publication_date" content="<%= citation_publication_date %>">
-<%- file_resources.each do |file| %>
+<%- file_version_memberships.includes(:file_resource).each do |file| %>
   <meta name="citation_pdf_url" content="<%= resource_download_url(file.id, resource_id: resource.uuid) %>">
 <%- end %>

--- a/app/components/google_scholar_metadata_component.rb
+++ b/app/components/google_scholar_metadata_component.rb
@@ -31,9 +31,9 @@ class GoogleScholarMetadataComponent < ApplicationComponent
     Date.edtf(published_date).year
   end
 
-  def file_resources
-    return [] unless policy.download?
+  def file_version_memberships
+    return FileVersionMembership.none unless policy.download?
 
-    resource.file_resources
+    resource.file_version_memberships
   end
 end


### PR DESCRIPTION
Fixes #1048.

Previously, the `GoogleScholarMetadataComponent` was using `file_resource` to generate the download URL. This resulted in broken links for `citation_pdf_url` in the metadata. With this change, `citation_pdf_url`s actually resolve, and match the download links in the body of the page.