### PR TITLE
Create reusable ResourceButton component

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -103,8 +103,8 @@ RSpec/MultipleSubjects:
 
 RSpec/VerifiedDoubles:
   Exclude:
-    - 'spec/components/edit_resource_button_spec.rb'
     - 'spec/components/mintable_doi_component_spec.rb'
+    - 'spec/components/resource_edit_button_spec.rb'
     - 'spec/components/work_versions/version_navigation_component_spec.rb'
     - 'spec/components/work_histories/work_history_component_spec.rb'
 

--- a/app/components/resource_button.html.erb
+++ b/app/components/resource_button.html.erb
@@ -1,8 +1,8 @@
 <%= link_to path,
             method: method,
             class: 'btn btn-outline-light btn--squish btn--edit mr-lg-2',
-            title: t('resources.edit_button.tooltip'),
+            title: tooltip,
             data: { toggle: 'tooltip', placement: 'bottom' } do %>
             <%= label %>
-            <i class="material-icons" aria-hidden="true">edit</i>
+            <i class="material-icons" aria-hidden="true"><%= icon %></i>
 <% end %>

--- a/app/components/resource_button.rb
+++ b/app/components/resource_button.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class ResourceButton < ApplicationComponent
+  attr_reader :resource, :policy
+
+  def initialize(resource:, policy: nil)
+    @resource = resource
+    @policy = policy
+  end
+
+  def method; end
+
+  private
+
+    def has_draft?
+      return false if collection?
+
+      resource.work.draft_version.present?
+    end
+
+    def collection?
+      resource.is_a?(CollectionDecorator)
+    end
+
+    def type
+      collection? ? 'Collection' : 'Work'
+    end
+end

--- a/app/components/resource_edit_button.rb
+++ b/app/components/resource_edit_button.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
-class EditResourceButton < ApplicationComponent
-  attr_reader :resource, :policy
-
-  def initialize(resource:, policy:)
-    @resource = resource
-    @policy = policy
-  end
-
+class ResourceEditButton < ResourceButton
   def path
     if collection?
       dashboard_form_collection_details_path(resource.id)
@@ -24,25 +17,17 @@ class EditResourceButton < ApplicationComponent
     I18n.t('resources.edit_button.text', type: type)
   end
 
+  def tooltip
+    I18n.t('resources.edit_button.tooltip')
+  end
+
+  def icon
+    'edit'
+  end
+
   def method
     return if collection? || has_draft?
 
     'post'
   end
-
-  private
-
-    def has_draft?
-      return false if collection?
-
-      resource.work.draft_version.present?
-    end
-
-    def collection?
-      resource.is_a?(CollectionDecorator)
-    end
-
-    def type
-      collection? ? 'Collection' : 'Work'
-    end
 end

--- a/app/components/resource_settings_button.rb
+++ b/app/components/resource_settings_button.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ResourceSettingsButton < ResourceButton
+  def path
+    if collection?
+      edit_dashboard_collection_path(resource)
+    else
+      edit_dashboard_work_path(resource)
+    end
+  end
+
+  def label
+    I18n.t('resources.settings_button.text', type: type)
+  end
+
+  def tooltip
+    I18n.t('resources.settings_button.tooltip')
+  end
+
+  def icon
+    'settings'
+  end
+end

--- a/app/views/resources/_collection.html.erb
+++ b/app/views/resources/_collection.html.erb
@@ -9,17 +9,11 @@
 <%= content_for :navbar_items do %>
   <% if policy(collection).edit? %>
     <li class="nav-item py-1">
-      <%= render EditResourceButton.new(resource: collection, policy: policy(collection)) %>
+      <%= render ResourceEditButton.new(resource: collection, policy: policy(collection)) %>
     </li>
 
     <li class="nav-item py-1">
-      <%= link_to edit_dashboard_collection_path(collection),
-                  class: 'btn btn-outline-light btn--squish mr-lg-2 btn--settings',
-                  title: t('resources.settings_button.tooltip'),
-                  data: { toggle: 'tooltip', placement: 'bottom' } do %>
-          <%= t('resources.settings_button.text', type: 'Collection') %>
-          <i class="material-icons" aria-hidden="true">settings</i>
-      <% end %>
+      <%= render ResourceSettingsButton.new(resource: collection) %>
     </li>
   <% end %>
 <% end %>

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -18,19 +18,12 @@
 
   <% if policy(work_version.work).edit? %>
     <li class="nav-item py-1">
