### PR TITLE
disable thumbnails from default queue

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,4 +6,3 @@
   - mailers
   - shrine
   - statistics
-  - thumbnails


### PR DESCRIPTION
This is a minor one, but I got thinking (dangerous, i know) we might not want to include thumbnails as part of the default backgrounding. our default concurrency is 5, and for thumbnails we might want it a bit lower, we also might want to park these jobs on another node / etc, and this will allow us to do just that. Thoughts? 