### PR TITLE
removes unused docker-compose services. refactors startup for performance

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,0 +1,7 @@
+# Get values from vault
+# vault kv get secret/devteam/scholarsphere
+export OAUTH_APP_ID=
+export OAUTH_APP_SECRET=
+export OAUTH_APP_URL=
+export OAUTH_AUTHORIZE_URL=
+export OAUTH_TOKEN_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ cc-test-reporter
 .cache
 .yarnrc
 doc/api/*
+.envrc

--- a/bin/startup
+++ b/bin/startup
@@ -3,10 +3,13 @@ set -e
 
 if [ "${RAILS_ENV:-development}" != "production" ]; then
   bundle check || bundle
+  echo "Initalizing the database and solr"
+  bundle exec rails solr:init
+  bundle exec rails db:create db:migrate
+  bundle exec rails db:seed:groups
 fi
 
 echo "starting rails"
 rm -f tmp/pids/server.pid
-bundle exec rails db:create db:migrate db:seed
-bundle exec rails solr:init
+
 bundle exec rails s -b '0.0.0.0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ x-web_env: &web_env
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-scholarsphere}
       AWS_BUCKET: scholarsphere
       AWS_REGION: us-east-1
-      S3_ENDPOINT: http://minio:9000
+      S3_ENDPOINT: ${S3_ENDPOINT:-http://docker.for.mac.localhost:9000}
       RAILS_ENV: ${RAILS_ENV:-development}
       SOLR_HOST: solr
       SOLR_COLLECTION: scholarsphere

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,21 +37,6 @@ services:
       - redis-data:/data
     ports:
     - "6379:6379"
-  sidekiq:
-    tty: true
-    stdin_open: true
-    <<: *web_env
-    build:
-      context: . 
-      target: base
-    command:
-      - /app/bin/sidekiq
-    volumes:
-    - bundle-data:/app/vendor/bundle
-    - node-data:/app/node_modules
-    - type: bind
-      source: ./
-      target: /app/
   web:
     tty: true
     stdin_open: true
@@ -97,12 +82,6 @@ services:
       "-c",
       "solr -c && solr auth enable -credentials $$SOLR_USERNAME:$$SOLR_PASSWORD -z localhost:9983; solr stop && solr -c -f",
     ]
-
-  adminer:
-    image: adminer
-    restart: always
-    ports:
-    - "8080:8080"
   db:
     environment:
       POSTGRES_PASSWORD: scholarsphere


### PR DESCRIPTION
I'm going through the docker-compose setup for Monday, and came across some items that needed fixing. sidekiq doesn't need to be running all the time, so i took that service out. if we need to run sidekiq for testing we can do that as a one off (i'll put that in the docs) I have also updated the docs to go along with this PR (https://github.com/psu-libraries/scholarsphere/wiki/Docker)

I moved the startup items around, to only run in development mode, in kubernetes we are going to handle this with a cron job. I removed the db:seed task, because it ran at every startup, is slow, and will fill up the database over time. In the docs there's a seperate command to run to seed the database if you want

