### PR TITLE
Markdown support for field hints' translations

### DIFF
--- a/app/components/field_hint_component.html.erb
+++ b/app/components/field_hint_component.html.erb
@@ -1,0 +1,1 @@
+<small id="<%= dom_id %>" class="form-text text-muted"><%= raw hint_text %></small>

--- a/app/components/field_hint_component.rb
+++ b/app/components/field_hint_component.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class FieldHintComponent < ApplicationComponent
+  attr_reader :form,
+              :attribute
+
+  class << self
+    def markdown
+      @markdown ||= Redcarpet::Markdown.new(
+        Redcarpet::Render::HTML.new(filter_html: false),
+        {}
+      )
+    end
+  end
+
+  def initialize(form:, attribute:)
+    @form = form
+    @attribute = attribute
+  end
+
+  def render?
+    I18n.exists?(i18n_key)
+  end
+
+  def dom_id
+    return unless render?
+
+    "#{form_field_id}-hint"
+  end
+
+  def hint_text
+    render_markdown I18n.t(i18n_key)
+  end
+
+  def i18n_key
+    @i18n_key ||= ['helpers', 'hint', form.object.class.model_name.i18n_key, attribute].join('.')
+  end
+
+  private
+
+    def render_markdown(text)
+      rendered = self.class.markdown.render(text)
+
+      # remove the surrounding <p> tag that redcarpet insists on inserting
+      rendered
+        .strip
+        .gsub(/\A<p>(.*)<\/p>\Z/m, '\1')
+    end
+
+    # @note Based off of ActionView::Helpers::Tags::Base#tag_id.
+    def form_field_id
+      sanitized_object_name = form.object_name
+        .gsub(/\]\[|[^-a-zA-Z0-9:.]/, '_') # Replace non-alphanumerics with '_'
+        .sub(/_$/, '')                     # Remove a trailing '_'
+      [sanitized_object_name, attribute.to_s].join('_')
+    end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,13 +27,4 @@ module ApplicationHelper
       link_to link, path, options.merge(class: 'nav-link')
     end
   end
-
-  # @note Based off of ActionView::Helpers::Tags::Base#tag_id. Because it's a private method, and we shouldn't override
-  # it, we're redoing it here.
-  def form_field_id(form, attribute)
-    sanitized_object_name = form.object_name
-      .gsub(/\]\[|[^-a-zA-Z0-9:.]/, '_') # Replace non-alphanumerics with '_'
-      .sub(/_$/, '')                     # Remove a trailing '_'
-    [sanitized_object_name, attribute.to_s].join('_')
-  end
 end

--- a/app/views/form_fields/_multi_text.html.erb
+++ b/app/views/form_fields/_multi_text.html.erb
@@ -1,8 +1,4 @@
 <% terms = form.object.send(attribute).empty? ? [''] : form.object.send(attribute) %>
-<%- field_id = form_field_id(form, attribute) %>
-<%- hint_id = "#{field_id}-hint" %>
-<%- hint_i18n_key = ['helpers', 'hint', form.object.class.model_name.i18n_key, attribute].join('.') %>
-<%- has_hint = I18n.exists?(hint_i18n_key) %>
 
 <div class="mb-3">
   <div data-controller="multiple-fields">
@@ -16,7 +12,5 @@
     <% end %>
   </div>
 
-  <% if has_hint %>
-    <small id="<%= hint_id %>" class="form-text text-muted"><%= t hint_i18n_key %></small>
-  <% end %>
+  <%= render FieldHintComponent.new(form: form, attribute: attribute) %>
 </div>

--- a/app/views/form_fields/_select.html.erb
+++ b/app/views/form_fields/_select.html.erb
@@ -1,7 +1,4 @@
-<%- field_id = form_field_id(form, attribute) %>
-<%- hint_id = "#{field_id}-hint" %>
-<%- hint_i18n_key = ['helpers', 'hint', form.object.class.model_name.i18n_key, attribute].join('.') %>
-<%- has_hint = I18n.exists?(hint_i18n_key) %>
+<%- hint = FieldHintComponent.new(form: form, attribute: attribute) %>
 
 <div class="form-group has-float-label mb-3">
   <%= form.select attribute,
@@ -11,7 +8,7 @@
                     class: 'form-control custom-select',
                     required: local_assigns[:required].presence,
                     multiple: local_assigns.fetch(:multiple, false),
-                    aria: { describedby: (has_hint && hint_id).presence }
+                    aria: { describedby: hint.dom_id }
                   } %>
   <%= form.label attribute %>
 
@@ -19,7 +16,5 @@
     <small class="form-text feedback-invalid"><%= form.object.errors[attribute].join('; ') %></small>
   <% end %>
 
-  <% if has_hint %>
-    <small id="<%= hint_id %>" class="form-text text-muted"><%= t hint_i18n_key %></small>
-  <% end %>
+  <%= render hint %>
 </div>

--- a/app/views/form_fields/_text.html.erb
+++ b/app/views/form_fields/_text.html.erb
@@ -1,7 +1,4 @@
-<%- field_id = form_field_id(form, attribute) %>
-<%- hint_id = "#{field_id}-hint" %>
-<%- hint_i18n_key = ['helpers', 'hint', form.object.class.model_name.i18n_key, attribute].join('.') %>
-<%- has_hint = I18n.exists?(hint_i18n_key) %>
+<%- hint = FieldHintComponent.new(form: form, attribute: attribute) %>
 
 <div class="form-group has-float-label mb-3">
   <%= form.text_field attribute,
@@ -9,14 +6,12 @@
                       placeholder: true,
                       required: local_assigns[:required].presence,
                       data: local_assigns[:data],
