### PR TITLE
I#1031 change depositor

### DIFF
--- a/app/controllers/dashboard/collections_controller.rb
+++ b/app/controllers/dashboard/collections_controller.rb
@@ -42,11 +42,14 @@ module Dashboard
       def initialize_forms
         @collection.attributes = collection_params
         @editors_form = EditorsForm.new(resource: @collection, user: current_user, params: editors_params)
+        @depositor_form = DepositorForm.new(resource: @collection, params: depositor_params)
       end
 
       def select_form_model
         if params[:editors_form].present?
           @editors_form
+        elsif params[:depositor_form].present?
+          @depositor_form
         else
           @collection
         end
@@ -67,6 +70,14 @@ module Dashboard
           .permit(
             edit_users: [],
             edit_groups: []
+          )
+      end
+
+      def depositor_params
+        params
+          .fetch(:depositor_form, {})
+          .permit(
+            :psu_id
           )
       end
   end

--- a/app/controllers/dashboard/works_controller.rb
+++ b/app/controllers/dashboard/works_controller.rb
@@ -40,6 +40,7 @@ module Dashboard
 
         @embargo_form = EmbargoForm.new(work: @undecorated_work, params: embargo_params)
         @editors_form = EditorsForm.new(resource: @undecorated_work, user: current_user, params: editors_params)
+        @depositor_form = DepositorForm.new(resource: @undecorated_work, params: depositor_params)
       end
 
       def select_form_model
@@ -47,6 +48,8 @@ module Dashboard
           @embargo_form
         elsif params[:editors_form].present?
           @editors_form
+        elsif params[:depositor_form].present?
+          @depositor_form
         else
           @work
         end
@@ -76,6 +79,14 @@ module Dashboard
           .permit(
             edit_users: [],
             edit_groups: []
+          )
+      end
+
+      def depositor_params
+        params
+          .fetch(:depositor_form, {})
+          .permit(
+            :psu_id
           )
       end
   end

--- a/app/forms/depositor_form.rb
+++ b/app/forms/depositor_form.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class DepositorForm
+  include ActiveModel::Model
+
+  attr_reader :resource
+
+  def initialize(resource:, params:)
+    @resource = resource
+    super(params)
+  end
+
+  def psu_id
+    @psu_id ||= resource.depositor.psu_id
+  end
+
+  def psu_id=(psu_id)
+    @psu_id = psu_id
+  end
+
+  def save
+    resource.depositor = find_or_build_actor
+    return false if errors.present?
+
+    resource.save
+  end
+
+  private
+
+    def find_or_build_actor
+      Actor.find_by(psu_id: @psu_id) || BuildNewActor.call(psu_id: @psu_id)
+    rescue PennState::SearchService::NotFound
+      errors.add(:psu_id, :not_found, psu_id: @psu_id)
+      resource.depositor
+    end
+end

--- a/app/views/dashboard/collections/edit.html.erb
+++ b/app/views/dashboard/collections/edit.html.erb
@@ -19,11 +19,18 @@
           <li class="nav-item">
             <%= link_to t('dashboard.shared.editors_form.heading'), "##{t('dashboard.shared.editors_form.heading').parameterize}", class: 'nav-link' %>
           </li>
+
           <% if current_user.admin? && policy(@collection).destroy? %>
+            <li class="nav-item">
+              <%= link_to t('dashboard.shared.depositor_form.heading'),
+                          "##{t('dashboard.shared.depositor_form.heading').parameterize}",
+                          class: 'nav-link' %>
+            </li>
             <li class="nav-item">
               <a class="nav-link" href="#<%= t('.danger.heading').parameterize %>"><%= t('.danger.heading') %></a>
             </li>
           <% end %>
+
         </ul>
       </aside>
     </div>
@@ -52,6 +59,13 @@
       </div>
 
       <% if current_user.admin? && policy(@collection).destroy? %>
+        <div class="keyline keyline--left">
+          <h2 id="<%= t('dashboard.shared.depositor_form.heading').parameterize %>" class="h4"><%= t('dashboard.shared.depositor_form.heading') %></h2>
+        </div>
+
+        <div class="actions mb-3">
+          <%= render 'dashboard/shared/depositor_form', depositor_form: @depositor_form, url: dashboard_collection_path(@collection) %>
+        </div>
         <div class="keyline keyline--left">
           <h2 id="<%= t('.danger.heading').parameterize %>" class="h4"><%= t('.danger.heading') %></h2>
         </div>

