### PR TITLE
Show messages for draft work versions

### DIFF
--- a/app/components/work_version_detail_component.html.erb
+++ b/app/components/work_version_detail_component.html.erb
@@ -1,7 +1,9 @@
 <div class="alert alert-warning" role="alert">
   <%= t "resources.#{i18n_key}.message" %>
 
-  <%= link_to t("resources.#{i18n_key}.link"),
-              resource_path(linked_version),
-              class: 'alert-link' %>
+  <% if !current_representative_version? %>
+    <%= link_to t("resources.#{i18n_key}.link"),
+                resource_path(work.uuid),
+                class: 'alert-link' %>
+  <% end %>
 </div>

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -68,6 +68,8 @@
       </nav>
 
       <%= render '/layouts/navbar' %>
+
+      <%= yield(:detail_components) %>
     </header>
 
     <main class="main">

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -40,10 +40,11 @@
   <% end %>
 <% end %>
 
-<div class="container-fluid">
-
+<%- content_for :detail_components do %>
   <%= render WorkVersionDetailComponent.new(work_version: work_version) %>
+<% end %>
 
+<div class="container-fluid">
   <article class="row">
     <div class="col-lg-7">
       <h1 class="h2 mb-3"><%= work_version.title %></h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -532,8 +532,8 @@ en:
       link: View the current version.
       message: This is an older version of the work.
     draft_version:
-      link: View the draft version.
-      message: An updated draft version for this work is available.
+      link: View the current version.
+      message: This is a draft version of the work.
     versions: Versions
     work_history: Work History
     works: Works


### PR DESCRIPTION
Fixes #1081 
Fixes #1079 

If a user is viewing a draft work version and there is a published version available, show a message directing the user to the latest published version.

This is an inversion of the previous messaging; we no longer show a message on published versions that a draft version is available.

## Viewing the draft

![Screen Shot 2021-06-24 at 11 14 09 AM](https://user-images.githubusercontent.com/312085/123288255-61e21700-d4dd-11eb-8aac-a84f9492001c.png)

## Viewing an older version

![Screen Shot 2021-06-24 at 11 14 17 AM](https://user-images.githubusercontent.com/312085/123288281-69092500-d4dd-11eb-9893-cd0b476b00a7.png)

