### PR TITLE
Add rel="nofollow" to file download links

### DIFF
--- a/app/views/shared/_work_version_files.html.erb
+++ b/app/views/shared/_work_version_files.html.erb
@@ -7,7 +7,9 @@
       <li class="file-card__item">
         <div class="file-card__content">
           <h3>
-            <%= link_to resource_download_path(file.id, resource_id: work_version.uuid), title: t('resources.download', name: file.title) do %>
+            <%= link_to resource_download_path(file.id, resource_id: work_version.uuid),
+                        title: t('resources.download', name: file.title),
+                        rel: 'nofollow' do %>
               <%= file.title %>
             <% end %>
           </h3>


### PR DESCRIPTION
Closes #1230.

This will discourage search engines, etc. from accessing these links
when crawling ScholarSphere.