### PR TITLE
Validate format of DOIs in the doi field

### DIFF
--- a/app/models/concerns/all_dois.rb
+++ b/app/models/concerns/all_dois.rb
@@ -16,6 +16,11 @@ module AllDois
       symbolized_args = args.map(&:to_sym)
       define_method(:fields_with_dois) { symbolized_args }
     end
+
+    # Validates the Datacite DOI field to ensure it's in the correct format for the API
+    validates :doi,
+              datacite_doi: true,
+              unless: -> { doi.blank? }
   end
 
   # Returns an arary of all valid dois found within the methods specified by the

--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -6,6 +6,14 @@ class Doi
 
   MANAGED_PREFIXES = ['10.26207', '10.18113'].freeze
 
+  # @note If the DOI is valid from Datacite's point of view, it will be valid from our perspective, as well as have one
+  # of our managed prefixes, _and_ have a particular format that the Datacite API can interpret.
+  def self.valid_datacite_doi?(doi)
+    formatted_doi = new(doi)
+
+    formatted_doi.valid? && formatted_doi.managed? && doi == formatted_doi.to_datacite
+  end
+
   # @param [String] doi
   def initialize(doi)
     @doi = begin
@@ -39,6 +47,10 @@ class Doi
 
   def uri
     URI("https://doi.org/#{prefix}/#{suffix}")
+  end
+
+  def to_datacite
+    "#{prefix}/#{suffix}"
   end
 
   private

--- a/app/validators/datacite_doi_validator.rb
+++ b/app/validators/datacite_doi_validator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DataciteDoiValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if Doi.valid_datacite_doi?(value)
+
+    record.errors.add(attribute, (options[:message] || :invalid_doi))
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,6 +159,7 @@ en:
     messages:
       invalid_edtf: is not a valid date in EDTF format
       invalid_orcid: is not a valid ORCiD id
+      invalid_doi: is not a properly formatted DOI from our Datacite service
     not_found:
       heading: Resource not found or unavailable
       content: >

--- a/spec/controllers/dois_controller_spec.rb
+++ b/spec/controllers/dois_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe DoisController, type: :controller do
       end
 
       context 'with a Work that already has a DOI' do
-        let(:resource) { create :work, doi: '123/456' }
+        let(:resource) { create :work, doi: FactoryBotHelpers.datacite_doi }
 
         it 'does NOT mint a new doi' do
           do_post

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -41,7 +41,7 @@ FactoryBot.define do
     end
 
     trait :with_a_doi do
-      doi { FactoryBotHelpers.valid_doi }
+      doi { FactoryBotHelpers.datacite_doi }
     end
   end
 end

--- a/spec/features/dashboard/collection_settings_spec.rb
+++ b/spec/features/dashboard/collection_settings_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'Collection Settings Page', with_user: :user do
     context 'when an admin user' do
       let(:user) { create :user, :admin }
 
-      before { collection.update!(doi: FactoryBotHelpers.valid_doi) }
+      before { collection.update!(doi: FactoryBotHelpers.datacite_doi) }
 
       it 'allows a collection to be deleted' do
         visit edit_dashboard_collection_path(collection)

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -286,10 +286,9 @@ RSpec.describe Collection, type: :model do
     end
 
     context 'when the collection has a doi' do
-      let(:collection) { build(:collection) }
+      let(:collection) { build(:collection, :with_a_doi) }
 
       it 'updates the metadata with DataCite' do
-        collection.doi = 'a doi'
         collection.update_doi = true
         collection.save
         expect(DoiUpdatingJob).to have_received(:perform_later).with(collection)

--- a/spec/models/concerns/all_dois_spec.rb
+++ b/spec/models/concerns/all_dois_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe AllDois do
 
   before(:all) do
     class TestModel
+      # @note This is to fake ActiveRecord integration
+      def self.validates(*args)
+        # noop
+      end
+
       include AllDois
       fields_with_dois :doi, :identifier, :other
 

