### PR TITLE
Combine Edit and Create Version buttons into an Update Work button

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -15,6 +15,7 @@ linters:
   HardCodedString:
     enabled: true
     exclude:
+      - '*app/components/edit_resource_button.html.erb'
       - '*app/components/flash_message_component.html.erb'
       - '*app/views/actor_mailer/*'
       - '*app/views/catalog/_search_form.html.erb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -103,6 +103,7 @@ RSpec/MultipleSubjects:
 
 RSpec/VerifiedDoubles:
   Exclude:
+    - 'spec/components/edit_resource_button_spec.rb'
     - 'spec/components/mintable_doi_component_spec.rb'
     - 'spec/components/work_versions/version_navigation_component_spec.rb'
     - 'spec/components/work_histories/work_history_component_spec.rb'

--- a/app/components/edit_resource_button.html.erb
+++ b/app/components/edit_resource_button.html.erb
@@ -1,0 +1,8 @@
+<%= link_to path,
+            method: method,
+            class: 'btn btn-outline-light btn--squish btn--edit mr-lg-2',
+            title: t('resources.edit_button.tooltip'),
+            data: { toggle: 'tooltip', placement: 'bottom' } do %>
+            <%= label %>
+            <i class="material-icons" aria-hidden="true">edit</i>
+<% end %>

--- a/app/components/edit_resource_button.rb
+++ b/app/components/edit_resource_button.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class EditResourceButton < ApplicationComponent
+  attr_reader :resource, :policy
+
+  def initialize(resource:, policy:)
+    @resource = resource
+    @policy = policy
+  end
+
+  def path
+    if collection?
+      dashboard_form_collection_details_path(resource.id)
+    elsif has_draft?
+      # update the existing draft version
+      dashboard_form_work_version_details_path(resource.work.draft_version.id)
+    elsif policy.new?
+      # create a new draft work version
+      dashboard_work_work_versions_path(resource.work)
+    end
+  end
+
+  def label
+    I18n.t('resources.edit_button.text', type: type)
+  end
+
+  def method
+    return if collection? || has_draft?
+
+    'post'
+  end
+
+  private
+
+    def has_draft?
+      return false if collection?
+
+      resource.work.draft_version.present?
+    end
+
+    def collection?
+      resource.is_a?(CollectionDecorator)
+    end
+
+    def type
+      collection? ? 'Collection' : 'Work'
+    end
+end

--- a/app/javascript/frontend/styles/_common.scss
+++ b/app/javascript/frontend/styles/_common.scss
@@ -991,10 +991,18 @@ h4,
     padding-right: .85rem;
   }
 
