### PR TITLE
Prevent "Penn State Only" WorkVersions from being published with an open access license

### DIFF
--- a/app/controllers/dashboard/form/base_controller.rb
+++ b/app/controllers/dashboard/form/base_controller.rb
@@ -16,9 +16,9 @@ module Dashboard
           end
         end
 
-        def process_response(on_error:)
+        def process_response(on_error:, validation_context: nil)
           respond_to do |format|
-            if save_resource
+            if save_resource(validation_context: validation_context)
               format.html do
                 redirect_upon_success
               end
@@ -78,10 +78,10 @@ module Dashboard
           resource_klass.model_name.param_key
         end
 
-        def save_resource
+        def save_resource(validation_context: nil)
           @resource.indexing_source = nil # uses the default source
           @resource.update_doi = (publish? || finish? || save_and_exit?)
-          @resource.save
+          @resource.save(context: validation_context)
         end
     end
   end

--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -30,7 +30,8 @@ module Dashboard
           @resource.publish
         end
 
-        process_response(on_error: :edit)
+        validation_context = current_user.admin? ? nil : :user_publish
+        process_response(on_error: :edit, validation_context: validation_context)
       end
 
       private

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -70,6 +70,12 @@ class WorkVersion < ApplicationRecord
         all.map { |license| license[:id] }
       end
 
+      def ids_for_authorized_visibility
+        %w(
+          https://rightsstatements.org/page/InC/1.0/
+        )
+      end
+
       def active
         all.map.select do |license|
           license[:active] == true
@@ -130,6 +136,19 @@ class WorkVersion < ApplicationRecord
             inclusion: {
               in: WorkVersion::Licenses.ids,
               allow_nil: true # Avoid duplicating the above presence validation
+            },
+            if: :published?
+
+  # You'll notice this validation is almost identical to the one above. It
+  # introduces a tighter set of valid licenses if the work is set to
+  # Authorized visibility, and if the optional validation context is used
+  validates :rights,
+            inclusion: {
+              allow_nil: true,
+              in: WorkVersion::Licenses.ids_for_authorized_visibility,
+              message: :incompatible_license_for_authorized_visibility,
+              if: -> { visibility == Permissions::Visibility::AUTHORIZED },
+              on: :user_publish
             },
             if: :published?
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,7 @@ en:
               blank: is required to publish the work
             rights:
               blank: is required to publish the work
+              incompatible_license_for_authorized_visibility: The access and license settings conflict with each other. Please set access to "Public" (preferred), or set the license to "In Copyright (Rights Reserved)."
   activemodel:
     attributes:
       depositor_form:

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -137,7 +137,44 @@ RSpec.describe WorkVersion, type: :model do
         expect(work_version).not_to allow_value('not an EDTF formatted date').for(:published_date)
       end
 
-      context 'when publishing an idential work version' do
+      context 'when visibility is set to AUTHORIZED' do
+        before do
+          work_version.work.access_controls.destroy_all
+          work_version.work.grant_authorized_access
+        end
+
+        context 'when the validation context is `:user_publish`' do
+          let(:valid_licenses) { described_class::Licenses.ids_for_authorized_visibility }
+          let(:invalid_licenses) { described_class::Licenses.ids - valid_licenses }
+
+          it 'requires #rights to be in WorkVersion::Licenses::ids_for_authorized_visibility' do
+            expect(work_version).to(
+              validate_inclusion_of(:rights)
+              .in_array(valid_licenses)
+              .on(:user_publish)
+              .with_message(:incompatible_license_for_authorized_visibility)
+            )
+
+            invalid_licenses.each do |invalid_license|
+              expect(work_version).not_to(
+                allow_value(invalid_license)
+                .for(:rights)
+                .on(:user_publish)
+              )
+            end
+          end
+        end
+
+        context 'when the validation context is something other than `:user_publish`' do
+          let(:valid_licenses) { described_class::Licenses.ids }
+
+          it 'allows #rights to be any value in WorkVersion::Licenses::ids' do
+            expect(work_version).to validate_inclusion_of(:rights).in_array(valid_licenses)
+          end
+        end
+      end
+
+      context 'when publishing an identical work version' do
         subject(:work_version) { BuildNewWorkVersion.call(work.versions[0]) }
 
         let(:work) { create(:work, has_draft: false) }
@@ -148,7 +185,7 @@ RSpec.describe WorkVersion, type: :model do
         end
       end
 
-      context 'when publishing an idential third work version' do
+      context 'when publishing an identical third work version' do
         subject(:work_version) { BuildNewWorkVersion.call(work.versions[1]) }
 
         let(:work) { create(:work, has_draft: false, versions_count: 2) }
@@ -501,6 +538,12 @@ RSpec.describe WorkVersion, type: :model do
       subject { described_class::DEFAULT }
 
       it { is_expected.to eq('https://rightsstatements.org/page/InC/1.0/') }
+    end
+
+    describe '::ids_for_authorized_visibility' do
+      subject { described_class.ids_for_authorized_visibility }
+
+      it { is_expected.to contain_exactly('https://rightsstatements.org/page/InC/1.0/') }
     end
 
     describe '::all' do


### PR DESCRIPTION
This is conceptually pretty simple: on the Publish tab, if you choose open access then you can pick any license from the dropdown; if you choose Penn-State only access then you can only choose a subset of those licenses.

If that's all there was to it, this would be trivial. Unfortunately, because we have legacy data in the system that may be in violation of this new rule, and because Admins still need the ability to edit those legacy works, we need to make this validation conditional upon the current logged in user.

We don't have an existing pattern for doing this in scholarsphere, this is actually the first instance of a validation that's different between a plebeian and an admin. The idea that I had was to use Rails validation contexts ([Rails docs](https://guides.rubyonrails.org/active_record_validations.html#on) and [a blog](https://boringrails.com/tips/activerecord-validation-context)). 

On the one hand they work. And they work pretty well in this case. My beef with them is that they can only be additive, in other words you can only use them to add more validations and you cannot use them to remove existing validations. I would have rather had admins been the special case, but because the validations need to be _less restrictive_ for admins, they must instead be the default case, and regular users must be the special case. I don't care for that, but I also can't figure out a better way.

Closes #1184 