### PR TITLE
Index file metadata

### DIFF
--- a/app/schemas/file_resource_schema.rb
+++ b/app/schemas/file_resource_schema.rb
@@ -5,6 +5,7 @@ class FileResourceSchema < BaseSchema
     DefaultSchema.new(resource: resource)
       .document
       .merge(extracted_text_document)
+      .merge(metadata_document)
   end
 
   def reject
@@ -18,6 +19,14 @@ class FileResourceSchema < BaseSchema
 
       {
         extracted_text_tei: resource.extracted_text
+      }
+    end
+
+    def metadata_document
+      {
+        mime_type_ssi: resource.file.mime_type,
+        size_isi: resource.file.size,
+        original_filename_ssi: resource.file.original_filename
       }
     end
 end

--- a/spec/models/file_resource_spec.rb
+++ b/spec/models/file_resource_spec.rb
@@ -178,11 +178,14 @@ RSpec.describe FileResource, type: :model do
 
     let(:expected_keys) do
       %w(
+        created_at_dtsi
         deposited_at_dtsi
         extracted_text_tei
-        created_at_dtsi
         id
+        mime_type_ssi
         model_ssi
+        original_filename_ssi
+        size_isi
         updated_at_dtsi
         uuid_ssi
       )

--- a/spec/schemas/file_resource_schema_spec.rb
+++ b/spec/schemas/file_resource_schema_spec.rb
@@ -5,19 +5,27 @@ require 'rails_helper'
 RSpec.describe FileResourceSchema do
   subject { described_class.new(resource: resource) }
 
-  let(:resource) { instance_spy('FileResource', extracted_text: extracted_text) }
+  let(:resource) { instance_spy('FileResource', extracted_text: extracted_text, file: file_metadata) }
+  let(:file_metadata) { OpenStruct.new(mime_type: mime_type, size: size, original_filename: filename) }
+  let(:mime_type) { Faker::File.mime_type }
+  let(:size) { Faker::Number.number }
+  let(:filename) { Faker::File.file_name }
+  let(:extracted_text) { Faker::String.random }
 
   describe '#document' do
-    let(:extracted_text) { nil }
-
-    context 'when there is no extracted text' do
-      its(:document) { is_expected.to be_empty }
+    its(:document) do
+      is_expected.to include(
+        extracted_text_tei: extracted_text,
+        mime_type_ssi: mime_type,
+        size_isi: size,
+        original_filename_ssi: filename
+      )
     end
 
-    context 'when there is an extracted text file' do
-      let(:extracted_text) { Faker::String.random }
+    context 'when there is no extracted text' do
+      let(:extracted_text) { nil }
 
-      its(:document) { is_expected.to eq({ extracted_text_tei: extracted_text }) }
+      its(:document) { is_expected.not_to include(extracted_text_tei: '') }
     end
   end
 end


### PR DESCRIPTION
File size, mime type, and the file's original filename are indexed into Solr. This allows us to perform future searches based on mime type, or to report on file sizes.