### PR TITLE
FindByMimeType and UpdateExtractedText

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,11 @@ Metrics/CyclomaticComplexity:
     - 'app/services/doi_service.rb'
     - 'app/services/authorship_migration/work_version_creation_migration.rb'
 
+
+Rails/DynamicFindBy:
+  Exclude:
+    - 'spec/models/file_resource_spec.rb'
+
 Rails/FilePath:
   EnforcedStyle: arguments
 

--- a/app/models/file_resource.rb
+++ b/app/models/file_resource.rb
@@ -28,6 +28,11 @@ class FileResource < ApplicationRecord
     IndexingService.commit
   end
 
+  # @param [String, Symbol, Array]
+  def self.find_by_mime_type(types)
+    FindByMimeType.call(mime_types: types)
+  end
+
   # @note Using `head_object` will retrieve the metadata without retrieving the entire object.
   def etag
     @etag ||= client

--- a/app/services/find_by_mime_type.rb
+++ b/app/services/find_by_mime_type.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# @abstract Returns or yields a set of FileResource objects based on their mime types.
+#
+# Examples
+#
+# Return a set of file resources for a given mime type
+#
+#   resources = FindByMimeType.call(mime_types: 'image/png')
+#
+# Return a set of file resources for a set of mime types
+#
+#   resources = FindByMimeType.call(mime_types: ['image/png', 'image/jpeg'])
+#
+# Iterate over all text-based file resources. This is helpful when needing to batch process a large set of files
+#
+#   FindByMimeType.call(mime_types: :text) do |resource|
+#     resource.update(...)
+#   end
+#
+
+class FindByMimeType
+  TEXT = %w(
+    application/msword
+    application/pdf
+    application/postscript
+    application/rtf
+    application/vnd.ms-excel
+    application/vnd.oasis.opendocument.spreadsheet
+    application/vnd.oasis.opendocument.text
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    application/vnd.wordperfect
+    application/x-mobipocket-ebook
+    html
+    text
+    xml
+  ).freeze
+
+  class << self
+    def call(mime_types: [])
+      types = mime_types == :text ? TEXT : Array.wrap(mime_types)
+      sql = build_statement(types)
+
+      ActiveRecord::Base
+        .connection
+        .execute(sql)
+        .values
+        .flatten
+        .map do |id|
+          FileResource.find(id) do |resource|
+            block_given? ? yield(resource) : resource
+          end
+        end
+    end
+
+    private
+
+      def build_statement(types)
+        inner_sql = types.map do |type|
+          "file_data->'metadata'->>'mime_type' LIKE '%#{type}%'"
+        end.join("\n            OR    ")
+
+        %(
+        SELECT DISTINCT
+          file_version_memberships.file_resource_id
+        FROM
+          file_version_memberships
+        WHERE
+          file_version_memberships.work_version_id IN (
+            SELECT id
+            FROM work_versions
+            WHERE aasm_state = 'published'
+          )
+        AND
+          file_version_memberships.file_resource_id IN (
+            SELECT id
+            FROM file_resources
+            WHERE #{inner_sql}
+          )
+        )
+      end
+  end
+end

--- a/app/services/update_extracted_text.rb
+++ b/app/services/update_extracted_text.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# @abstract Updates the extracted text for a give FileResource.
+class UpdateExtractedText
+  def self.call(resource:, force: false)
+    return if resource.extracted_text.present? && (force != true)
+
+    MetadataListener::Job.perform_later(
+      path: [resource.file_data['storage'], resource.file_data['id']].join('/'),
+      endpoint: FileUploader.api_endpoint(resource),
+      api_token: ExternalApp.metadata_listener.token,
+      services: [:extracted_text]
+    )
+  end
+end

--- a/spec/models/file_resource_spec.rb
+++ b/spec/models/file_resource_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe FileResource, type: :model do
     end
   end
 
+  describe '::find_by_mime_type' do
+    before { allow(FindByMimeType).to receive(:call) }
+
+    it 'delegates the query to FindByMimeType' do
+      described_class.find_by_mime_type('mime_type')
+      expect(FindByMimeType).to have_received(:call).with(mime_types: 'mime_type')
+    end
+  end
+
   describe '#save' do
     let(:file_resource) { described_class.new }
     let(:file) { File.open(File.join(fixture_path, 'image.png')) }

--- a/spec/services/find_by_mime_type_spec.rb
+++ b/spec/services/find_by_mime_type_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FindByMimeType do
+  subject { described_class.call(mime_types: types) }
+
+  context 'when querying by all text types' do
+    subject { described_class.call(mime_types: :text) }
+
+    it { is_expected.to be_empty }
+  end
+
+  context 'when querying for a specific type' do
+    let(:types) { 'image/png' }
+
+    before { create(:work_version, :published, :with_files) }
+
+    it 'yields the search result' do
+      described_class.call(mime_types: 'image/png') do |resource|
+        expect(resource).to be_a(FileResource)
+      end
+    end
+  end
+end

--- a/spec/services/update_extracted_text_spec.rb
+++ b/spec/services/update_extracted_text_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe UpdateExtractedText do
+  let(:resource) { FactoryBot.build(:file_resource, id: 1) }
+
+  before do
+    allow(MetadataListener::Job).to receive(:perform_later)
+  end
+
+  context 'when the file has no extracted text' do
+    it 'updates the resource' do
+      expect(resource.extracted_text).not_to be_present
+      described_class.call(resource: resource)
+      expect(MetadataListener::Job).to have_received(:perform_later).with(
+        path: [resource.file_data['storage'], resource.file_data['id']].join('/'),
+        endpoint: FileUploader.api_endpoint(resource),
+        api_token: ExternalApp.metadata_listener.token,
+        services: [:extracted_text]
+      )
+    end
+  end
+
+  context 'when the file has extracted text present' do
+    before { allow(resource).to receive(:extracted_text).and_return('text') }
+
+    it 'does NOT update the resource' do
+      expect(resource.extracted_text).to be_present
+      described_class.call(resource: resource)
+      expect(MetadataListener::Job).not_to have_received(:perform_later)
+    end
+  end
+
+  context 'when the file has extracted text and force is true' do
+    before { allow(resource).to receive(:extracted_text).and_return('text') }
+
+    it 'updates the resource' do
+      expect(resource.extracted_text).to be_present
+      described_class.call(resource: resource, force: true)
+      expect(MetadataListener::Job).to have_received(:perform_later).with(
+        path: [resource.file_data['storage'], resource.file_data['id']].join('/'),
+        endpoint: FileUploader.api_endpoint(resource),
+        api_token: ExternalApp.metadata_listener.token,
+        services: [:extracted_text]
+      )
+    end
+  end
+end


### PR DESCRIPTION
Creates two new service classes allowing us to update a file's extracted text based on its mime type. Two different classes can be used, together if needed, or separately for other purposes.

FindByMimeType allows us to do

``` ruby
FileResource.find_by_mime_type('image/png')
```

much like we would any other column-level query in ActiveRecord, only in this case, the service object builds the necessary sql query to perform the search.

UpdateExtractedText will update any FileResource that doesn't have existing extracted text. Forcing it, with `force: true`, will update it even if it already has text. Resulting jobs are always run async.

Fixes #1057 