--- a/app/views/dashboard/shared/_depositor_form.html.erb
+++ b/app/views/dashboard/shared/_depositor_form.html.erb
@@ -1,0 +1,18 @@
+<p><%= t('.explanation') %></p>
+
+<%- depositor_form_id = "edit_depositor_#{dom_id depositor_form.resource}" %>
+<%= form_for depositor_form,
+             url: url,
+             method: :patch,
+             remote: false,
+             html: { id: depositor_form_id, class: 'edit-resource-depositor' } do |form| %>
+
+  <%= hidden_field_tag 'form_id', depositor_form_id %>
+  <%= render FormErrorMessageComponent.new(form: form) %>
+
+  <%= render 'form_fields/text', form: form, attribute: :psu_id, required: true %>
+
+  <div class="actions mt-1 mb-3">
+    <%= form.submit t('.submit_button'), class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/app/views/dashboard/works/edit.html.erb
+++ b/app/views/dashboard/works/edit.html.erb
@@ -23,11 +23,18 @@
           <li class="nav-item">
             <%= link_to t('dashboard.shared.editors_form.heading'), "##{t('dashboard.shared.editors_form.heading').parameterize}", class: 'nav-link' %>
           </li>
+
           <% if current_user.admin? && policy(@work.latest_version).destroy? %>
-          <li class="nav-item">
-            <a class="nav-link" href="#<%= t('.danger.heading').parameterize %>"><%= t('.danger.heading') %></a>
-          </li>
-        <% end %>
+            <li class="nav-item">
+              <%= link_to t('dashboard.shared.depositor_form.heading'),
+                          "##{t('dashboard.shared.depositor_form.heading').parameterize}",
+                          class: 'nav-link' %>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="#<%= t('.danger.heading').parameterize %>"><%= t('.danger.heading') %></a>
+            </li>
+          <% end %>
+
         </ul>
       </aside>
     </div>
@@ -102,6 +109,14 @@
       </div>
 
       <% if current_user.admin? && policy(@work.latest_version).destroy? %>
+        <div class="keyline keyline--left">
+          <h2 id="<%= t('dashboard.shared.depositor_form.heading').parameterize %>" class="h4"><%= t('dashboard.shared.depositor_form.heading') %></h2>
+        </div>
+
+        <div class="actions mb-3">
+          <%= render 'dashboard/shared/depositor_form', depositor_form: @depositor_form, url: dashboard_work_path(@work) %>
+        </div>
+
         <div class="keyline keyline--left">
           <h2 id="<%= t('.danger.heading').parameterize %>" class="h4"><%= t('.danger.heading') %></h2>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,9 @@ en:
             rights:
               blank: is required to publish the work
   activemodel:
+    attributes:
+      depositor_form:
+        psu_id: Access Account
     errors:
       models:
         editors_form:
@@ -103,6 +106,10 @@ en:
             edit_users:
               not_found: "User %{access_id} could not be found"
               unexpected: "%{access_id} is not a valid user"
+        depositor_form:
+          attributes:
+            psu_id:
+              not_found: "User %{psu_id} could not be found"
         embargo_form:
           attributes:
             embargoed_until:
@@ -178,6 +185,8 @@ en:
     hint:
       editors_form:
         edit_users: Requires the user's Penn State Access ID (e.g., xyz500)
+      depositor_form:
+        psu_id: Enter the user's Penn State Access ID (e.g., xyz500)
       permissions:
         visibility:
           authenticated: >
@@ -267,6 +276,10 @@ en:
         explanation: "Gives the ability for other users from Penn State to edit your %{type}. This can be done on a per-user basis, or a group basis."
         submit_button: Update Editors
         depositor: "%{depositor_name} (%{depositor_id}) deposited this %{type} and will always have edit access."
+      depositor_form:
+        heading: Depositor
+        explanation: "Changes the depositor of the work. Currently, only existing Penn State users are allowed."
+        submit_button: Update Depositor
     works:
       index:
         heading: "Your ScholarSphere Deposits"
@@ -288,16 +301,24 @@ en:
           submit_button: Update Access Settings
         embargo:
           heading: Embargo
-          explanation: Files will be restricted (not downloadable) until after the embargo date. When the embargo lifts, files may be accessed based on the access settings above.
+          explanation: >
+            Files will be restricted (not downloadable) until after the embargo date. When the embargo lifts, files may
+            be accessed based on the access settings above.
           submit_button: Update Embargo Settings
           remove_button: Remove Embargo
         doi:
           heading: DOI
           explanation: A Digital Object Identifier (DOI) is a persistent identifier that can be used in print or on the web.
-          not_allowed: A DOI may only be created on published works. Since this work is a draft, you'll need to wait until it's published to create a DOI for it.
+          not_allowed: >
+            A DOI may only be created on published works. Since this work is a draft, you'll need to wait until it's
+            published to create a DOI for it.
         danger:
           heading: Danger
-          explanation: Only the most recent version can be deleted. Deleting a version cannot be undone. If the most recent version is the only version of the work, the work itself will be deleted (regardless of publication status). If the work has a DOI, it will no longer resolve; you are responsible for updating the DOI to a new URI.
+          explanation: >
+              Only the most recent version can be deleted. Deleting a version cannot be undone. If the most recent
+              version is the only version of the work, the work itself will be deleted (regardless of publication
+              status). If the work has a DOI, it will no longer resolve; you are responsible for updating the DOI to a
+              new URI.
       update:
         success: "Work settings successfully updated."
     form: 

