### PR TITLE
Updates to merge/delete collection services

### DIFF
--- a/app/services/delete_collection.rb
+++ b/app/services/delete_collection.rb
@@ -20,16 +20,13 @@ class DeleteCollection
     ActiveRecord::Base.transaction do
       works = collection.works.map(&:itself)
 
-      collection.works = []
-      collection.save!
+      collection.destroy!
 
       works.each do |work|
-        work.versions.each do |version|
-          DestroyWorkVersion.call(version, force: true)
+        while work.versions.any?
+          DestroyWorkVersion.call(work.versions.last, force: true)
         end
       end
-
-      collection.destroy!
     end
 
     @successful = true

--- a/app/services/delete_collection.rb
+++ b/app/services/delete_collection.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class DeleteCollection
+  attr_reader :uuid
+
+  def self.call(uuid)
+    instance = new(uuid)
+    instance.delete
+    instance
+  end
+
+  def initialize(uuid)
+    @uuid = uuid
+    @successful = false # updated by #delete
+  end
+
+  def delete
+    return false if collection.nil?
+
+    ActiveRecord::Base.transaction do
+      works = collection.works.map(&:itself)
+
+      collection.works = []
+      collection.save!
+
+      works.each do |work|
+        work.versions.each do |version|
+          DestroyWorkVersion.call(version, force: true)
+        end
+      end
+
+      collection.destroy!
+    end
+
+    @successful = true
+    true
+  end
+
+  def successful?
+    @successful
+  end
+
+  private
+
+    def collection
+      @collection ||= Collection.find_by(uuid: uuid)
+    end
+end

--- a/app/services/merge_collection.rb
+++ b/app/services/merge_collection.rb
@@ -2,20 +2,20 @@
 
 class MergeCollection
   class << self
-    def call(uuid, delete_collection: true)
-      instance = new(uuid, delete_collection)
+    def call(uuid, force: false)
+      instance = new(uuid, force)
       instance.save
       instance
     end
   end
 
   attr_reader :uuid,
-              :delete_collection,
+              :force,
               :errors
 
-  def initialize(uuid, delete_collection)
+  def initialize(uuid, force)
     @uuid = uuid
-    @delete_collection = delete_collection
+    @force = force
     @errors = []
     @successful = false # updated by #save
   end
@@ -37,24 +37,14 @@ class MergeCollection
 
         new_work.update_index
       end
-
-      if delete_collection?
-        collection.destroy!
-
-        collection.works.each do |work|
-          work.versions.each do |version|
-            DestroyWorkVersion.call(version, force: true)
-          end
-        end
-      end
     end
 
     @successful = true
     true
   end
 
-  def delete_collection?
-    @delete_collection
+  def force?
+    @force
   end
 
   def valid?
@@ -71,7 +61,8 @@ class MergeCollection
       validate_work_metadata(w)
       validate_access_controls(w)
       validate_work_version_metadata(w)
-      validate_creators(w)
+      validate_creators(w) unless force?
+      validate_keywords(w) unless force?
     end
   end
 
@@ -112,12 +103,25 @@ class MergeCollection
     end
 
     def validate_creators(work)
-      if canonical_work_version.creators.map(&:actor_id) != work.representative_version.creators.map(&:actor_id)
-        w_creators = work.representative_version.creators.inspect
-        canonical_creators = canonical_work_version.creators.inspect
-        diff = "#{canonical_creators}\n#{w_creators}"
+      collection_actor_ids = Set.new(collection.creators.map(&:actor_id))
+      work_actor_ids = Set.new(work.representative_version.creators.map(&:actor_id))
 
-        errors << "Work-#{canonical_work.id} has different creators than Work-#{work.id}\n#{diff}"
+      if collection_actor_ids != work_actor_ids
+        w_creators = work.representative_version.creators.inspect
+        collection_creators = collection.creators.inspect
+        diff = "#{collection_creators}\n#{w_creators}"
+
+        errors << "Collection-#{collection.id} has different creators than Work-#{work.id}\n#{diff}"
+      end
+    end
+
+    def validate_keywords(work)
+      collection_keywords = Set.new(collection.metadata['keyword'])
+      work_keywords = Set.new(work.representative_version.metadata['keyword'])
+
+      if collection_keywords != work_keywords
+        diff = "#{collection_keywords.to_a}\n#{work_keywords.to_a}"
+        errors << "Collection-#{collection.id} has different keywords than Work-#{work.id}\n#{diff}"
       end
     end
 
@@ -153,7 +157,9 @@ class MergeCollection
         work.representative_version
       )
 
