### PR TITLE
Work factory keeps the same list of actors for all versions

### DIFF
--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -17,6 +17,8 @@ FactoryBot.define do
       end
 
       after(:build, :stub) do |work_version, evaluator|
+        next if work_version.creators.any? # Skip if there are already creators specified
+
         work_version.creators = build_list(:authorship, evaluator.creator_count) do |creator, index|
           creator.resource = work_version
           creator.position = index

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -24,12 +24,20 @@ FactoryBot.define do
       num_drafts_to_build = evaluator.has_draft ? 1 : 0
       num_published_to_build = evaluator.versions_count - num_drafts_to_build
 
+      # We are going to use these to create the same actors across all the
+      # authorships in all the work versions we create below, so that the
+      # authors will stay the same across versions
+      author_actors = build_list(:actor, 2)
+
       num_published_to_build.times do |n|
         work.versions << build(:work_version,
                                :published,
                                :with_complete_metadata,
                                work: work,
-                               version_number: (n + 1))
+                               version_number: (n + 1),
+                               creators: author_actors.each_with_index.map do |actor, index|
+                                           Authorship.new(actor: actor, position: index + 1)
+                                         end)
       end
 
       if evaluator.has_draft
@@ -37,7 +45,11 @@ FactoryBot.define do
                                :draft,
                                :with_complete_metadata,
                                work: work,
-                               version_number: (num_published_to_build + 1))
+                               version_number: (num_published_to_build + 1),
+                               creators: author_actors.each_with_index.map do |actor, index|
+                                           Authorship.new(actor: actor, position: index + 1)
+                                         end)
+
       end
     end
   end

--- a/spec/schemas/work_version_schema_spec.rb
+++ b/spec/schemas/work_version_schema_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe WorkVersionSchema, type: :schema do
     context 'when a work has migration errors' do
       let(:resource) { create(:work).versions.first }
 
+      before do
+        resource.creators = []
+        resource.file_resources = []
+      end
+
       it { expect(errors).not_to include(
         "Work versions file resources can't be blank",
         "Work versions creator aliases can't be blank"


### PR DESCRIPTION
In our data model, a Work requires at least one associated WorkVersion. So, our factory creates one or more versions when creating a work. You can tell the work factory to create multiple versions if you wish. Previously, each of these versions was created in isolation and therefore was created with its own unique list of authors. This is not a violation of our data model, but for some reason @awead didn't like that and wrote #827 

This PR does a little legwork to maintain the same list of authors within each version created by the work factory. It's a little less complicated than I thought it might be, and only broke one spec in the process.

Closes #827 