+  &--edit i {
+    position: relative;
+    margin-left: 2px;
+    margin-right: -6px;
+    margin-top: -6px;
+    top: 6px;
+  }
+
   &--settings i {
     position: relative;
     margin-top: -6px;
-    top: 4px;
+    top: 6px;
   }
 
   &--collapse-normal {

--- a/app/views/resources/_collection.html.erb
+++ b/app/views/resources/_collection.html.erb
@@ -8,18 +8,18 @@
 
 <%= content_for :navbar_items do %>
   <% if policy(collection).edit? %>
-    <li class="nav-item">
-      <%= link_to(edit_dashboard_collection_path(collection),
-                  class: 'btn btn-outline-light btn--squish mr-lg-2 btn--settings') do %>
-          <%= t('resources.settings_button.text', type: 'Collection') %>
-          <i class="material-icons">settings</i>
-      <% end %>
+    <li class="nav-item py-1">
+      <%= render EditResourceButton.new(resource: collection, policy: policy(collection)) %>
     </li>
 
     <li class="nav-item py-1">
-      <%= link_to t('resources.collection.edit_button'),
-                  dashboard_form_collection_details_path(collection.id),
-                  class: 'btn btn-outline-light btn--squish mr-lg-2' %>
+      <%= link_to edit_dashboard_collection_path(collection),
+                  class: 'btn btn-outline-light btn--squish mr-lg-2 btn--settings',
+                  title: t('resources.settings_button.tooltip'),
+                  data: { toggle: 'tooltip', placement: 'bottom' } do %>
+          <%= t('resources.settings_button.text', type: 'Collection') %>
+          <i class="material-icons" aria-hidden="true">settings</i>
+      <% end %>
     </li>
   <% end %>
 <% end %>

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -7,33 +7,27 @@
 <% end %>
 
 <%= content_for :navbar_items do %>
+  <% if current_user.admin? %>
+    <li class="nav-item py-1">
+      <a class="btn btn-outline-light btn--squish mr-lg-2 qa-edit-version"
+          href="<%= dashboard_form_work_version_details_path(work_version.id) %>">
+        <%= I18n.t('resources.work_version.admin_edit_button', version: work_version.display_version_short) %>
+      </a>
+    </li>
+  <% end %>
+
   <% if policy(work_version.work).edit? %>
     <li class="nav-item py-1">
-      <%= render LinkDisabledByTooltipComponent.new(
-            enabled: policy(work_version).edit?,
-            text: I18n.t('resources.work_version.edit_button.text', version: work_version.display_version_short),
-            path: dashboard_form_work_version_details_path(work_version.id),
-            tooltip: I18n.t('resources.work_version.edit_button.tooltip'),
-            class_list: 'btn btn-outline-light btn--squish mr-lg-2 qa-edit-version'
-          ) %>
+      <%= render EditResourceButton.new(resource: work_version, policy: policy(work_version.work.representative_version)) %>
     </li>
 
     <li class="nav-item py-1">
-      <%= render LinkDisabledByTooltipComponent.new(
-            enabled: policy(work_version).new?,
-            text: I18n.t('resources.work_version.create_button.text', version: work_version.display_version_short),
-            path: dashboard_work_work_versions_path(work_version.work),
-            method: :post,
-            tooltip: I18n.t('resources.work_version.create_button.tooltip'),
-            class_list: 'btn btn-outline-light btn--squish mr-lg-4 qa-create-draft'
-          ) %>
-    </li>
-
-    <li class="nav-item py-1">
-      <%= link_to(edit_dashboard_work_path(work_version.work),
-                  class: 'btn btn-outline-light btn--squish mr-lg-2 btn--settings') do %>
+      <%= link_to edit_dashboard_work_path(work_version.work),
+                  class: 'btn btn-outline-light btn--squish mr-lg-2 btn--settings',
+                  title: t('resources.settings_button.tooltip'),
+                  data: { toggle: 'tooltip', placement: 'bottom' } do %>
           <%= t('resources.settings_button.text', type: 'Work') %>
-          <i class="material-icons">settings</i>
+          <i class="material-icons" aria-hidden="true">settings</i>
       <% end %>
     </li>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -549,18 +549,16 @@ en:
       confirm: 'Do you want to create a DOI? This DOI will always resolve to the most recently published version of this work.'
       disable_with: 'Creating...'
     work_version:
-      edit_button:
-        text: 'Edit %{version}'
-        tooltip: 'Only a draft can be edited. Create a new version to add changes to the published work.'
-      create_button:
-        text: 'Create New Version From %{version}'
-        tooltip: 'A new draft version can only be created from the latest published version. Only one draft version may exist at any time.'
+      admin_edit_button: 'Edit %{version}'
     collection:
-      edit_button: 'Edit'
       delete_button: 'Delete'
       delete_confirm: "Are you sure you want to delete this collection? This cannot be undone."
+    edit_button:
+      text: 'Update %{type}'
+      tooltip: 'Change resource description or content.'
     settings_button:
       text: '%{type} Settings'
+      tooltip: 'Manage access settings, embargoes, DOIs, and more.'
   shared:
     search:
       heading: 'Browse and search for works'

--- a/spec/components/edit_resource_button_spec.rb
+++ b/spec/components/edit_resource_button_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EditResourceButton, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:button) { node.css('a').first }
+
+  context 'when the resource is a work version' do
+    let(:work) { WorkDecorator.new(create(:work, versions_count: 2, has_draft: true)) }
+    let(:v1) { work.decorated_versions.first }
+    let(:v2) { work.decorated_versions.last }
+
+    let(:mock_helpers) { spy 'MockHelpers', policy: mock_policy }
+    let(:mock_policy) { instance_spy 'WorkVersionPolicy', new?: true }
+
+    let(:node) { render_inline(described_class.new(resource: v1, policy: mock_policy)) }
+
+    context 'when a work has an existing draft' do
+      specify do
+        expect(button.attributes['href'].value).to eq "/dashboard/form/work_versions/#{v2.id}/details"
+        expect(button.attributes['data-method']).to be_nil
+        expect(button.text).to include 'Update Work'
+      end
+    end
+
+    context 'when a work does NOT have an existing draft' do
+      let(:work) { WorkDecorator.new(create(:work, versions_count: 2, has_draft: false)) }
+
+      specify do
+        expect(v1.work.draft_version).to be_nil
+        expect(button.attributes['href'].value).to eq "/dashboard/works/#{work.id}/work_versions"
+        expect(button.attributes['data-method'].value).to eq 'post'
+        expect(button.text).to include 'Update Work'
+      end
+    end
+  end
+
+  context 'when the resource is a collection' do
+    let(:collection) { CollectionDecorator.new(create(:collection)) }
+    let(:node) { render_inline(described_class.new(resource: collection, policy: nil)) }
+
+    specify do
+      expect(button.attributes['href'].value).to eq dashboard_form_collection_details_path(collection.id)
+      expect(button.attributes['data-method']).to be_nil
+      expect(button.text).to include 'Update Collection'
+    end
+  end
+end

