### PR TITLE
Create new versions from the representative

### DIFF
--- a/app/controllers/dashboard/work_versions_controller.rb
+++ b/app/controllers/dashboard/work_versions_controller.rb
@@ -6,7 +6,7 @@ module Dashboard
       work = Work.find(params[:work_id])
       authorize(work, :create_version?)
 
-      @work_version = BuildNewWorkVersion.call(work.latest_version)
+      @work_version = BuildNewWorkVersion.call(work.representative_version)
 
       respond_to do |format|
         if @work_version.save


### PR DESCRIPTION
New versions of works should come from the representative version, which could either be withdrawn or published, but will always be the version that the user sees in their dashboard.

Fixes #1054 