### PR TITLE
Users should not edit withdrawn works

### DIFF
--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -14,10 +14,7 @@ class WorkPolicy < ApplicationPolicy
   def edit?
     editable?
   end
-
-  def update?
-    edit?
-  end
+  alias_method :update?, :edit?
 
   # @note Even though this is not imposed at the database level, no one should be able to create a
   # new version if a draft one already exists.

--- a/app/policies/work_version_policy.rb
+++ b/app/policies/work_version_policy.rb
@@ -16,7 +16,7 @@ class WorkVersionPolicy < ApplicationPolicy
   end
 
   def edit?
-    return false if record.published? && !user.admin?
+    return false if (record.published? || record.withdrawn?) && !user.admin?
 
     editable?
   end


### PR DESCRIPTION
An oversight in the WorkVersionPolicy was allowing users edit access to their withdrawn works. Now, users cannot edit a withdrawn work; however, admins still can.

Fixes #1053 