### PR TITLE
Fix bug where "Publish" button was incorrectly being hidden if errors on the form

### DIFF
--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -57,6 +57,22 @@ module Dashboard
           resource.aasm_state = initial_state
         end
 
+        # This controller can be used in two ways, either by a user to publish
+        # a new WorkVersion (most common scenario), or by an admin to edit an
+        # already published version. When we render the form (and re-render the
+        # form with errors) we need to know which action the user is
+        # attempting, so we can render the proper buttons.
+        helper_method :form_should_publish?
+        def form_should_publish?
+          not_published = !@resource.published?
+          marked_as_published_but_not_persisted = (
+            @resource.aasm.from_state != :published &&
+              @resource.aasm.to_state == :published
+          )
+
+          not_published || marked_as_published_but_not_persisted
+        end
+
         def work_version_params
           params
             .require(:work_version)

--- a/app/views/dashboard/form/publish/edit.html.erb
+++ b/app/views/dashboard/form/publish/edit.html.erb
@@ -46,7 +46,7 @@
 
             <%= render 'dashboard/form/shared/action_footer',
                        form: form,
-                       primary_action: form.object.published? ? :finish : :publish %>
+                       primary_action: form_should_publish? ? :publish : :finish %>
 
           <% end %>
 


### PR DESCRIPTION
This closes #1195 which describes this bug in detail. See the writeup there.