### PR TITLE
Use I18n.t! in tests

### DIFF
--- a/spec/components/back_to_work_button_component_spec.rb
+++ b/spec/components/back_to_work_button_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BackToWorkButtonComponent, type: :component do
     let(:work) { create :work, has_draft: false, versions_count: 1 }
 
     it "renders a link back to the _Work's_ resource page" do
-      expect(result.text).to eq I18n.t('dashboard.works.edit.back', raise: true)
+      expect(result.text).to eq I18n.t!('dashboard.works.edit.back', raise: true)
       expect(result[:href]).to eq resource_path(work.uuid)
     end
   end

--- a/spec/components/display_doi_component_spec.rb
+++ b/spec/components/display_doi_component_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DisplayDoiComponent, type: :component do
     let(:doi) { FactoryBotHelpers.valid_doi }
 
     its(:css_class) { is_expected.to eq('text-primary') }
-    its(:tooltip) { is_expected.to eq(I18n.t('resources.doi.valid')) }
+    its(:tooltip) { is_expected.to eq(I18n.t!('resources.doi.valid')) }
 
     specify { expect(element.text).to include(doi) }
   end
@@ -26,7 +26,7 @@ RSpec.describe DisplayDoiComponent, type: :component do
     let(:doi) { FactoryBotHelpers.invalid_doi }
 
     its(:css_class) { is_expected.to eq('text-danger') }
-    its(:tooltip) { is_expected.to eq(I18n.t('resources.doi.invalid')) }
+    its(:tooltip) { is_expected.to eq(I18n.t!('resources.doi.invalid')) }
 
     specify { expect(element.text).to include(doi) }
   end
@@ -35,7 +35,7 @@ RSpec.describe DisplayDoiComponent, type: :component do
     let(:doi) { FactoryBotHelpers.unmanaged_doi }
 
     its(:css_class) { is_expected.to eq('text-secondary') }
-    its(:tooltip) { is_expected.to eq(I18n.t('resources.doi.unmanaged')) }
+    its(:tooltip) { is_expected.to eq(I18n.t!('resources.doi.unmanaged')) }
 
     specify { expect(element.text).to include(doi) }
   end

--- a/spec/components/files_visibility_detail_component_spec.rb
+++ b/spec/components/files_visibility_detail_component_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe FilesVisibilityDetailComponent, type: :component do
       let(:work_version) { build(:work_version, :published, work: work) }
 
       it 'displays a message' do
-        expect(content).to include I18n.t('files_message.embargo.heading', date: embargo_date.strftime('%Y-%m-%d'))
-        expect(content).to include I18n.t('files_message.embargo.public_message')
+        expect(content).to include I18n.t!('files_message.embargo.heading', date: embargo_date.strftime('%Y-%m-%d'))
+        expect(content).to include I18n.t!('files_message.embargo.public_message')
       end
     end
 
@@ -34,8 +34,8 @@ RSpec.describe FilesVisibilityDetailComponent, type: :component do
       let(:user) { work.depositor.user }
 
       it 'displays a message' do
-        expect(content).to include I18n.t('files_message.embargo.heading', date: embargo_date.strftime('%Y-%m-%d'))
-        expect(content).to include I18n.t('files_message.edit_message')
+        expect(content).to include I18n.t!('files_message.embargo.heading', date: embargo_date.strftime('%Y-%m-%d'))
+        expect(content).to include I18n.t!('files_message.edit_message')
       end
     end
 
@@ -45,9 +45,9 @@ RSpec.describe FilesVisibilityDetailComponent, type: :component do
       let(:controller_name) { 'work_versions' }
 
       it 'displays a message' do
-        expect(content).to include I18n.t('files_message.embargo.heading', date: embargo_date.strftime('%Y-%m-%d'))
-        expect(content).to include I18n.t('files_message.edit_message')
-        expect(content).to include I18n.t('files_message.link_text')
+        expect(content).to include I18n.t!('files_message.embargo.heading', date: embargo_date.strftime('%Y-%m-%d'))
+        expect(content).to include I18n.t!('files_message.edit_message')
+        expect(content).to include I18n.t!('files_message.link_text')
       end
     end
 
@@ -57,9 +57,9 @@ RSpec.describe FilesVisibilityDetailComponent, type: :component do
       let(:work) { build(:work, visibility: Permissions::Visibility::AUTHORIZED, embargoed_until: embargo_date) }
 
       it 'displays a message' do
-        expect(content).to include I18n.t('files_message.embargo_unauthorized.heading',
-                                          date: embargo_date.strftime('%Y-%m-%d'))
-        expect(content).to include I18n.t('files_message.embargo_unauthorized.public_message')
+        expect(content).to include I18n.t!('files_message.embargo_unauthorized.heading',
+                                           date: embargo_date.strftime('%Y-%m-%d'))
+        expect(content).to include I18n.t!('files_message.embargo_unauthorized.public_message')
       end
     end
   end
