### PR TITLE
Fix flaky specs from VCR and WebMock

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -9,6 +9,8 @@ class AnalyticsController < ApplicationController
       format.html { head :unsupported_media_type }
       format.json { render json: view_statistics }
     end
+  rescue ActiveRecord::RecordNotFound
+    head 404, content_type: 'text/plain'
   end
 
   private

--- a/app/javascript/frontend/scripts/view_statistics_chart.js
+++ b/app/javascript/frontend/scripts/view_statistics_chart.js
@@ -13,6 +13,7 @@ function loadChart () {
   d3.json(url)
     .then(parseData)
     .then((parsedData) => drawChart(d3.select(this), parsedData))
+    .catch(() => { })
 }
 
 function parseData (data) {

--- a/spec/controllers/analytics_controller_spec.rb
+++ b/spec/controllers/analytics_controller_spec.rb
@@ -44,5 +44,11 @@ RSpec.describe AnalyticsController, type: :controller do
         it { is_expected.to have_http_status(:unsupported_media_type) }
       end
     end
+
+    context "when the requested resource can't be found" do
+      before { get(:show, params: { resource_id: 'not-a-resource' }) }
+
+      specify { expect(response).to have_http_status(:not_found) }
+    end
   end
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -2,13 +2,24 @@
 
 require 'vcr'
 
+# Fix flaky behavior ("Too many open files - socket(2) for "127.0.0.1" port 9515")
+#   - https://github.com/teamcapybara/capybara#gotchas
+#   - https://github.com/bblimke/webmock/blob/master/README.md#connecting-on-nethttpstart
+WebMock.allow_net_connect!(net_http_connect_on_start: true)
+
+# Allow connections to Docker images and webriver update urls
+driver_hosts = Webdrivers::Common.subclasses
+  .map(&:base_url)
+  .map { |url| URI.parse(url).host }
+allowed_hosts = %w(selenium minio solr) + driver_hosts
+
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   c.hook_into :webmock
   c.configure_rspec_metadata!
   c.allow_http_connections_when_no_cassette = true
   c.ignore_localhost = true
-  c.ignore_hosts 'selenium', 'minio', 'solr'
+  c.ignore_hosts *allowed_hosts
   c.debug_logger = File.open('log/vcr.log', 'w')
   c.default_cassette_options = { erb: true, update_content_length_header: true }
 end


### PR DESCRIPTION
This fixes two issues that were causing rspec errors on my local dev box and on ci. 

The first commit fixes some weirdness surrounding selenium and chromedriver. I was experiencing issues around this even though I don't see this happening in ci. I am running selenium/chromedriver on my local machine rather than through docker, which probably explains some things—I should probably fix up my development environment to use the docker image, but whatever.

The second commit fixes the actual issue we were seeing on ci. What happens is, the resource page hits a small json endpoint called `AnalyticsController` which returns the data needed to draw the analytics/view graphs:

![Screen Shot 2022-01-25 at 11 25 47 AM](https://user-images.githubusercontent.com/14730/151030355-1abfeb08-9db3-4fbb-99cd-e7a7e744b7a4.png)

The errors in ci were from that controller raising `RecordNotFound` error, which I believe is from a race condition of the tests tearing down the database at the same time this ajax call was firing. To fix the failing specs, I simply made this controller rescue `RecordNotFound` and explicitly return a 404. In the production environment, this is done automatically; also in production, the likelihood of a person hitting this same race condition is extremely slim. A work would need to be deleted in the milliseconds between when a user loaded a work's resource page, but before the ajax call to the analytics was fired off. 

Closes #1183 