-      <%= render EditResourceButton.new(resource: work_version, policy: policy(work_version.work.representative_version)) %>
+      <%= render ResourceEditButton.new(resource: work_version, policy: policy(work_version.work.representative_version)) %>
     </li>
 
     <li class="nav-item py-1">
-      <%= link_to edit_dashboard_work_path(work_version.work),
-                  class: 'btn btn-outline-light btn--squish mr-lg-2 btn--settings',
-                  title: t('resources.settings_button.tooltip'),
-                  data: { toggle: 'tooltip', placement: 'bottom' } do %>
-          <%= t('resources.settings_button.text', type: 'Work') %>
-          <i class="material-icons" aria-hidden="true">settings</i>
-      <% end %>
+      <%= render ResourceSettingsButton.new(resource: work_version.work) %>
     </li>
-
   <% end %>
 <% end %>
 

--- a/spec/components/resource_edit_button_spec.rb
+++ b/spec/components/resource_edit_button_spec.rb
@@ -2,10 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe EditResourceButton, type: :component do
+RSpec.describe ResourceEditButton, type: :component do
   include Rails.application.routes.url_helpers
 
   let(:button) { node.css('a').first }
+  let(:icon) { node.css('i').first }
 
   context 'when the resource is a work version' do
     let(:work) { WorkDecorator.new(create(:work, versions_count: 2, has_draft: true)) }
@@ -19,8 +20,9 @@ RSpec.describe EditResourceButton, type: :component do
 
     context 'when a work has an existing draft' do
       specify do
-        expect(button.attributes['href'].value).to eq "/dashboard/form/work_versions/#{v2.id}/details"
+        expect(button.attributes['href'].value).to eq dashboard_form_work_version_details_path(v2.id)
         expect(button.attributes['data-method']).to be_nil
+        expect(icon.text).to include 'edit'
         expect(button.text).to include 'Update Work'
       end
     end
@@ -30,8 +32,9 @@ RSpec.describe EditResourceButton, type: :component do
 
       specify do
         expect(v1.work.draft_version).to be_nil
-        expect(button.attributes['href'].value).to eq "/dashboard/works/#{work.id}/work_versions"
+        expect(button.attributes['href'].value).to eq dashboard_work_work_versions_path(work)
         expect(button.attributes['data-method'].value).to eq 'post'
+        expect(icon.text).to include 'edit'
         expect(button.text).to include 'Update Work'
       end
     end

--- a/spec/components/resource_settings_button_spec.rb
+++ b/spec/components/resource_settings_button_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ResourceSettingsButton, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:button) { node.css('a').first }
+  let(:icon) { node.css('i').first }
+
+  context 'when the resource is a work' do
+    let(:work) { WorkDecorator.new(create(:work, versions_count: 2, has_draft: true)) }
+
+    let(:node) { render_inline(described_class.new(resource: work)) }
+
+    specify do
+      expect(button.attributes['href'].value).to eq edit_dashboard_work_path(work)
+      expect(button.attributes['data-method']).to be_nil
+      expect(icon.text).to include 'settings'
+      expect(button.text).to include 'Work Settings'
+    end
+  end
+
+  context 'when the resource is a collection' do
+    let(:collection) { CollectionDecorator.new(create(:collection)) }
+    let(:node) { render_inline(described_class.new(resource: collection, policy: nil)) }
+
+    specify do
+      expect(button.attributes['href'].value).to eq edit_dashboard_collection_path(collection)
+      expect(button.attributes['data-method']).to be_nil
+      expect(icon.text).to include 'settings'
+      expect(button.text).to include 'Collection Settings'
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1105.

We now have an "abstract" component called `ResourceButton`, with two components extending its functionality:

- `EditResourceButton`
- `ResourceSettingsButton`

These two components are currently used in the Work Version and Collection details views.