### PR TITLE
Preview/1151 dismax q escape

### DIFF
--- a/app/models/concerns/catalog_search_behavior.rb
+++ b/app/models/concerns/catalog_search_behavior.rb
@@ -7,7 +7,7 @@ module CatalogSearchBehavior
   def search_related_files(solr_parameters)
     return if blacklight_params[:q].blank? || blacklight_params.fetch(:search_field, 'all_fields') != 'all_fields'
 
-    user_query = blacklight_params[:q]
+    user_query = escape(blacklight_params[:q])
     solr_parameters[:q] = "{!lucene}#{dismax_query(user_query)} #{related_file_resources(user_query)}"
     solr_parameters[:defType] = 'lucene'
   end
@@ -89,5 +89,10 @@ module CatalogSearchBehavior
 
     def escape_value(value)
       RSolr.solr_escape(value).gsub(/ /, '\ ')
+    end
+
+    def escape(value)
+      # Need to escape hyphen since it is a lucene special character
+      value.gsub(/-/, ' \1')
     end
 end

--- a/app/models/concerns/catalog_search_behavior.rb
+++ b/app/models/concerns/catalog_search_behavior.rb
@@ -92,7 +92,6 @@ module CatalogSearchBehavior
     end
 
     def escape(value)
-      # Need to escape hyphen since it is a lucene special character
-      value.gsub(/-/, ' \1')
+      CGI.escape(value)
     end
 end

--- a/spec/features/catalog/catalog_spec.rb
+++ b/spec/features/catalog/catalog_spec.rb
@@ -152,6 +152,16 @@ RSpec.describe 'Blacklight catalog page', :inline_jobs do
     end
   end
 
+  context 'when the search term has a lucene special character in it' do
+    let(:work_version) { create(:work_version, :published, title: 'Title with-dash') }
+
+    it 'displays search results correctly', with_user: :user do
+      visit(search_catalog_path(q: work_version.title))
+
+      expect(page).to have_selector('h3', text: work_version.title)
+    end
+  end
+
   context 'when the application is read-only', :read_only do
     it 'displays a message' do
       visit(search_catalog_path)

--- a/spec/models/dashboard/search_builder_spec.rb
+++ b/spec/models/dashboard/search_builder_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Dashboard::SearchBuilder do
 
       it 'searches related files' do
         expect(parameters['q']).to eq(
-          '{!lucene}{!dismax v=user query} {!join from=id to=file_resource_ids_ssim}{!dismax v=user query}'
+          '{!lucene}{!dismax v=user+query} {!join from=id to=file_resource_ids_ssim}{!dismax v=user+query}'
         )
       end
     end
@@ -52,7 +52,7 @@ RSpec.describe Dashboard::SearchBuilder do
 
       it 'searches related files' do
         expect(parameters['q']).to eq(
-          '{!lucene}{!dismax v=user query} {!join from=id to=file_resource_ids_ssim}{!dismax v=user query}'
+          '{!lucene}{!dismax v=user+query} {!join from=id to=file_resource_ids_ssim}{!dismax v=user+query}'
         )
       end
     end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe SearchBuilder do
 
       it 'searches related files' do
         expect(parameters['q']).to eq(
-          '{!lucene}{!dismax v=user query} {!join from=id to=file_resource_ids_ssim}{!dismax v=user query}'
+          '{!lucene}{!dismax v=user+query} {!join from=id to=file_resource_ids_ssim}{!dismax v=user+query}'
         )
       end
     end
@@ -75,7 +75,7 @@ RSpec.describe SearchBuilder do
 
       it 'searches related files' do
         expect(parameters['q']).to eq(
-          '{!lucene}{!dismax v=user query} {!join from=id to=file_resource_ids_ssim}{!dismax v=user query}'
+          '{!lucene}{!dismax v=user+query} {!join from=id to=file_resource_ids_ssim}{!dismax v=user+query}'
         )
       end
     end


### PR DESCRIPTION
Uses `CGI.escape` to escape special characters in the user query portion of the solr query. resolves #1151 