--- a/spec/features/dashboard/catalog_spec.rb
+++ b/spec/features/dashboard/catalog_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'Dashboard catalog page', :inline_jobs do
       expect(page).not_to have_text(restricted_work.versions.first.title)
       expect(page).not_to have_text(restricted_collection.title)
       click_link(editable_work.versions.first.title)
-      expect(page).to have_link('Edit V1')
+      expect(page).to have_link('Update Work')
     end
   end
 

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Public Resources', type: :feature do
 
         ## Does not have edit controls
         within('header') do
-          expect(page).not_to have_content(I18n.t!('resources.work_version.edit_button.text', version: 'V2'))
+          expect(page).not_to have_content(I18n.t!('resources.work_version.admin_edit_button', version: 'V2'))
           expect(page).not_to have_content(I18n.t!('resources.settings_button.text', type: 'Work'))
         end
 
@@ -73,7 +73,7 @@ RSpec.describe 'Public Resources', type: :feature do
 
         ## Does not have edit controls
         within('header') do
-          expect(page).not_to have_content(I18n.t!('resources.work_version.edit_button.text', version: 'V3'))
+          expect(page).not_to have_content(I18n.t!('resources.work_version.admin_edit_button', version: 'V3'))
           expect(page).not_to have_content(I18n.t!('resources.settings_button.text', type: 'Work'))
         end
 
@@ -101,24 +101,22 @@ RSpec.describe 'Public Resources', type: :feature do
           expect(page).to have_content(v2.title) # Sanity
 
           within('header') do
-            ## Edit controls are visible
-            expect(page).to have_content(I18n.t!('resources.work_version.edit_button.text', version: 'V2'))
-              .and have_content(I18n.t!('resources.work_version.create_button.text', version: 'V2'))
-              .and have_content(I18n.t!('resources.settings_button.text', type: 'Work'))
+            ## Edit Version button is hidden, but Update Work and Work Settings buttons are shown
+            expect(page).not_to have_content(I18n.t!('resources.work_version.admin_edit_button', version: 'V2'))
 