@@ -78,8 +78,8 @@ RSpec.describe FilesVisibilityDetailComponent, type: :component do
       let(:work) { build(:work, visibility: Permissions::Visibility::AUTHORIZED) }
 
       it 'displays a message' do
-        expect(content).to include I18n.t('files_message.unauthorized.heading')
-        expect(content).to include I18n.t('files_message.unauthorized.public_message')
+        expect(content).to include I18n.t!('files_message.unauthorized.heading')
+        expect(content).to include I18n.t!('files_message.unauthorized.public_message')
       end
     end
   end

--- a/spec/components/flash_message_component_spec.rb
+++ b/spec/components/flash_message_component_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe FlashMessageComponent, type: :component do
       let(:flash) { [] }
 
       specify do
-        expect(result.css('div.alert-warning').text).to match(/#{I18n.t('read_only')}/)
+        expect(result.css('div.alert-warning').text).to match(/#{I18n.t!('read_only')}/)
       end
     end
 

--- a/spec/components/form_error_message_component_spec.rb
+++ b/spec/components/form_error_message_component_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe FormErrorMessageComponent, type: :component do
     let(:heading) { nil }
 
     it 'renders the default heading' do
-      expected_error_msg = I18n.t(
+      expected_error_msg = I18n.t!(
         'dashboard.form.heading.error_message',
         error: pluralize(record.errors.count, 'error')
       )

--- a/spec/components/form_tabs_component_spec.rb
+++ b/spec/components/form_tabs_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe FormTabsComponent, type: :component do
     end
 
     it "renders the current controller's tab as active" do
-      expect(tabs.css('.nav-item.active').text).to eq I18n.t('dashboard.form.tabs.work_version_details')
+      expect(tabs.css('.nav-item.active').text).to eq I18n.t!('dashboard.form.tabs.work_version_details')
     end
   end
 
@@ -26,11 +26,11 @@ RSpec.describe FormTabsComponent, type: :component do
 
     it 'renders the inactive tabs as links' do
       expect(tabs.css('a.nav-item').length).to eq 3
-      expect(tabs.css('a.nav-item').map(&:text)).not_to include(I18n.t('dashboard.form.tabs.work_version_details'))
+      expect(tabs.css('a.nav-item').map(&:text)).not_to include(I18n.t!('dashboard.form.tabs.work_version_details'))
     end
 
     it 'renders the active tab as a non-link' do
-      expect(tabs.css('.nav-item.active').text).to eq I18n.t('dashboard.form.tabs.work_version_details')
+      expect(tabs.css('.nav-item.active').text).to eq I18n.t!('dashboard.form.tabs.work_version_details')
     end
   end
 
@@ -44,7 +44,7 @@ RSpec.describe FormTabsComponent, type: :component do
     end
 
     it "renders the current controller's tab as active" do
-      expect(tabs.css('.nav-item.active').text).to eq I18n.t('dashboard.form.tabs.collection_details')
+      expect(tabs.css('.nav-item.active').text).to eq I18n.t!('dashboard.form.tabs.collection_details')
     end
   end
 
@@ -54,11 +54,11 @@ RSpec.describe FormTabsComponent, type: :component do
 
     it 'renders the inactive tabs as links' do
       expect(tabs.css('a.nav-item').length).to eq 2
-      expect(tabs.css('a.nav-item').map(&:text)).not_to include(I18n.t('dashboard.form.tabs.collection_details'))
+      expect(tabs.css('a.nav-item').map(&:text)).not_to include(I18n.t!('dashboard.form.tabs.collection_details'))
     end
 
     it 'renders the active tab as a non-link' do
-      expect(tabs.css('.nav-item.active').text).to eq I18n.t('dashboard.form.tabs.collection_details')
+      expect(tabs.css('.nav-item.active').text).to eq I18n.t!('dashboard.form.tabs.collection_details')
     end
   end
 end

--- a/spec/components/mintable_doi_component_spec.rb
+++ b/spec/components/mintable_doi_component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe MintableDoiComponent, type: :component do
       expect(html.css('form').attribute('action').value)
         .to eq resource_doi_path(resource.uuid)
 
-      expect(html.css('input').attribute('value').text).to eq I18n.t('resources.doi.create')
+      expect(html.css('input').attribute('value').text).to eq I18n.t!('resources.doi.create')
     end
   end
 

--- a/spec/components/minting_status_doi_component_spec.rb
+++ b/spec/components/minting_status_doi_component_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe MintingStatusDoiComponent, type: :component do
       end
 
       its(:css_class) { is_expected.to eq('badge badge-light') }
-      specify { expect(html.text).to include(I18n.t('resources.doi.waiting')) }
+      specify { expect(html.text).to include(I18n.t!('resources.doi.waiting')) }
     end
 
     context 'when the doi minter is minting' do
@@ -66,7 +66,7 @@ RSpec.describe MintingStatusDoiComponent, type: :component do
       end
 
       its(:css_class) { is_expected.to eq('badge badge-light') }
-      specify { expect(html.text).to include(I18n.t('resources.doi.minting')) }
+      specify { expect(html.text).to include(I18n.t!('resources.doi.minting')) }
     end
 
     context 'when the doi minter is error' do
@@ -77,7 +77,7 @@ RSpec.describe MintingStatusDoiComponent, type: :component do
       end
 
       its(:css_class) { is_expected.to eq('text-danger') }
-      specify { expect(html.text).to include(I18n.t('resources.doi.error')) }
+      specify { expect(html.text).to include(I18n.t!('resources.doi.error')) }
     end
   end
 end

--- a/spec/components/visibility_badge_component_spec.rb
+++ b/spec/components/visibility_badge_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe VisibilityBadgeComponent, type: :component do
     let(:work) { build(:work) }
 
     specify do
-      expect(badge.text).to include(I18n.t('visibility_badge_component.label.open'))
+      expect(badge.text).to include(I18n.t!('visibility_badge_component.label.open'))
       expect(badge.attributes['data-before'].value).to eq('lock_open')
       expect(badge.classes).to contain_exactly('badge', 'badge--icon', 'badge--icon-orange')
       expect(badge['title']).to be_nil
@@ -21,11 +21,11 @@ RSpec.describe VisibilityBadgeComponent, type: :component do
       let(:work) { build(:work, embargoed_until: embargo_date) }
 
       specify do
-        expect(badge.text).to include(I18n.t('visibility_badge_component.label.embargoed'))
+        expect(badge.text).to include(I18n.t!('visibility_badge_component.label.embargoed'))
         expect(badge.attributes['data-before'].value).to eq('lock_clock')
         expect(badge.classes).to contain_exactly('badge', 'badge--icon', 'badge--icon-red')
-        expect(badge['title']).to eq(I18n.t('visibility_badge_component.tooltip.embargoed',
-                                            date: embargo_date.strftime('%Y-%m-%d')))
+        expect(badge['title']).to eq(I18n.t!('visibility_badge_component.tooltip.embargoed',
+                                             date: embargo_date.strftime('%Y-%m-%d')))
       end
     end
   end
@@ -34,7 +34,7 @@ RSpec.describe VisibilityBadgeComponent, type: :component do
     let(:work) { build(:work, visibility: Permissions::Visibility::AUTHORIZED) }
 
     specify do
-      expect(badge.text).to include(I18n.t('visibility_badge_component.label.authenticated'))
+      expect(badge.text).to include(I18n.t!('visibility_badge_component.label.authenticated'))
       expect(badge.attributes['data-before'].value).to eq('pets')
       expect(badge.classes).to contain_exactly('badge', 'badge--icon', 'badge--icon-blue')
       expect(badge['title']).to be_nil
@@ -44,11 +44,11 @@ RSpec.describe VisibilityBadgeComponent, type: :component do
       let(:work) { build(:work, embargoed_until: embargo_date, visibility: Permissions::Visibility::AUTHORIZED) }
 
       specify do
-        expect(badge.text).to include(I18n.t('visibility_badge_component.label.embargoed'))
+        expect(badge.text).to include(I18n.t!('visibility_badge_component.label.embargoed'))
         expect(badge.attributes['data-before'].value).to eq('lock_clock')
         expect(badge.classes).to contain_exactly('badge', 'badge--icon', 'badge--icon-red')
-        expect(badge['title']).to eq(I18n.t('visibility_badge_component.tooltip.embargoed',
-                                            date: embargo_date.strftime('%Y-%m-%d')))
+        expect(badge['title']).to eq(I18n.t!('visibility_badge_component.tooltip.embargoed',
+                                             date: embargo_date.strftime('%Y-%m-%d')))
       end
     end
   end
@@ -57,7 +57,7 @@ RSpec.describe VisibilityBadgeComponent, type: :component do
     let(:work) { build(:work, visibility: Permissions::Visibility::PRIVATE) }
 
     specify do
-      expect(badge.text).to include(I18n.t('visibility_badge_component.label.restricted'))
+      expect(badge.text).to include(I18n.t!('visibility_badge_component.label.restricted'))
       expect(badge.attributes['data-before'].value).to eq('lock')
       expect(badge.classes).to contain_exactly('badge', 'badge--icon', 'badge--icon-red')
       expect(badge['title']).to be_nil
@@ -67,11 +67,11 @@ RSpec.describe VisibilityBadgeComponent, type: :component do
       let(:work) { build(:work, embargoed_until: embargo_date, visibility: Permissions::Visibility::PRIVATE) }
 
       specify do
-        expect(badge.text).to include(I18n.t('visibility_badge_component.label.embargoed'))
+        expect(badge.text).to include(I18n.t!('visibility_badge_component.label.embargoed'))
         expect(badge.attributes['data-before'].value).to eq('lock_clock')
         expect(badge.classes).to contain_exactly('badge', 'badge--icon', 'badge--icon-red')
-        expect(badge['title']).to eq(I18n.t('visibility_badge_component.tooltip.embargoed',
-                                            date: embargo_date.strftime('%Y-%m-%d')))
+        expect(badge['title']).to eq(I18n.t!('visibility_badge_component.tooltip.embargoed',
+                                             date: embargo_date.strftime('%Y-%m-%d')))
       end
     end
   end

--- a/spec/components/withdrawn_detail_component_spec.rb
+++ b/spec/components/withdrawn_detail_component_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe WithdrawnDetailComponent, type: :component do
     let(:work_version) { build(:work_version, :withdrawn, work: work) }
 
     it 'displays a message' do
-      expect(content).to include I18n.t('files_message.withdrawn.heading')
-      expect(content).to include I18n.t('files_message.withdrawn.public_message')
+      expect(content).to include I18n.t!('files_message.withdrawn.heading')
+      expect(content).to include I18n.t!('files_message.withdrawn.public_message')
     end
   end
 
@@ -32,8 +32,8 @@ RSpec.describe WithdrawnDetailComponent, type: :component do
     let(:user) { work.depositor.user }
 
     it 'displays a message' do
-      expect(content).to include I18n.t('files_message.withdrawn.heading')
-      expect(content).to include I18n.t('files_message.edit_message')
+      expect(content).to include I18n.t!('files_message.withdrawn.heading')
+      expect(content).to include I18n.t!('files_message.edit_message')
     end
   end
 

--- a/spec/components/work_histories/creator_change_component_spec.rb
+++ b/spec/components/work_histories/creator_change_component_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe WorkHistories::CreatorChangeComponent, type: :component do
       # It: renders the null-user properly
       #
       expect(result.css('.version-timeline__change-user').text)
-        .to eq I18n.t('dashboard.work_history.unknown_user')
+        .to eq I18n.t!('dashboard.work_history.unknown_user')
 
       ##########################################################################
       #

--- a/spec/components/work_histories/file_membership_change_component_spec.rb
+++ b/spec/components/work_histories/file_membership_change_component_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe WorkHistories::FileMembershipChangeComponent, type: :component do
       # It: renders the null-user properly
       #
       expect(result.css('.version-timeline__change-user').text)
-        .to eq I18n.t('dashboard.work_history.unknown_user')
+        .to eq I18n.t!('dashboard.work_history.unknown_user')
 
       ##########################################################################
       #

--- a/spec/components/work_histories/work_version_change_component_spec.rb
+++ b/spec/components/work_histories/work_version_change_component_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe WorkHistories::WorkVersionChangeComponent, type: :component do
       # It: renders the null-user properly
       #
       expect(result.css('.version-timeline__change-user').text)
-        .to eq I18n.t('dashboard.work_history.unknown_user')
+        .to eq I18n.t!('dashboard.work_history.unknown_user')
 
       ##########################################################################
       #

--- a/spec/controllers/api/v1/rest_controller_spec.rb
+++ b/spec/controllers/api/v1/rest_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Api::V1::RestController, type: :controller do
       before { get :index }
 
       its(:status) { is_expected.to eq 401 }
-      its(:body) { is_expected.to include(I18n.t('api.errors.not_authorized')) }
+      its(:body) { is_expected.to include(I18n.t!('api.errors.not_authorized')) }
     end
 
     context 'when providing a bad token' do
@@ -36,7 +36,7 @@ RSpec.describe Api::V1::RestController, type: :controller do
       before { get :index }
 
       its(:status) { is_expected.to eq 401 }
-      its(:body) { is_expected.to include(I18n.t('api.errors.not_authorized')) }
+      its(:body) { is_expected.to include(I18n.t!('api.errors.not_authorized')) }
     end
   end
 
@@ -55,7 +55,7 @@ RSpec.describe Api::V1::RestController, type: :controller do
 
     context 'when the application is read-only', :read_only do
       its(:status) { is_expected.to eq 401 }
-      its(:body) { is_expected.to include(I18n.t('api.errors.not_authorized')) }
+      its(:body) { is_expected.to include(I18n.t!('api.errors.not_authorized')) }
     end
   end
 

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe UserDecorator do
     context 'when user is a guest' do
       before { allow(user).to receive(:guest?).and_return(true) }
 
-      its(:display_name) { is_expected.to eq I18n.t('navbar.guest_name') }
+      its(:display_name) { is_expected.to eq I18n.t!('navbar.guest_name') }
     end
 
     context 'when user is not a guest' do
@@ -35,7 +35,7 @@ RSpec.describe UserDecorator do
         allow(user).to receive(:admin?).and_return(true)
       end
 
-      its(:display_name) { is_expected.to eq I18n.t('navbar.admin_name') }
+      its(:display_name) { is_expected.to eq I18n.t!('navbar.admin_name') }
     end
   end
 end

--- a/spec/features/catalog/catalog_spec.rb
+++ b/spec/features/catalog/catalog_spec.rb
@@ -147,8 +147,8 @@ RSpec.describe 'Blacklight catalog page', :inline_jobs do
     it 'displays no search results', with_user: :user do
       visit(search_catalog_path(q: 'asdfasdfasdfasdfasdfasdfasdf'))
 
-      expect(page).to have_selector('h4', text: I18n.t('catalog.zero_results.info.heading'))
-      expect(page).to have_content(I18n.t('catalog.zero_results.info.content'))
+      expect(page).to have_selector('h4', text: I18n.t!('catalog.zero_results.info.heading'))
+      expect(page).to have_content(I18n.t!('catalog.zero_results.info.content'))
     end
   end
 
@@ -157,7 +157,7 @@ RSpec.describe 'Blacklight catalog page', :inline_jobs do
       visit(search_catalog_path)
 
       within('.alert-warning') do
-        expect(page).to have_content(I18n.t('read_only'))
+        expect(page).to have_content(I18n.t!('read_only'))
       end
       expect(page).to have_link('Login', class: 'disabled')
     end

--- a/spec/features/dashboard/catalog_spec.rb
+++ b/spec/features/dashboard/catalog_spec.rb
@@ -116,8 +116,8 @@ RSpec.describe 'Dashboard catalog page', :inline_jobs do
     it 'displays no search results', with_user: :user do
       visit(dashboard_root_path(q: 'asdfasdfasdfasdfasdfasdfasdf'))
 
-      expect(page).to have_selector('h4', text: I18n.t('dashboard.catalog.zero_results.info.heading'))
-      expect(page).to have_content(I18n.t('dashboard.catalog.zero_results.info.content'))
+      expect(page).to have_selector('h4', text: I18n.t!('dashboard.catalog.zero_results.info.heading'))
+      expect(page).to have_content(I18n.t!('dashboard.catalog.zero_results.info.content'))
     end
   end
 
@@ -126,7 +126,7 @@ RSpec.describe 'Dashboard catalog page', :inline_jobs do
       visit(dashboard_root_path)
 
       within('.alert-warning') do
-        expect(page).to have_content(I18n.t('read_only'))
+        expect(page).to have_content(I18n.t!('read_only'))
       end
       expect(page).to have_link('Login', class: 'disabled')
     end
@@ -151,8 +151,8 @@ RSpec.describe 'Dashboard catalog page', :inline_jobs do
       end
 
       within('.alert') do
-        expect(page).to have_content(I18n.t('files_message.withdrawn.heading'))
-        expect(page).to have_content(I18n.t('files_message.edit_message'))
+        expect(page).to have_content(I18n.t!('files_message.withdrawn.heading'))
+        expect(page).to have_content(I18n.t!('files_message.edit_message'))
       end
     end
   end

--- a/spec/features/dashboard/collection_settings_spec.rb
+++ b/spec/features/dashboard/collection_settings_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'Collection Settings Page', with_user: :user do
 
   it 'is available from the resource page' do
     visit resource_path(collection.uuid)
-    click_on I18n.t('resources.settings_button.text', type: 'Collection')
-    expect(page).to have_content(I18n.t('dashboard.collections.edit.heading', title: collection.title))
+    click_on I18n.t!('resources.settings_button.text', type: 'Collection')
+    expect(page).to have_content(I18n.t!('dashboard.collections.edit.heading', title: collection.title))
   end
 
   describe 'Minting a DOI' do
@@ -19,10 +19,10 @@ RSpec.describe 'Collection Settings Page', with_user: :user do
     end
 
     it 'works from the Settings page' do
-      click_button I18n.t('resources.doi.create')
+      click_button I18n.t!('resources.doi.create')
 
       expect(page).to have_current_path(edit_dashboard_collection_path(collection))
-      expect(page).not_to have_button I18n.t('resources.doi.create')
+      expect(page).not_to have_button I18n.t!('resources.doi.create')
     end
   end
 

--- a/spec/features/dashboard/file_management_spec.rb
+++ b/spec/features/dashboard/file_management_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe 'Dashboard File Management', with_user: :user do
     visit(dashboard_work_version_file_list_path(work_version))
 
     within "##{dom_id(file_membership)}" do
-      click_link I18n.t('dashboard.file_list.edit.rename')
+      click_link I18n.t!('dashboard.file_list.edit.rename')
     end
 
     edited_filename = "EDITED#{File.extname(file_membership.title)}"
     fill_in FileVersionMembership.human_attribute_name('title'), with: edited_filename
-    click_button I18n.t('dashboard.file_version_memberships.edit.save')
+    click_button I18n.t!('dashboard.file_version_memberships.edit.save')
 
     expect(file_membership.reload.title).to eq edited_filename
 
@@ -31,9 +31,9 @@ RSpec.describe 'Dashboard File Management', with_user: :user do
     edited_filename = "EDITED#{File.extname(file_membership.title)}"
 
     within "##{dom_id(file_membership)}" do
-      click_link I18n.t('dashboard.file_list.edit.rename')
+      click_link I18n.t!('dashboard.file_list.edit.rename')
       fill_in FileVersionMembership.human_attribute_name('title'), with: edited_filename
-      click_button I18n.t('dashboard.file_version_memberships.edit.save')
+      click_button I18n.t!('dashboard.file_version_memberships.edit.save')
 
       # Note, there's an implicit trick here to make Capybara wait for AJAX
       expect(find('.filename')).to have_content edited_filename
@@ -46,7 +46,7 @@ RSpec.describe 'Dashboard File Management', with_user: :user do
     visit(dashboard_work_version_file_list_path(work_version))
 
     within "##{dom_id(file_membership)}" do
-      click_link I18n.t('dashboard.file_list.edit.delete')
+      click_link I18n.t!('dashboard.file_list.edit.delete')
     end
 
     expect { file_membership.reload }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/features/dashboard/profile_spec.rb
+++ b/spec/features/dashboard/profile_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe 'Profile', type: :feature, with_user: :user do
       expect(user.actor.surname).to eq(attributes[:surname])
       expect(user.actor.orcid).to eq(attributes[:orcid])
       expect(user.actor.psu_id).to eq(user.access_id)
-      expect(page).to have_content(I18n.t('navbar.heading.dashboard'))
-      expect(page).to have_content(I18n.t('dashboard.profiles.update.success'))
+      expect(page).to have_content(I18n.t!('navbar.heading.dashboard'))
+      expect(page).to have_content(I18n.t!('dashboard.profiles.update.success'))
     end
   end
 
@@ -38,8 +38,8 @@ RSpec.describe 'Profile', type: :feature, with_user: :user do
       expect(page).to have_content('Edit Profile')
       expect(page).to have_field('ORCiD', text: '')
       click_button 'Save'
-      expect(page).to have_content(I18n.t('navbar.heading.dashboard'))
-      expect(page).to have_content(I18n.t('dashboard.profiles.update.success'))
+      expect(page).to have_content(I18n.t!('navbar.heading.dashboard'))
+      expect(page).to have_content(I18n.t!('dashboard.profiles.update.success'))
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe 'Profile', type: :feature, with_user: :user do
     it 'offers the option to enable admin privileges' do
       visit edit_dashboard_profile_path
       within('#topbar') do
-        expect(page).to have_content(I18n.t('navbar.admin_name'))
+        expect(page).to have_content(I18n.t!('navbar.admin_name'))
         expect(page).to have_link('Sidekiq')
         expect(page).to have_link('Health Checks')
       end
@@ -59,8 +59,8 @@ RSpec.describe 'Profile', type: :feature, with_user: :user do
       click_button 'Save'
       user.reload
       expect(user.admin_enabled).to be(false)
-      expect(page).to have_content(I18n.t('navbar.heading.dashboard'))
-      expect(page).to have_content(I18n.t('dashboard.profiles.update.success'))
+      expect(page).to have_content(I18n.t!('navbar.heading.dashboard'))
+      expect(page).to have_content(I18n.t!('dashboard.profiles.update.success'))
       within('#topbar') do
         expect(page).to have_content(user.access_id)
         expect(page).not_to have_link('Sidekiq')

--- a/spec/features/dashboard/work_settings_spec.rb
+++ b/spec/features/dashboard/work_settings_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe 'Work Settings Page', with_user: :user do
 
   it 'is available from the resource page' do
     visit resource_path(work.uuid)
-    click_on I18n.t('resources.settings_button.text', type: 'Work')
-    expect(page).to have_content(I18n.t('dashboard.works.edit.heading', work_title: work.latest_version.title))
+    click_on I18n.t!('resources.settings_button.text', type: 'Work')
+    expect(page).to have_content(I18n.t!('dashboard.works.edit.heading', work_title: work.latest_version.title))
   end
 
   describe 'Updating visibility' do
@@ -28,9 +28,9 @@ RSpec.describe 'Work Settings Page', with_user: :user do
       )
 
       choose authorized_checkbox_label
-      click_button I18n.t('dashboard.works.edit.visibility.submit_button')
+      click_button I18n.t!('dashboard.works.edit.visibility.submit_button')
 
-      expect(page).to have_content(I18n.t('dashboard.works.edit.heading', work_title: work.latest_version.title))
+      expect(page).to have_content(I18n.t!('dashboard.works.edit.heading', work_title: work.latest_version.title))
 
       work.reload
       expect(work.visibility).to eq Permissions::Visibility::AUTHORIZED
@@ -46,14 +46,14 @@ RSpec.describe 'Work Settings Page', with_user: :user do
 
     it 'works from the Settings page' do
       fill_in 'embargo_form_embargoed_until', with: '2030-11-11'
-      click_button I18n.t('dashboard.works.edit.embargo.submit_button')
+      click_button I18n.t!('dashboard.works.edit.embargo.submit_button')
 
-      expect(page).to have_content(I18n.t('dashboard.works.edit.heading', work_title: work.latest_version.title))
+      expect(page).to have_content(I18n.t!('dashboard.works.edit.heading', work_title: work.latest_version.title))
 
       work.reload
       expect(work.embargoed_until).to be_within(1.minute).of(Time.zone.local(2030, 11, 11, 0))
 
-      click_button I18n.t('dashboard.works.edit.embargo.remove_button')
+      click_button I18n.t!('dashboard.works.edit.embargo.remove_button')
 
       work.reload
       expect(work.embargoed_until).to be_nil
@@ -71,10 +71,10 @@ RSpec.describe 'Work Settings Page', with_user: :user do
       let(:work) { create :work, versions_count: 1, has_draft: false, depositor: user.actor }
 
       it 'works from the Settings page' do
-        click_button I18n.t('resources.doi.create')
+        click_button I18n.t!('resources.doi.create')
 
         expect(page).to have_current_path(edit_dashboard_work_path(work))
-        expect(page).not_to have_button I18n.t('resources.doi.create')
+        expect(page).not_to have_button I18n.t!('resources.doi.create')
       end
     end
 
@@ -82,8 +82,8 @@ RSpec.describe 'Work Settings Page', with_user: :user do
       let(:work) { create :work, versions_count: 1, has_draft: true, depositor: user.actor }
 
       it 'is not allowed' do
-        expect(page).not_to have_content I18n.t('resources.doi.create')
-        expect(page).to have_content I18n.t('dashboard.works.edit.doi.not_allowed')
+        expect(page).not_to have_content I18n.t!('resources.doi.create')
+        expect(page).to have_content I18n.t!('dashboard.works.edit.doi.not_allowed')
       end
     end
   end

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -144,14 +144,14 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         fill_in 'work_version_title', with: "Changed #{metadata[:title]}"
 
-        dismiss_confirm(I18n.t('dashboard.form.unsaved_changes_prompt')) do
-          click_on I18n.t('dashboard.form.tabs.contributors')
+        dismiss_confirm(I18n.t!('dashboard.form.unsaved_changes_prompt')) do
+          click_on I18n.t!('dashboard.form.tabs.contributors')
         end
 
         expect(page).to have_current_path(dashboard_form_work_version_details_path(work_version))
 
-        accept_confirm(I18n.t('dashboard.form.unsaved_changes_prompt')) do
-          click_on I18n.t('dashboard.form.tabs.contributors')
+        accept_confirm(I18n.t!('dashboard.form.unsaved_changes_prompt')) do
+          click_on I18n.t!('dashboard.form.tabs.contributors')
         end
 
         expect(page).to have_current_path(dashboard_form_contributors_path('work_version', work_version))
@@ -475,7 +475,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(page).to have_current_path(dashboard_form_publish_path(work_version))
 
         within '#error_explanation' do
-          expect(page).to have_content(I18n.t('errors.messages.invalid_edtf'))
+          expect(page).to have_content(I18n.t!('errors.messages.invalid_edtf'))
         end
 
         work_version.reload

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe 'Public Resources', type: :feature do
 
         ## Does not have edit controls
         within('header') do
-          expect(page).not_to have_content(I18n.t('resources.work_version.edit_button.text', version: 'V2'))
-          expect(page).not_to have_content(I18n.t('resources.settings_button.text', type: 'Work'))
+          expect(page).not_to have_content(I18n.t!('resources.work_version.edit_button.text', version: 'V2'))
+          expect(page).not_to have_content(I18n.t!('resources.settings_button.text', type: 'Work'))
         end
 
         ## Ensure we cannot navigate to the draft version
@@ -62,7 +62,7 @@ RSpec.describe 'Public Resources', type: :feature do
         within('.navbar .dropdown--versions') { click_on 'V1' }
 
         expect(page).to have_content(v1.title)
-        expect(page).to have_content(I18n.t('resources.old_version.message'))
+        expect(page).to have_content(I18n.t!('resources.old_version.message'))
       end
 
       it 'I can access a draft resource if I know the uuid' do
@@ -73,8 +73,8 @@ RSpec.describe 'Public Resources', type: :feature do
 
         ## Does not have edit controls
         within('header') do
-          expect(page).not_to have_content(I18n.t('resources.work_version.edit_button.text', version: 'V3'))
-          expect(page).not_to have_content(I18n.t('resources.settings_button.text', type: 'Work'))
+          expect(page).not_to have_content(I18n.t!('resources.work_version.edit_button.text', version: 'V3'))
+          expect(page).not_to have_content(I18n.t!('resources.settings_button.text', type: 'Work'))
         end
 
         ## Does have draft in the navigation menu
@@ -102,9 +102,9 @@ RSpec.describe 'Public Resources', type: :feature do
 
           within('header') do
             ## Edit controls are visible
-            expect(page).to have_content(I18n.t('resources.work_version.edit_button.text', version: 'V2'))
-              .and have_content(I18n.t('resources.work_version.create_button.text', version: 'V2'))
-              .and have_content(I18n.t('resources.settings_button.text', type: 'Work'))
+            expect(page).to have_content(I18n.t!('resources.work_version.edit_button.text', version: 'V2'))
+              .and have_content(I18n.t!('resources.work_version.create_button.text', version: 'V2'))
+              .and have_content(I18n.t!('resources.settings_button.text', type: 'Work'))
 
             ## Edit button is disabled, create draft button is enabled
             expect(page).to have_selector('.qa-edit-version.disabled')
@@ -225,7 +225,7 @@ RSpec.describe 'Public Resources', type: :feature do
         expect(page.title).to include(collection.title)
 
         within('header') do
-          expect(page).to have_content(I18n.t('resources.collection.edit_button'))
+          expect(page).to have_content(I18n.t!('resources.collection.edit_button'))
         end
       end
     end

--- a/spec/support/feature_helpers/dashboard_form.rb
+++ b/spec/support/feature_helpers/dashboard_form.rb
@@ -86,32 +86,32 @@ module FeatureHelpers
 
     def self.save_as_draft_and_exit
       fix_sticky_footer
-      click_on I18n.t('dashboard.form.actions.save_and_exit.work_version')
+      click_on I18n.t!('dashboard.form.actions.save_and_exit.work_version')
     end
 
     def self.save_and_exit
       fix_sticky_footer
-      click_on I18n.t('dashboard.form.actions.save_and_exit.collection')
+      click_on I18n.t!('dashboard.form.actions.save_and_exit.collection')
     end
 
     def self.save_and_continue
       fix_sticky_footer
-      click_on I18n.t('dashboard.form.actions.save_and_continue')
+      click_on I18n.t!('dashboard.form.actions.save_and_continue')
     end
 
     def self.publish
       fix_sticky_footer
-      click_on I18n.t('dashboard.form.actions.publish')
+      click_on I18n.t!('dashboard.form.actions.publish')
     end
 
     def self.finish
       fix_sticky_footer
-      click_on I18n.t('dashboard.form.actions.finish')
+      click_on I18n.t!('dashboard.form.actions.finish')
     end
 
     def self.delete
       fix_sticky_footer
-      click_on I18n.t('dashboard.form.actions.destroy.button')
+      click_on I18n.t!('dashboard.form.actions.destroy.button')
     end
 
     def self.cancel

--- a/spec/validators/datacite_doi_validator_spec.rb
+++ b/spec/validators/datacite_doi_validator_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe DataciteDoiValidator do
     it 'is expected not to be valid' do
       expect(model).not_to be_valid
       expect(model.errors[:doi_field]).to contain_exactly(
-        I18n.t('errors.messages.invalid_doi')
+        I18n.t!('errors.messages.invalid_doi')
       )
     end
   end

--- a/spec/validators/edtf_date_validator_spec.rb
+++ b/spec/validators/edtf_date_validator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe EdtfDateValidator do
     it 'is expected not to be valid' do
       expect(model).not_to be_valid
       expect(model.errors[:date_field]).to contain_exactly(
-        I18n.t('errors.messages.invalid_edtf')
+        I18n.t!('errors.messages.invalid_edtf')
       )
     end
   end


### PR DESCRIPTION
Fixes #865.

Using I18n.t!() will raise errors if any translations are missing.