--- a/spec/factories/file_resources.rb
+++ b/spec/factories/file_resources.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require Rails.root.join('spec', 'support', 'file_helpers')
+
 FactoryBot.define do
   factory :file_resource do
     # Fast version with no image processing.

--- a/spec/features/dashboard/collection_settings_spec.rb
+++ b/spec/features/dashboard/collection_settings_spec.rb
@@ -109,4 +109,28 @@ RSpec.describe 'Collection Settings Page', with_user: :user do
       end
     end
   end
+
+  describe 'Changing the depositor' do
+    context 'with a standard user' do
+      it 'does not allow the change' do
+        visit edit_dashboard_collection_path(collection)
+        expect(page).not_to have_content(I18n.t!('dashboard.shared.depositor_form.heading'))
+        expect(page).not_to have_link(I18n.t!('dashboard.shared.depositor_form.submit_button'))
+      end
+    end
+
+    context 'with an admin user' do
+      let(:user) { create :user, :admin }
+      let(:actor) { create(:actor) }
+
+      it 'allows the change' do
+        visit edit_dashboard_collection_path(collection)
+        fill_in('Access Account', with: actor.psu_id)
+        click_on(I18n.t!('dashboard.shared.depositor_form.submit_button'))
+        expect(page).to have_content(I18n.t!('dashboard.collections.update.success'))
+        collection.reload
+        expect(collection.depositor).to eq(actor)
+      end
+    end
+  end
 end

--- a/spec/features/dashboard/work_settings_spec.rb
+++ b/spec/features/dashboard/work_settings_spec.rb
@@ -175,4 +175,28 @@ RSpec.describe 'Work Settings Page', with_user: :user do
       end
     end
   end
+
+  describe 'Changing the depositor' do
+    context 'with a standard user' do
+      it 'does not allow the change' do
+        visit edit_dashboard_work_path(work)
+        expect(page).not_to have_content(I18n.t!('dashboard.shared.depositor_form.heading'))
+        expect(page).not_to have_link(I18n.t!('dashboard.shared.depositor_form.submit_button'))
+      end
+    end
+
+    context 'with an admin user' do
+      let(:user) { create :user, :admin }
+      let(:actor) { create(:actor) }
+
+      it 'allows the change' do
+        visit edit_dashboard_work_path(work)
+        fill_in('Access Account', with: actor.psu_id)
+        click_on(I18n.t!('dashboard.shared.depositor_form.submit_button'))
+        expect(page).to have_content(I18n.t!('dashboard.works.update.success'))
+        work.reload
+        expect(work.depositor).to eq(actor)
+      end
+    end
+  end
 end

--- a/spec/forms/depositor_form_spec.rb
+++ b/spec/forms/depositor_form_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DepositorForm, type: :model do
+  subject(:form) { described_class.new(resource: resource, params: params) }
+
+  let(:resource) { build(:work) }
+  let(:user_attributes) { attributes_for(:user) }
+
+  describe '#psu_id' do
+    context 'without a value in the params' do
+      let(:params) { {} }
+
+      its(:psu_id) { is_expected.to eq(resource.depositor.psu_id) }
+    end
+
+    context 'with an id in the params' do
+      let(:params) { { psu_id: user_attributes[:access_id] } }
+
+      its(:psu_id) { is_expected.to eq(user_attributes[:access_id]) }
+    end
+  end
+
+  describe '#save' do
+    context 'when the actor exists in the system' do
+      let(:actor) { create(:actor) }
+      let(:params) { { psu_id: actor.psu_id } }
+
+      it 'updates the resource with the existing actor' do
+        form.save
+        expect(resource.depositor).to eq(actor)
+      end
+    end
+
+    context 'when the actor does NOT exist but is at Penn State' do
+      let(:params) { { psu_id: user_attributes[:access_id] } }
+      let(:actor) { build(:actor, psu_id: user_attributes[:access_id]) }
+
+      before { allow(BuildNewActor).to receive(:call).with(psu_id: user_attributes[:access_id]).and_return(actor) }
+
+      it 'returns a new actor' do
+        form.save
+        expect(resource.depositor).to eq(actor)
+      end
+    end
+
+    context 'when the neither actor NOR Penn State user exists' do
+      let(:params) { { psu_id: user_attributes[:access_id] } }
+
+      before do
+        allow(BuildNewActor).to receive(:call)
+          .with(psu_id: user_attributes[:access_id])
+          .and_raise(PennState::SearchService::NotFound)
+      end
+
+      it 'returns a new actor' do
+        form.save
+        expect(form.errors.full_messages).to include(
+          "Access Account User #{user_attributes[:access_id]} could not be found"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a additional form to the work and collection settings page to switch the depositor to a different actor. Existing actors or current Penn State users are allowed via the BuildNewActor service. If the actor does not exist, and the user's access id is not currently active at Penn State, then the user is not allowed to be the depositor.

Fixes #1031 