### PR TITLE
Don't log solr parameters

### DIFF
--- a/app/models/concerns/catalog_search_behavior.rb
+++ b/app/models/concerns/catalog_search_behavior.rb
@@ -17,10 +17,6 @@ module CatalogSearchBehavior
     solr_parameters[:fq] << '{!terms f=model_ssi}Work,Collection'
   end
 
-  def log_solr_parameters(solr_parameters)
-    Rails.logger.debug("Solr parameters: #{solr_parameters.inspect}")
-  end
-
   def limit_to_public_resources(solr_parameters)
     return if current_user.admin?
 

--- a/app/models/dashboard/member_works_search_builder.rb
+++ b/app/models/dashboard/member_works_search_builder.rb
@@ -13,7 +13,6 @@ module Dashboard
       restrict_search_to_work_titles
       apply_gated_edit
       limit_to_public_resources
-      log_solr_parameters
     )
 
     # @note Builds a Solr query to return a list of all the works a user may add to a collection

--- a/app/models/dashboard/search_builder.rb
+++ b/app/models/dashboard/search_builder.rb
@@ -12,7 +12,6 @@ module Dashboard
       search_related_files
       restrict_search_to_works_and_collections
       apply_gated_edit
-      log_solr_parameters
     )
   end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -12,7 +12,6 @@ class SearchBuilder < Blacklight::SearchBuilder
     restrict_search_to_works_and_collections
     apply_gated_discovery
     limit_to_public_resources
-    log_solr_parameters
   )
 
   def apply_gated_discovery(solr_parameters)

--- a/spec/models/dashboard/member_works_search_builder_spec.rb
+++ b/spec/models/dashboard/member_works_search_builder_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe Dashboard::MemberWorksSearchBuilder do
       is_expected.to include(
         :restrict_search_to_work_titles,
         :apply_gated_edit,
-        :limit_to_public_resources,
-        :log_solr_parameters
+        :limit_to_public_resources
       )
     end
   end

--- a/spec/models/dashboard/search_builder_spec.rb
+++ b/spec/models/dashboard/search_builder_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Dashboard::SearchBuilder do
   describe '.default_processor_chain' do
     its(:default_processor_chain) do
       is_expected.to include(
-        :log_solr_parameters,
         :search_related_files,
         :restrict_search_to_works_and_collections,
         :apply_gated_edit

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe SearchBuilder do
         :search_related_files,
         :restrict_search_to_works_and_collections,
         :apply_gated_discovery,
-        :limit_to_public_resources,
-        :log_solr_parameters
+        :limit_to_public_resources
       )
     end
   end


### PR DESCRIPTION
This is already being done via Blacklight.logger.

Fixes #435 