-            ## Edit button is disabled, create draft button is enabled
-            expect(page).to have_selector('.qa-edit-version.disabled')
-            expect(page).to have_selector('.qa-create-draft')
-            expect(page).not_to have_selector('.qa-create-draft.disabled')
+            expect(page).to have_content(I18n.t!('resources.edit_button.text', type: 'Work'))
+              .and have_content(I18n.t!('resources.settings_button.text', type: 'Work'))
           end
 
           ## Navigate to an old version
           within('.version-navigation .list-group') { click_on 'V1' }
 
           within('header') do
-            ## Edit and create draft buttons are now both disabled
-            expect(page).to have_selector('.qa-edit-version.disabled')
-            expect(page).to have_selector('.qa-create-draft.disabled')
+            ## Edit Version button is still hidden, and Update Work and Work Settings buttons are still shown
+            expect(page).not_to have_content(I18n.t!('resources.work_version.admin_edit_button', version: 'V1'))
+
+            expect(page).to have_content(I18n.t!('resources.edit_button.text', type: 'Work'))
+              .and have_content(I18n.t!('resources.settings_button.text', type: 'Work'))
           end
         end
       end
@@ -130,9 +128,11 @@ RSpec.describe 'Public Resources', type: :feature do
           expect(page).to have_content(v2.title) # Sanity
 
           within('header') do
-            ## Edit and create buttons are disabled
-            expect(page).to have_selector('.qa-edit-version.disabled')
-            expect(page).to have_selector('.qa-create-draft.disabled')
+            ## Edit Version button is hidden, but Update Work and Work Settings buttons are shown
+            expect(page).not_to have_content(I18n.t!('resources.work_version.admin_edit_button', version: 'V2'))
+
+            expect(page).to have_content(I18n.t!('resources.edit_button.text', type: 'Work'))
+              .and have_content(I18n.t!('resources.settings_button.text', type: 'Work'))
           end
 
           ## Does have draft in work history
@@ -144,11 +144,26 @@ RSpec.describe 'Public Resources', type: :feature do
           within('.version-navigation .list-group') { click_on 'V3' }
 
           within('header') do
-            ## Edit button enabled, create button disabled
-            expect(page).to have_selector('.qa-edit-version')
-            expect(page).not_to have_selector('.qa-edit-version.disabled')
-            expect(page).to have_selector('.qa-create-draft.disabled')
+            ## Edit Version button is still hidden, and Update Work and Work Settings buttons are still shown
+            expect(page).not_to have_content(I18n.t!('resources.work_version.admin_edit_button', version: 'V3'))
+
+            expect(page).to have_content(I18n.t!('resources.edit_button.text', type: 'Work'))
+              .and have_content(I18n.t!('resources.settings_button.text', type: 'Work'))
           end
+        end
+      end
+    end
+
+    context 'when logged in as an admin', with_user: :user do
+      let(:user) { build(:user, :admin) }
+
+      before do
+        visit resource_path(work.uuid)
+      end
+
+      it 'displays the "Edit Work Version" button' do
+        within ('header') do
+          expect(page).to have_content(I18n.t!('resources.work_version.admin_edit_button', version: 'V2'))
         end
       end
     end
@@ -225,7 +240,7 @@ RSpec.describe 'Public Resources', type: :feature do
         expect(page.title).to include(collection.title)
 
         within('header') do
-          expect(page).to have_content(I18n.t!('resources.collection.edit_button'))
+          expect(page).to have_content(I18n.t!('resources.edit_button.text', type: 'Collection'))
         end
       end
     end


### PR DESCRIPTION
Fixes #1078.
Fixes #1082.

The functionality of the edit and create new version butons has been combined into a single button whose action changes depending on whether a draft version exists.

If a draft version exists, the update button acts as "edit draft," and if no draft version exists, the update button acts as "create new draft."

The button to edit a specific version (draft or otherwise) is now an admin-only feature.

This is available for preview at https://scholarsphere-update-work-button.dsrd.libraries.psu.edu

<img width="475" alt="Screen Shot 2021-06-24 at 10 45 08 AM" src="https://user-images.githubusercontent.com/639920/123283312-48d76700-d4d9-11eb-8076-de30c7251a29.png">