### PR TITLE
Combine Edit and Create Version buttons into an Update Version button

### DIFF
--- a/app/components/update_work_component.html.erb
+++ b/app/components/update_work_component.html.erb
@@ -1,0 +1,5 @@
+<%= link_to path,
+            method: method,
+            class: 'btn btn-outline-light btn--squish mr-lg-4 qa-create-draft' do %>
+            <%= I18n.t('resources.work_version.update_button') %>
+<% end %>

--- a/app/components/update_work_component.rb
+++ b/app/components/update_work_component.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class UpdateWorkComponent < ApplicationComponent
+  def initialize(work_version:, policy:)
+    @work_version = work_version
+    @policy = policy
+  end
+
+  def render
+    true
+  end
+
+  private
+
+    def path
+      if @policy.new?
+        # create a new draft work version
+        dashboard_work_work_versions_path(@work_version.work)
+      else
+        # update the existing draft version
+        dashboard_form_work_version_details_path(@work_version.id)
+      end
+    end
+
+    def method
+      return 'post' if @policy.new?
+    end
+end

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -13,25 +13,17 @@
       ) %>
 
   <% if policy(work_version.work).edit? %>
-    <li class="nav-item">
-      <%= render LinkDisabledByTooltipComponent.new(
-            enabled: policy(work_version).edit?,
-            text: I18n.t('resources.work_version.edit_button.text', version: work_version.display_version_short),
-            path: dashboard_form_work_version_details_path(work_version.id),
-            tooltip: I18n.t('resources.work_version.edit_button.tooltip'),
-            class_list: 'btn btn-outline-light btn--squish mr-lg-2 qa-edit-version'
-          ) %>
-    </li>
+    <% if current_user.admin? %>
+      <li class="nav-item">
+        <a class="btn btn-outline-light btn--squish mr-lg-2 qa-edit-version"
+           href="<%= dashboard_form_work_version_details_path(work_version.id) %>">
+          <%= I18n.t('resources.work_version.edit_button', version: work_version.display_version_short) %>
+        </a>
+      </li>
+    <% end %>
 
     <li class="nav-item">
-      <%= render LinkDisabledByTooltipComponent.new(
-            enabled: policy(work_version).new?,
-            text: I18n.t('resources.work_version.create_button.text', version: work_version.display_version_short),
-            path: dashboard_work_work_versions_path(work_version.work),
-            method: :post,
-            tooltip: I18n.t('resources.work_version.create_button.tooltip'),
-            class_list: 'btn btn-outline-light btn--squish mr-lg-4 qa-create-draft'
-          ) %>
+      <%= render UpdateWorkComponent.new(work_version: work_version, policy: policy(work_version)) %>
     </li>
 
     <li class="nav-item">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -548,12 +548,8 @@ en:
       confirm: 'Do you want to create a DOI? This DOI will always resolve to the most recently published version of this work.'
       disable_with: 'Creating...'
     work_version:
-      edit_button:
-        text: 'Edit %{version}'
-        tooltip: 'Only a draft can be edited. Create a new version to add changes to the published work.'
-      create_button:
-        text: 'Create New Version From %{version}'
-        tooltip: 'A new draft version can only be created from the latest published version. Only one draft version may exist at any time.'
+      edit_button: 'Edit %{version}'
+      update_button: 'Update Work'
     collection:
       edit_button: 'Edit'
       delete_button: 'Delete'


### PR DESCRIPTION
The functionality of the edit and create new version butons has been combined into a single button whose action changes depending on whether a draft version exists.

If a draft version exists, the update button acts as "edit draft," and if no draft version exists, the update button acts as "create new draft."

The button to edit a specific version (draft or otherwise) is now an admin-only feature.