### PR TITLE
Return the deposited year for uncertain dates

### DIFF
--- a/app/components/google_scholar_metadata_component.rb
+++ b/app/components/google_scholar_metadata_component.rb
@@ -28,7 +28,7 @@ class GoogleScholarMetadataComponent < ApplicationComponent
   def citation_publication_date
     return deposited_at.year unless EdtfDate.valid?(published_date)
 
-    Date.edtf(published_date).year
+    Date.edtf(published_date).try(:year) || deposited_at.year
   end
 
   def file_version_memberships

--- a/spec/components/google_scholar_metadata_component_spec.rb
+++ b/spec/components/google_scholar_metadata_component_spec.rb
@@ -67,5 +67,11 @@ RSpec.describe GoogleScholarMetadataComponent, type: :component do
 
       its(:citation_publication_date) { is_expected.to eq(2002) }
     end
+
+    context 'with valid EDTF interval' do
+      let(:resource) { build(:work_version, published_date: '2010/2020') }
+
+      its(:citation_publication_date) { is_expected.to eq(Time.zone.now.year) }
+    end
   end
 end


### PR DESCRIPTION
If EDTF can't determine a year for a given date, then return the deposited year. Valid EDTF dates, such as intervals like `2010/2020` don't have exact years, so we won't attempt to guess one.

Fixes #1038 