### PR TITLE
Featured Works: Prevent long titles from overlapping cards

### DIFF
--- a/app/javascript/frontend/styles/_common.scss
+++ b/app/javascript/frontend/styles/_common.scss
@@ -127,6 +127,11 @@ h4,
   }
 }
 
+.ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 //
 // Utility Classes
 //

--- a/app/views/featured_resources/_collection.html.erb
+++ b/app/views/featured_resources/_collection.html.erb
@@ -1,6 +1,6 @@
 <div class="col-xl">
   <div class="surface ft-work">
-    <h3><%= link_to collection.title, resource_path(collection.uuid) %></h3>
+    <h3 class="ellipsis"><%= link_to collection.title, resource_path(collection.uuid) %></h3>
     <div class="row">
       <%= render ThumbnailComponent.new(resource: collection, featured: true) %>
       <%# @note This can serve as the collection's metadata component until such time as it needs to be different %>

--- a/app/views/featured_resources/_work_version.html.erb
+++ b/app/views/featured_resources/_work_version.html.erb
@@ -1,6 +1,6 @@
 <div class="col-xl">
   <div class="surface ft-work">
-    <h3><%= link_to work_version.title, resource_path(work_version.uuid) %></h3>
+    <h3 class="ellipsis"><%= link_to work_version.title, resource_path(work_version.uuid) %></h3>
     <div class="row">
       <%= render ThumbnailComponent.new(resource: work_version, featured: true) %>
       <%= render FeaturedWorkMetadataComponent.new(work_version: work_version) %>


### PR DESCRIPTION
Fixes #493.

An `.ellipsis` CSS class has been added which can be used if this comes up in other situations.

### Before:
<img width="450" alt="Screen Shot 2021-06-14 at 12 27 28 PM" src="https://user-images.githubusercontent.com/639920/121927536-2b521280-cd0d-11eb-969c-ff8d08845065.png">

### After:
<img width="446" alt="Screen Shot 2021-06-14 at 12 27 15 PM" src="https://user-images.githubusercontent.com/639920/121927548-2ee59980-cd0d-11eb-8110-ac9e59ad48b4.png">