--- a/spec/models/doi_search_spec.rb
+++ b/spec/models/doi_search_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe DoiSearch do
-  let!(:work_version_1) { create :work_version, doi: 'doi:10.26207/upw2-pkx3' }
-  let!(:work_version_2) { create :work_version, doi: 'doi:10.18113/dmnf-6dzs', identifier: ['doi:10.26207/upw2-pkx3'] }
-  let!(:collection) { create :collection, doi: 'doi:10.18113/qi03-b693' }
+  let!(:work_version_1) { create :work_version, doi: '10.26207/upw2-pkx3' }
+  let!(:work_version_2) { create :work_version, doi: '10.18113/dmnf-6dzs', identifier: ['doi:10.26207/upw2-pkx3'] }
+  let!(:collection) { create :collection, doi: '10.18113/qi03-b693' }
 
   before do
     Work.reindex_all(async: false)

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Doi do
   context 'with doi:10.26207/jc7z-sa94' do
     let(:doi) { 'doi:10.26207/jc7z-sa94' }
 
+    specify { expect(described_class).not_to be_valid_datacite_doi(doi) }
     it { is_expected.to be_valid }
     it { is_expected.to be_managed }
     its(:prefix) { is_expected.to eq('10.26207') }
@@ -15,12 +16,14 @@ RSpec.describe Doi do
     its(:registrant_code) { is_expected.to eq('26207') }
     its(:suffix) { is_expected.to eq('jc7z-sa94') }
     its(:to_s) { is_expected.to eq('doi:10.26207/jc7z-sa94') }
+    its(:to_datacite) { is_expected.to eq('10.26207/jc7z-sa94') }
     its(:uri) { is_expected.to eq(URI('https://doi.org/10.26207/jc7z-sa94')) }
   end
 
   context 'with doi:10.18113/S1X934' do
     let(:doi) { 'doi:10.18113/S1X934' }
 
+    specify { expect(described_class).not_to be_valid_datacite_doi(doi) }
     it { is_expected.to be_valid }
     it { is_expected.to be_managed }
   end
@@ -30,13 +33,19 @@ RSpec.describe Doi do
 
     before { ENV['DATACITE_PREFIX'] = "10.#{Faker::Number.number(digits: 5)}" }
 
+    specify { expect(described_class).not_to be_valid_datacite_doi(doi) }
     it { is_expected.to be_valid }
     it { is_expected.to be_managed }
+  end
+
+  context 'with a valid Datacite DOI' do
+    specify { expect(described_class).to be_valid_datacite_doi(FactoryBotHelpers.datacite_doi) }
   end
 
   context 'with https://doi.org/10.1515/pol-2020-2011' do
     let(:doi) { 'https://doi.org/10.1515/pol-2020-2011' }
 
+    specify { expect(described_class).not_to be_valid_datacite_doi(doi) }
     it { is_expected.to be_valid }
     it { is_expected.not_to be_managed }
     its(:prefix) { is_expected.to eq('10.1515') }
@@ -44,12 +53,14 @@ RSpec.describe Doi do
     its(:registrant_code) { is_expected.to eq('1515') }
     its(:suffix) { is_expected.to eq('pol-2020-2011') }
     its(:to_s) { is_expected.to eq('doi:10.1515/pol-2020-2011') }
+    its(:to_datacite) { is_expected.to eq('10.1515/pol-2020-2011') }
     its(:uri) { is_expected.to eq(URI('https://doi.org/10.1515/pol-2020-2011')) }
   end
 
   context 'with 10.1007/s10570-013-0029-x' do
     let(:doi) { '10.1007/s10570-013-0029-x' }
 
+    specify { expect(described_class).not_to be_valid_datacite_doi(doi) }
     it { is_expected.to be_valid }
     it { is_expected.not_to be_managed }
     its(:prefix) { is_expected.to eq('10.1007') }
@@ -57,12 +68,14 @@ RSpec.describe Doi do
     its(:registrant_code) { is_expected.to eq('1007') }
     its(:suffix) { is_expected.to eq('s10570-013-0029-x') }
     its(:to_s) { is_expected.to eq('doi:10.1007/s10570-013-0029-x') }
+    its(:to_datacite) { is_expected.to eq('10.1007/s10570-013-0029-x') }
     its(:uri) { is_expected.to eq(URI('https://doi.org/10.1007/s10570-013-0029-x')) }
   end
 
   context 'with a mult-segment doi like "doi:10.21345/asdf/qwer"' do
     let(:doi) { 'doi:10.21345/asdf/qwer' }
 
+    specify { expect(described_class).not_to be_valid_datacite_doi(doi) }
     it { is_expected.to be_valid }
     it { is_expected.not_to be_managed }
     its(:prefix) { is_expected.to eq('10.21345') }