-                      aria: { describedby: (has_hint && hint_id).presence } %>
+                      aria: { describedby: hint.dom_id } %>
   <%= form.label attribute %>
 
   <% if form.object.errors.include?(attribute) %>
     <small class="form-text feedback-invalid"><%= form.object.errors[attribute].join('; ') %></small>
   <% end %>
 
-  <% if has_hint %>
-    <small id="<%= hint_id %>" class="form-text text-muted"><%= t hint_i18n_key %></small>
-  <% end %>
+  <%= render hint %>
 </div>

--- a/app/views/form_fields/_text_area.html.erb
+++ b/app/views/form_fields/_text_area.html.erb
@@ -1,7 +1,4 @@
-<%- field_id = form_field_id(form, attribute) %>
-<%- hint_id = "#{field_id}-hint" %>
-<%- hint_i18n_key = ['helpers', 'hint', form.object.class.model_name.i18n_key, attribute].join('.') %>
-<%- has_hint = I18n.exists?(hint_i18n_key) %>
+<%- hint = FieldHintComponent.new(form: form, attribute: attribute) %>
 
 <div class="form-group has-float-label mb-3">
   <%= form.text_area attribute,
@@ -10,14 +7,12 @@
                      cols: 40,
                      placeholder: true,
                      required: local_assigns[:required].presence,
-                     aria: { describedby: (has_hint && hint_id).presence } %>
+                     aria: { describedby: hint.dom_id } %>
   <%= form.label attribute %>
 
   <% if form.object.errors.include?(attribute) %>
     <small class="form-text feedback-invalid"><%= form.object.errors[attribute].join('; ') %></small>
   <% end %>
 
-  <% if has_hint %>
-    <small id="<%= hint_id %>" class="form-text text-muted"><%= t hint_i18n_key %></small>
-  <% end %>
+  <%= render hint %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -182,6 +182,7 @@ en:
     description: 'A service of the University Libraries.'
     copyright_statement: 'Copyright © 2020 The Pennsylvania State University'
   helpers:
+    # Note, for hints (and only hints) you can use Markdown
     hint:
       editors_form:
         edit_users: Requires the user's Penn State Access ID (e.g., xyz500)

--- a/spec/components/field_hint_component_spec.rb
+++ b/spec/components/field_hint_component_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FieldHintComponent, type: :component do
+  subject(:component) { described_class.new(form: form, attribute: :doi) }
+
+  let(:form) { instance_spy 'FormBuilder', object: resource, object_name: 'work_form' }
+  let(:resource) { build_stubbed :work }
+
+  context 'when there is an entry in en.yml' do
+    let(:translation) { 'The Hint' }
+
+    before do
+      allow(I18n).to receive(:exists?).with('helpers.hint.work.doi').and_return(true)
+      allow(I18n).to receive(:t).with('helpers.hint.work.doi').and_return(translation)
+    end
+
+    its(:render?) { is_expected.to eq true }
+    its(:dom_id) { is_expected.to eq 'work_form_doi-hint' }
+
+    it 'renders' do
+      expect(
+        render_inline(component).css('small#work_form_doi-hint').to_html
+      ).to include(
+        'The Hint'
+      )
+    end
+
+    context 'when there is html in the en.yml file' do
+      let(:translation) { "The <a href='#'>Hint</a>" }
+
+      it 'renders the html raw without escaping it' do
+        expect(
+          render_inline(component).css('small').to_html
+        ).to include(
+          %(The <a href="#">Hint</a>)
+        )
+      end
+    end
+
+    context 'when there is markdown in the en.yml file' do
+      let(:translation) { 'The [Hint](#)' }
+
+      it 'renders the markdown into html' do
+        expect(
+          render_inline(component).css('small').to_html
+        ).to include(
+          %(The <a href="#">Hint</a>)
+        )
+      end
+    end
+  end
+
+  context 'when there is NOT an entry in en.yml' do
+    before do
+      allow(I18n).to receive(:exists?).with('helpers.hint.work.doi').and_return(false)
+    end
+
+    its(:dom_id) { is_expected.to eq nil }
+    its(:render?) { is_expected.to eq false }
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -9,21 +9,4 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     it { is_expected.to eq(root_path) }
   end
-
-  # Used in app/views/form_fields/*
-  describe '#form_field_id' do
-    it 'returns a sanitized dom id for the given form object and attribute' do
-      # Simulate a vanilla form
-      expect(helper.form_field_id(
-               instance_double('ActionView::Helpers::FormBuilder', object_name: 'work_version'),
-               :title
-             )).to eq 'work_version_title'
-
-      # Simulate a form with nested fields
-      expect(helper.form_field_id(
-               instance_double('ActionView::Helpers::FormBuilder', object_name: 'work_version[work_attributes]'),
-               :type
-             )).to eq 'work_version_work_attributes_type'
-    end
-  end
 end


### PR DESCRIPTION
For field hints (and only field hints) you can use either Markdown in the en.yml file and it will be parsed and rendered. You can also use raw HTML if you like, but the MD syntax is cleaner so I suggest you use that.

I did this by refactoring all of our input field partials to use a common View Component for rendering the hint. This view component has the smarts to parse the markdown that may be present in the en.yml file. Note that I did not add MD support to everything in the en.yml file, only this one component in our application logic. 

This had the side benefit of really cleaning up our form field partials too.
![Screen Shot 2022-01-18 at 2 00 31 PM](https://user-images.githubusercontent.com/14730/150003149-de3361e5-fe42-449f-8ac5-de0783bb42c4.jpg)

Closes #1156 