### PR TITLE
Hide the "Done" button in the file upload component.

### DIFF
--- a/app/javascript/controllers/uppy_controller.js
+++ b/app/javascript/controllers/uppy_controller.js
@@ -32,7 +32,8 @@ export default class extends Controller {
         target: this.element,
         inline: 'true',
         showProgressDetails: true,
-        height: 350
+        height: 350,
+        doneButtonHandler: null
       }).use(AwsS3Multipart, {
         companionUrl: '/'
       })


### PR DESCRIPTION
Closes #1127.

Per the [Uppy Dashboard plugin docs](https://uppy.io/docs/dashboard/#doneButtonHandler), setting the `doneButtonHandler` to `null` hides the Done button. It wasn't doing anything useful, so it seems to make sense just to hide it.

<img width="1159" alt="Screen Shot 2022-01-19 at 12 22 18 PM" src="https://user-images.githubusercontent.com/639920/150182124-db51ab53-8f83-4893-a790-80d203965616.png">