@@ -70,6 +83,7 @@ RSpec.describe Doi do
     its(:registrant_code) { is_expected.to eq('21345') }
     its(:suffix) { is_expected.to eq('asdf/qwer') }
     its(:to_s) { is_expected.to eq('doi:10.21345/asdf/qwer') }
+    its(:to_datacite) { is_expected.to eq('10.21345/asdf/qwer') }
     its(:uri) { is_expected.to eq(URI('https://doi.org/10.21345/asdf/qwer')) }
   end
 

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -396,7 +396,7 @@ RSpec.describe WorkVersion, type: :model do
       let(:work_version) { build(:work_version, :published) }
 
       it 'updates the metadata with DataCite' do
-        work_version.work.doi = 'a doi'
+        work_version.work.doi = FactoryBotHelpers.datacite_doi
         work_version.update_doi = true
         work_version.save
         expect(DoiUpdatingJob).to have_received(:perform_later)

--- a/spec/request/api/v1/dois_spec.rb
+++ b/spec/request/api/v1/dois_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'API V1 DOIs', type: :request do
-  let!(:collection) { create :collection, doi: 'doi:10.26207/utaj-jfhi' }
+  let!(:collection) { create :collection, doi: '10.26207/utaj-jfhi' }
 
   let(:api_token) { create(:api_token).token }
   let(:json_response) { JSON.parse(response.body) }

--- a/spec/support/factory_bot_helpers.rb
+++ b/spec/support/factory_bot_helpers.rb
@@ -46,4 +46,8 @@ module FactoryBotHelpers
   def self.unmanaged_doi
     "doi:10.#{Faker::Number.number(digits: 5)}/#{Faker::Alphanumeric.alphanumeric(number: 8).insert(4, '-')}"
   end
+
+  def self.datacite_doi
+    "#{Doi::MANAGED_PREFIXES.sample}/#{Faker::Alphanumeric.alphanumeric(number: 8).insert(4, '-')}"
+  end
 end

--- a/spec/support/shared/a_resource_that_can_provide_all_dois_in.rb
+++ b/spec/support/shared/a_resource_that_can_provide_all_dois_in.rb
@@ -3,4 +3,11 @@
 RSpec.shared_examples 'a resource that can provide all DOIs in' do |fields_with_dois|
   its(:fields_with_dois) { is_expected.to match_array fields_with_dois }
   its(:all_dois) { is_expected.to be_a Array }
+
+  describe 'DOI validations' do
+    it { is_expected.not_to allow_value(FactoryBotHelpers.valid_doi).for(:doi) }
+    it { is_expected.not_to allow_value(FactoryBotHelpers.invalid_doi).for(:doi) }
+    it { is_expected.not_to allow_value(FactoryBotHelpers.unmanaged_doi).for(:doi) }
+    it { is_expected.to allow_value(FactoryBotHelpers.datacite_doi).for(:doi) }
+  end
 end

--- a/spec/validators/datacite_doi_validator_spec.rb
+++ b/spec/validators/datacite_doi_validator_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DataciteDoiValidator do
+  subject(:model) { DataciteDoiTestModel.new }
+
+  before do
+    stub_const('DataciteDoiTestModel', Struct.new(:doi_field) {
+      include ActiveModel::Validations
+      validates :doi_field, datacite_doi: true
+    })
+  end
+
+  context 'with a valid Datacite DOI' do
+    before { model.doi_field = FactoryBotHelpers.datacite_doi }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with a invalid Datacite DOI' do
+    # A valid DOI does not mean a valid Datacite DOI
+    before { model.doi_field = FactoryBotHelpers.valid_doi }
+
+    it 'is expected not to be valid' do
+      expect(model).not_to be_valid
+      expect(model.errors[:doi_field]).to contain_exactly(
+        I18n.t('errors.messages.invalid_doi')
+      )
+    end
+  end
+end


### PR DESCRIPTION
Models that have the :doi field are required to have dois that are valid, managed, and formatted so that they can be updated by the Datacite API. Previously, any valid and manged DOI would suffice, but the API was unable to interpret DOIs with "doi:" or "http:" URIs, so now the required formate is simply "[prefix]/[suffix]".

Fixes #1035