-      attributes_we_dont_care_about = %i[title]
+      attributes_we_dont_care_about = %i[title keyword]
+      attributes_we_dont_care_about << :description if force?
+
       work_version_metadata_diff = work_version_metadata_diff.reject do |k, _v|
         attributes_we_dont_care_about.include?(k.to_sym)
       end
@@ -177,10 +183,17 @@ class MergeCollection
         .map(&:file_resources)
         .flatten
 
+      new_file_names = {}
+
+      collection.works.map(&:representative_version).each do |v|
+        file_resource_id = v.file_version_memberships.first.file_resource_id
+        new_file_names[file_resource_id] = v.title
+      end
+
       work = Work.build_with_empty_version(
         work_type: canonical_work.work_type,
         embargoed_until: canonical_work.embargoed_until,
-        doi: canonical_work.doi,
+        doi: collection.doi,
         depositor: canonical_work.depositor,
         proxy_depositor: canonical_work.proxy_depositor,
         deposited_at: deposited_at,
@@ -195,7 +208,13 @@ class MergeCollection
       version.file_resources = all_file_resources
       version.view_statistics = aggregate_view_statistics
       version.title = collection.title
-      version.publish
+      version.description = collection.description
+      version.metadata['keyword'] = collection.metadata['keyword']
+
+      # overwrite file names with the names of the work the file was originally associated with
+      version.file_version_memberships.each do |fvm|
+        fvm.title = new_file_names[fvm.file_resource_id]
+      end
 
       work
     end

--- a/app/services/merge_collection.rb
+++ b/app/services/merge_collection.rb
@@ -193,7 +193,6 @@ class MergeCollection
       work = Work.build_with_empty_version(
         work_type: canonical_work.work_type,
         embargoed_until: canonical_work.embargoed_until,
-        doi: collection.doi,
         depositor: canonical_work.depositor,
         proxy_depositor: canonical_work.proxy_depositor,
         deposited_at: deposited_at,
@@ -223,7 +222,6 @@ class MergeCollection
       {
         work_type: work.work_type,
         embargoed_until: work.embargoed_until,
-        doi: work.doi,
         depositor_id: work.depositor&.id,
         proxy_depositor_id: work.proxy_depositor&.id,
         notify_editors: work.notify_editors,

--- a/lib/tasks/resource.rake
+++ b/lib/tasks/resource.rake
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 namespace :resource do
-  desc 'Merge a collection into a single work + delete the original collection and its works'
-  task :merge_and_delete_collection, [:uuid] => :environment do |_task, args|
+  desc 'Merge a collection into a single work in draft state'
+  task :merge_collection, [:uuid] => :environment do |_task, args|
     uuid = args[:uuid]
 
     result = MergeCollection.call(uuid)
@@ -16,14 +16,29 @@ namespace :resource do
     end
   end
 
-  desc 'Merge a collection into a single work without deleting the original collection'
-  task :merge_collection, [:uuid] => :environment do |_task, args|
+  desc 'Force merge a collection into a single work in draft state'
+  task :force_merge_collection, [:uuid] => :environment do |_task, args|
     uuid = args[:uuid]
 
-    result = MergeCollection.call(uuid, delete_collection: false)
+    result = MergeCollection.call(uuid, force: true)
 
     if result.successful?
       puts 'Collection merged successfully!'
+    else
+      result.errors.each do |err|
+        puts err
+      end
+    end
+  end
+
+  desc 'Deletes a collection and all its works'
+  task :delete_collection, [:uuid] => :environment do |_task, args|
+    uuid = args[:uuid]
+
+    result = DeleteCollection.call(uuid)
+
+    if result.successful?
+      puts 'Collection deleted successfully'
     else
       result.errors.each do |err|
         puts err

--- a/lib/tasks/resource.rake
+++ b/lib/tasks/resource.rake
@@ -38,11 +38,9 @@ namespace :resource do
     result = DeleteCollection.call(uuid)
 
     if result.successful?
-      puts 'Collection deleted successfully'
+      puts 'Collection deleted successfully.'
     else
-      result.errors.each do |err|
-        puts err
-      end
+      puts 'Failed to delete collection.'
     end
   end
 end

--- a/spec/services/delete_collection_spec.rb
+++ b/spec/services/delete_collection_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DeleteCollection do
+  subject(:delete_result) { described_class.call(collection.uuid) }
+
+  let(:collection) { create(:collection, works: [work1, work2]) }
+
+  let(:work1) { create(:work, has_draft: false, versions_count: 1) }
+  let(:work2) { create(:work, has_draft: false, versions_count: 2) }
+
+  context 'when the collection cannot be found' do
+    it 'returns false' do
+      result = described_class.call('123')
+
+      expect(result.successful?).to be false
+    end
+  end
+
+  context 'when the collection is found' do
+    context 'when the collection is able to be deleted' do
+      it 'deletes the collection and all of its works and their versions' do
+        expect(delete_result).to be_successful
+
+        expect { delete_result }.to change(WorkVersion, :count).by 3
+
+        expect { collection.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { work1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { work2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'when the database transaction fails' do
+      before do
+        allow(DestroyWorkVersion).to receive(:call).and_raise(StandardError)
+      end
+
+      it 'rolls back all changes' do
+        expect {
+          begin
+            delete_result
+          rescue StandardError
+            # noop
+          end
+        }.not_to change(WorkVersion, :count)
+
+        expect(collection.reload).to be_present
+      end
+    end
+  end
+end

--- a/spec/services/delete_collection_spec.rb
+++ b/spec/services/delete_collection_spec.rb
@@ -7,8 +7,8 @@ describe DeleteCollection do
 
   let(:collection) { create(:collection, works: [work1, work2]) }
 
-  let(:work1) { create(:work, has_draft: false, versions_count: 1) }
-  let(:work2) { create(:work, has_draft: false, versions_count: 2) }
+  let!(:work1) { create(:work, has_draft: false, versions_count: 1) }
+  let!(:work2) { create(:work, has_draft: false, versions_count: 2) }
 
   context 'when the collection cannot be found' do
     it 'returns false' do
@@ -21,13 +21,13 @@ describe DeleteCollection do
   context 'when the collection is found' do
     context 'when the collection is able to be deleted' do
       it 'deletes the collection and all of its works and their versions' do
-        expect(delete_result).to be_successful
-
-        expect { delete_result }.to change(WorkVersion, :count).by 3
+        expect { delete_result }.to change(WorkVersion, :count).by -3
 
         expect { collection.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect { work1.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect { work2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+
+        expect(delete_result).to be_successful
       end
     end
 
@@ -45,6 +45,8 @@ describe DeleteCollection do
           end
         }.not_to change(WorkVersion, :count)
 
+        expect(work1.reload).to be_present
+        expect(work2.reload).to be_present
         expect(collection.reload).to be_present
       end
     end

--- a/spec/services/merge_collection_spec.rb
+++ b/spec/services/merge_collection_spec.rb
@@ -23,9 +23,9 @@ describe MergeCollection do
     work1.versions.first.update(title: 'work1.png')
     work2.versions.first.update(title: 'work2.png')
 
-    work1.versions.first.creators = collection.creators.map(&:dup)
-    work2.versions.first.creators = collection.creators.map(&:dup)
-    work1.save!
+    collection.creators = work1.versions.first.creators.map(&:dup)
+    work2.versions.first.creators = work1.versions.first.creators.map(&:dup)
+    collection.save!
     work2.save!
   end
 
@@ -216,8 +216,8 @@ describe MergeCollection do
 
       # check file names
       new_file_names = [
-        work1.versions.first.title,
-        work2.versions.first.title
+        'work1.png',
+        'work2.png'
       ]
       expect(version.file_version_memberships.map(&:title)).to match_array(new_file_names)
 

--- a/spec/services/merge_collection_spec.rb
+++ b/spec/services/merge_collection_spec.rb
@@ -3,9 +3,10 @@
 require 'rails_helper'
 
 describe MergeCollection do
-  subject(:merge_result) { described_class.call(collection.uuid) }
+  subject(:merge_result) { described_class.call(collection.uuid, force: force_merge) }
 
-  let(:collection) { create(:collection, works: [work1, work2]) }
+  let(:force_merge) { false }
+  let(:collection) { create(:collection, :with_a_doi, works: [work1, work2]) }
   let(:user) { create(:user) }
   let(:actor) { user.actor }
 
@@ -15,10 +16,16 @@ describe MergeCollection do
 
   # Update both works to have identical metadata on their versions, so we can induce various error states easily
   before do
+    collection.update(keyword: common_metadata[:keyword])
     work1.versions.first.update(common_metadata)
     work2.versions.first.update(common_metadata)
 
-    work2.versions.first.creators = work1.versions.first.creators.map(&:dup)
+    work1.versions.first.update(title: 'work1.png')
+    work2.versions.first.update(title: 'work2.png')
+
+    work1.versions.first.creators = collection.creators.map(&:dup)
+    work2.versions.first.creators = collection.creators.map(&:dup)
+    work1.save!
     work2.save!
   end
 
@@ -74,10 +81,21 @@ describe MergeCollection do
         work1.versions.first.update(description: 'new description')
       end
 
-      it 'returns an error message' do
-        error_msg = /Work-#{work1.id} has different WorkVersion metadata than Work-#{work2.id}/i
-        expect(merge_result.errors).to include(a_string_matching(error_msg))
-        expect(merge_result.errors).to include(a_string_matching(/new description/i))
+      context 'when the force param is false' do
+        it 'returns an error message' do
+          error_msg = /Work-#{work1.id} has different WorkVersion metadata than Work-#{work2.id}/i
+          expect(merge_result.errors).to include(a_string_matching(error_msg))
+          expect(merge_result.errors).to include(a_string_matching(/new description/i))
+        end
+      end
+
+      context 'when the force param is true' do
+        let(:force_merge) { true }
+
+        it 'does not return an error message' do
+          expect(merge_result).to be_successful
+          expect(merge_result.errors.length).to eq 0
+        end
       end
     end
 
@@ -108,16 +126,49 @@ describe MergeCollection do
         work2.save!
       end
 
+      context 'when the force param is false' do
+        it 'returns an error message' do
+          error_msg = /Collection-#{collection.id} has different creators than Work-#{work2.id}/i
+          expect(merge_result.errors).to include(a_string_matching(error_msg))
+        end
+      end
+
+      context 'when the force param is true' do
+        let(:force_merge) { true }
+
+        it 'does not return an error message' do
+          expect(merge_result).to be_successful
+          expect(merge_result.errors.length).to eq 0
+        end
+      end
+    end
+  end
+
+  context 'when the works in the collection have mismatched keywords' do
+    before do
+      work2.versions.first.update(keyword: 'new keyword')
+    end
+
+    context 'when the force param is false' do
       it 'returns an error message' do
-        error_msg = /Work-#{work1.id} has different creators than Work-#{work2.id}/i
+        error_msg = /Collection-#{collection.id} has different keywords than Work-#{work2.id}/i
         expect(merge_result.errors).to include(a_string_matching(error_msg))
+      end
+    end
+
+    context 'when the force param is true' do
+      let(:force_merge) { true }
+
+      it 'does not return an error message' do
+        expect(merge_result).to be_successful
+        expect(merge_result.errors.length).to eq 0
       end
     end
   end
 
   context 'when the database transaction fails' do
     before do
-      allow(DestroyWorkVersion).to receive(:call).and_raise(StandardError)
+      allow(WorkIndexer).to receive(:call).and_raise(StandardError)
     end
 
     it 'rolls back all changes' do
@@ -149,10 +200,11 @@ describe MergeCollection do
       version = new_work.versions.first
 
       # spot check attributes
-      expect(version).to be_published
+      expect(new_work.doi).to eq collection.doi
+      expect(version).not_to be_published
       expect(version.title).to eq collection.title
+      expect(version.description).to eq collection[:description]
       expect(version.rights).to eq common_metadata[:rights]
-      expect(version.description).to eq common_metadata[:description]
       expect(version.published_date).to eq common_metadata[:published_date]
 
       # check files
@@ -161,6 +213,13 @@ describe MergeCollection do
         work2.versions.first.file_resources
       ].flatten
       expect(version.file_resources).to match_array(original_files)
+
+      # check file names
+      new_file_names = [
+        work1.versions.first.title,
+        work2.versions.first.title
+      ]
+      expect(version.file_version_memberships.map(&:title)).to match_array(new_file_names)
 
       # check creators
       expect(version.creators.map(&:display_name)).to match_array(work1.versions.first.creators.map(&:display_name))
@@ -172,24 +231,6 @@ describe MergeCollection do
                          [Date.parse('2022-02-06'), 1],
                          [Date.parse('2022-02-07'), 2]
                        ])
-    end
-
-    context 'when the delete_collection param is true' do
-      it 'deletes the original collection and its works' do
-        merge_result
-        expect { collection.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        expect { work1.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        expect { work2.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      end
-    end
-
-    context 'when the delete_collection param is false' do
-      it 'does not delete the original collection or its works' do
-        described_class.call(collection.uuid, delete_collection: false)
-        expect(collection.reload).to be_present
-        expect(work1.reload).to be_present
-        expect(work2.reload).to be_present
-      end
     end
   end
 end

--- a/spec/services/merge_collection_spec.rb
+++ b/spec/services/merge_collection_spec.rb
@@ -200,7 +200,7 @@ describe MergeCollection do
       version = new_work.versions.first
 
       # spot check attributes
-      expect(new_work.doi).to eq collection.doi
+      expect(new_work.doi).to be_nil
       expect(version).not_to be_published
       expect(version.title).to eq collection.title
       expect(version.description).to eq collection[:description]


### PR DESCRIPTION
Re: #1185.

- `delete_collection` now lives in its own separate service/task
- `force_merge_collection` now allows the user to ignore mismatches in:
  - keywords
  - creators
  - descriptions
- merged work's files will be named after the work the file was originally associated with
- merged WorkVersion's keywords + description come from the collection