### PR TITLE
Authorize the user to destroy any collection

### DIFF
--- a/app/controllers/dashboard/collections_controller.rb
+++ b/app/controllers/dashboard/collections_controller.rb
@@ -4,15 +4,13 @@ module Dashboard
   class CollectionsController < BaseController
     layout 'frontend'
 
+    before_action :authorize_collection
+
     def edit
-      @collection = Collection.find(params[:id])
-      authorize(@collection)
       initialize_forms
     end
 
     def update
-      @collection = Collection.find(params[:id])
-      authorize(@collection)
       initialize_forms
 
       form = select_form_model
@@ -27,8 +25,6 @@ module Dashboard
     # DELETE /collections/1
     # DELETE /collections/1.json
     def destroy
-      @collection = current_user.collections.find(params[:id])
-      authorize(@collection)
       @collection.destroy
       respond_to do |format|
         format.html { redirect_to dashboard_root_path, notice: t('.success') }
@@ -37,6 +33,11 @@ module Dashboard
     end
 
     private
+
+      def authorize_collection
+        @collection = Collection.find(params[:id])
+        authorize(@collection)
+      end
 
       def initialize_forms
         @collection.attributes = collection_params

--- a/spec/controllers/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/dashboard/collections_controller_spec.rb
@@ -114,13 +114,25 @@ RSpec.describe Dashboard::CollectionsController, type: :controller do
         end
       end
 
+      context 'with an admin' do
+        let!(:collection) { someone_elses_collection }
+
+        let(:user) { create(:user, :admin) }
+
+        it "destroys the other user's collection" do
+          expect {
+            delete :destroy, params: { id: collection.to_param }
+          }.to change(Collection, :count).by(-1)
+        end
+      end
+
       context 'when the user does not own the collection' do
         let!(:collection) { someone_elses_collection }
 
-        it '404s' do
+        it 'raises a Pundit error' do
           expect {
             delete :destroy, params: { id: collection.to_param }
-          }.to raise_error(ActiveRecord::RecordNotFound)
+          }.to raise_error(Pundit::NotAuthorizedError)
         end
       end
     end


### PR DESCRIPTION
Users may have rights to destroy a collection they don't own, such as an admin or another user with edit access. We use Pundit policies to check this, just as we are with the other actions in the controller.

Fixes #1045 