### PR TITLE
Fix line break in middle of "Acknowledgements" in metadata table

### DIFF
--- a/app/javascript/frontend/styles/_common.scss
+++ b/app/javascript/frontend/styles/_common.scss
@@ -568,8 +568,8 @@ h4,
   }
 
   th {
-    padding-right: $spacer;
     padding-left: 0;
+    padding-right: 0;
     min-width: 150px;
   }
 


### PR DESCRIPTION
Fixes #1084.

Removed right padding to give text enough space to display on one line.

### Before
<img width="396" alt="Screen Shot 2021-06-14 at 3 57 24 PM" src="https://user-images.githubusercontent.com/639920/121952440-38312f00-cd2a-11eb-9893-30b54d13cbee.png">

### After
<img width="403" alt="Screen Shot 2021-06-14 at 3 57 00 PM" src="https://user-images.githubusercontent.com/639920/121952453-3e271000-cd2a-11eb-9b4e-5cc0d54949f1.png">
