### PR TITLE
WIP reports

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,8 @@ Metrics/BlockLength:
     - 'config/environments/development.rb'
     - 'spec/**/*'
     - 'lib/tasks/**/*'
+    - 'app/reports/**/*'
+    - 'spec/reports/**/*'
 
 Metrics/CyclomaticComplexity:
   Exclude:

--- a/app/controllers/dashboard/reports_controller.rb
+++ b/app/controllers/dashboard/reports_controller.rb
@@ -3,8 +3,7 @@
 require 'csv'
 
 class Dashboard::ReportsController < Dashboard::BaseController
-  def show
-  end
+  def show; end
 
   def all_files
     return deny_request unless current_user.admin?
@@ -25,6 +24,7 @@ class Dashboard::ReportsController < Dashboard::BaseController
   end
 
   private
+
     def deny_request
       render json: { message: I18n.t('errors.not_authorized.heading'), code: 401 }, status: 401
     end
@@ -32,14 +32,14 @@ class Dashboard::ReportsController < Dashboard::BaseController
     def generate_csv(report)
       result = CSV.generate(headers: true) do |csv|
         csv << report.headers
-  
+
         report.rows do |row|
           csv << row
         end
       end
 
       date = Time.now.strftime('%Y-%m-%d')
-  
+
       send_data result, filename: "#{report.name}_#{date}.csv"
     end
 end

--- a/app/controllers/dashboard/reports_controller.rb
+++ b/app/controllers/dashboard/reports_controller.rb
@@ -3,27 +3,23 @@
 require 'csv'
 
 class Dashboard::ReportsController < Dashboard::BaseController
-  def all_files
-    return deny_request unless current_user.admin?
+  before_action :authorize_report, except: [:index, :monthly_user_work_versions]
 
+  def index; end
+
+  def all_files
     generate_csv(AllFilesReport.new)
   end
 
   def all_works
-    return deny_request unless current_user.admin?
-
     generate_csv(AllWorksReport.new)
   end
 
   def all_work_versions
-    return deny_request unless current_user.admin?
-
     generate_csv(AllWorkVersionsReport.new)
   end
 
   def monthly_work_versions
-    return deny_request unless current_user.admin?
-
     date = Date.new(
       params[:report_date][:year].to_i,
       params[:report_date][:month].to_i,
@@ -45,6 +41,10 @@ class Dashboard::ReportsController < Dashboard::BaseController
   end
 
   private
+
+    def authorize_report
+      deny_request unless current_user.admin?
+    end
 
     def deny_request
       render json: { message: I18n.t('errors.not_authorized.heading'), code: 401 }, status: 401

--- a/app/controllers/dashboard/reports_controller.rb
+++ b/app/controllers/dashboard/reports_controller.rb
@@ -7,16 +7,26 @@ class Dashboard::ReportsController < Dashboard::BaseController
   end
 
   def all_works
-    report = AllWorksReport.new
-
-    result = ::CSV.generate(headers: true) do |csv|
-      csv << report.headers
-
-      report.rows do |row|
-        csv << row
-      end
-    end
-
-    send_data result, filename: 'report.csv'
+    generate_csv(AllWorksReport.new)
   end
+
+  def all_work_versions
+    generate_csv(AllWorkVersionsReport.new)
+  end
+
+  private
+
+    def generate_csv(report)
+      result = CSV.generate(headers: true) do |csv|
+        csv << report.headers
+  
+        report.rows do |row|
+          csv << row
+        end
+      end
+
+      date = Time.now.strftime('%Y-%m-%d')
+  
+      send_data result, filename: "#{report.name}_#{date}.csv"
+    end
 end

--- a/app/controllers/dashboard/reports_controller.rb
+++ b/app/controllers/dashboard/reports_controller.rb
@@ -23,6 +23,27 @@ class Dashboard::ReportsController < Dashboard::BaseController
     generate_csv(AllWorkVersionsReport.new)
   end
 
+  def monthly_work_versions
+    date = Date.new(
+      params[:report_date][:year].to_i,
+      params[:report_date][:month].to_i,
+      params[:report_date][:day].to_i
+    )
+
+    generate_csv(MonthlyWorksReport.new(date: date))
+  end
+
+  def monthly_user_work_versions
+    depositor = Actor.find_by!(psu_id: params['psu_id'])
+    date = Date.new(
+      params[:report_date][:year].to_i,
+      params[:report_date][:month].to_i,
+      params[:report_date][:day].to_i
+    )
+
+    generate_csv(MonthlyUserWorksReport.new(actor: depositor, date: date))
+  end
+
   private
 
     def deny_request

--- a/app/controllers/dashboard/reports_controller.rb
+++ b/app/controllers/dashboard/reports_controller.rb
@@ -7,72 +7,12 @@ class Dashboard::ReportsController < Dashboard::BaseController
   end
 
   def all_works
-    headers = [
-      'id',
-      'depositor',
-      'work_type',
-      'title',
-      'doi',
-      'deposited_at',
-      'deposit_agreed_at',
-      'embargoed_until',
-      'visibility',
-      'latest_published_version',
-      'downloads',
-      'views'
-    ]
-
-    works = Work
-      .includes(:versions, :depositor, :access_controls)
-
-    # TODO I think there is a cleaner way to do this, but this works
-    all_views_by_work_id = ViewStatistic
-      .where(resource_type: 'WorkVersion')
-      .joins('INNER JOIN work_versions ON view_statistics.resource_id = work_versions.id')
-      .group('work_versions.work_id')
-      .sum(:count)
-
-    all_downloads_by_work_id = ViewStatistic
-      .where(resource_type: 'FileResource')
-      .joins('INNER JOIN file_version_memberships ON view_statistics.resource_id = file_version_memberships.work_version_id')
-      .joins('INNER JOIN work_versions ON file_version_memberships.work_version_id = work_versions.id')
-      .group('work_versions.work_id')
-      .sum(:count)
+    report = AllWorksReport.new
 
     result = ::CSV.generate(headers: true) do |csv|
-      csv << headers
+      csv << report.headers
 
-      works.find_each do |work|
-        # Work#latest_published_version will hit the database, which we don't want here
-        latest_published_version = work
-              .versions
-              .filter(&:published?)
-              .sort_by(&:version_number)
-              .last
-
-        latest_version = work
-              .versions
-              .sort_by(&:version_number)
-              .last
-
-        views = all_views_by_work_id[work.id] || 0
-        downloads = all_downloads_by_work_id[work.id] || 0
-
-        row = [
-          work.uuid,
-          work.depositor.psu_id,
-          work.work_type,
-          latest_version.title,
-          work.doi,
-          work.deposited_at,
-          work.deposit_agreed_at,
-          work.embargoed_until,
-          work.visibility,
-          latest_published_version&.uuid,
-          downloads,
-          views
-        ]
-
+      report.rows do |row|
         csv << row
       end
     end

--- a/app/controllers/dashboard/reports_controller.rb
+++ b/app/controllers/dashboard/reports_controller.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+class Dashboard::ReportsController < Dashboard::BaseController
+  def show
+  end
+
+  def all_works
+    headers = [
+      'id',
+      'depositor',
+      'work_type',
+      'title',
+      'doi',
+      'deposited_at',
+      'deposit_agreed_at',
+      'embargoed_until',
+      'visibility',
+      'latest_published_version',
+      'downloads',
+      'views'
+    ]
+
+    works = Work
+      .includes(:versions, :depositor, :access_controls)
+
+    # TODO I think there is a cleaner way to do this, but this works
+    all_views_by_work_id = ViewStatistic
+      .where(resource_type: 'WorkVersion')
+      .joins('INNER JOIN work_versions ON view_statistics.resource_id = work_versions.id')
+      .group('work_versions.work_id')
+      .sum(:count)
+
+    all_downloads_by_work_id = ViewStatistic
+      .where(resource_type: 'FileResource')
+      .joins('INNER JOIN file_version_memberships ON view_statistics.resource_id = file_version_memberships.work_version_id')
+      .joins('INNER JOIN work_versions ON file_version_memberships.work_version_id = work_versions.id')
+      .group('work_versions.work_id')
+      .sum(:count)
+
+    result = ::CSV.generate(headers: true) do |csv|
+      csv << headers
+
+      works.find_each do |work|
+        # Work#latest_published_version will hit the database, which we don't want here
+        latest_published_version = work
+              .versions
+              .filter(&:published?)
+              .sort_by(&:version_number)
+              .last
+
+        latest_version = work
+              .versions
+              .sort_by(&:version_number)
+              .last
+
+        views = all_views_by_work_id[work.id] || 0
+        downloads = all_downloads_by_work_id[work.id] || 0
+
+        row = [
+          work.uuid,
+          work.depositor.psu_id,
+          work.work_type,
+          latest_version.title,
+          work.doi,
+          work.deposited_at,
+          work.deposit_agreed_at,
+          work.embargoed_until,
+          work.visibility,
+          latest_published_version&.uuid,
+          downloads,
+          views
+        ]
+
+        csv << row
+      end
+    end
+
+    send_data result, filename: 'report.csv'
+  end
+end

--- a/app/controllers/dashboard/reports_controller.rb
+++ b/app/controllers/dashboard/reports_controller.rb
@@ -6,15 +6,28 @@ class Dashboard::ReportsController < Dashboard::BaseController
   def show
   end
 
+  def all_files
+    return deny_request unless current_user.admin?
+
+    generate_csv(AllFilesReport.new)
+  end
+
   def all_works
+    return deny_request unless current_user.admin?
+
     generate_csv(AllWorksReport.new)
   end
 
   def all_work_versions
+    return deny_request unless current_user.admin?
+
     generate_csv(AllWorkVersionsReport.new)
   end
 
   private
+    def deny_request
+      render json: { message: I18n.t('errors.not_authorized.heading'), code: 401 }, status: 401
+    end
 
     def generate_csv(report)
       result = CSV.generate(headers: true) do |csv|

--- a/app/controllers/dashboard/reports_controller.rb
+++ b/app/controllers/dashboard/reports_controller.rb
@@ -3,8 +3,6 @@
 require 'csv'
 
 class Dashboard::ReportsController < Dashboard::BaseController
-  def show; end
-
   def all_files
     return deny_request unless current_user.admin?
 
@@ -24,6 +22,8 @@ class Dashboard::ReportsController < Dashboard::BaseController
   end
 
   def monthly_work_versions
+    return deny_request unless current_user.admin?
+
     date = Date.new(
       params[:report_date][:year].to_i,
       params[:report_date][:month].to_i,
@@ -34,7 +34,7 @@ class Dashboard::ReportsController < Dashboard::BaseController
   end
 
   def monthly_user_work_versions
-    depositor = Actor.find_by!(psu_id: params['psu_id'])
+    depositor = Actor.find_by!(psu_id: current_user.actor.psu_id)
     date = Date.new(
       params[:report_date][:year].to_i,
       params[:report_date][:month].to_i,

--- a/app/reports/all_files_report.rb
+++ b/app/reports/all_files_report.rb
@@ -40,6 +40,7 @@ class AllFilesReport
   end
 
   private
+
     def file_version_memberships
       FileVersionMembership
         .includes(:file_resource)
@@ -48,7 +49,7 @@ class AllFilesReport
 
     def load_downloads_by_file_resource(fvm_batch)
       resource_ids = Set[]
-      
+
       fvm_batch.each do |fvm|
         resource_ids << fvm.file_resource_id
       end
@@ -66,7 +67,7 @@ class AllFilesReport
       results = ActiveRecord::Base.connection.execute(query)
 
       downloads_by_file_resource = {}
-      
+
       results.each do |result|
         downloads_by_file_resource[result['resource_id']] = result['sum']
       end

--- a/app/reports/all_files_report.rb
+++ b/app/reports/all_files_report.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+class AllFilesReport
+  def name
+    'all_files'
+  end
+
+  def headers
+    %w[
+      id
+      version_id
+      filename
+      mime_type
+      size
+      downloads
+    ]
+  end
+
+  def rows
+    file_version_memberships.in_batches do |fvm_batch|
+      # Load out aggregates of downloads for this batch
+      downloads_by_file_resource_id = load_downloads_by_file_resource(fvm_batch)
+
+      # Iterate through each file_version_membership in this batch, yielding the CSV row
+      fvm_batch.each do |fvm|
+        downloads = downloads_by_file_resource_id[fvm.file_resource.id] || 0
+
+        row = [
+          fvm.file_resource.uuid,
+          fvm.work_version.uuid,
+          fvm.file_resource.file_data['metadata']['filename'],
+          fvm.file_resource.file_data['metadata']['mime_type'],
+          fvm.file_resource.file_data['metadata']['size'],
+          downloads
+        ]
+
+        yield(row)
+      end
+    end
+  end
+
+  private
+    def file_version_memberships
+      FileVersionMembership
+        .includes(:file_resource)
+        .includes(:work_version)
+    end
+
+    def load_downloads_by_file_resource(fvm_batch)
+      resource_ids = Set[]
+      
+      fvm_batch.each do |fvm|
+        resource_ids << fvm.file_resource_id
+      end
+
+      resource_ids = resource_ids.to_a.join(', ')
+
+      query = %{
+        SELECT resource_id, sum(count)
+        FROM view_statistics
+        WHERE resource_type = 'FileResource'
+        AND resource_id in (#{resource_ids})
+        GROUP BY resource_id
+      }
+
+      results = ActiveRecord::Base.connection.execute(query)
+
+      downloads_by_file_resource = {}
+      
+      results.each do |result|
+        downloads_by_file_resource[result['resource_id']] = result['sum']
+      end
+
+      downloads_by_file_resource
+    end
+end

--- a/app/reports/all_files_report.rb
+++ b/app/reports/all_files_report.rb
@@ -12,30 +12,34 @@ class AllFilesReport
       filename
       mime_type
       size
+      md5
+      sha256
       downloads
     ]
   end
 
   def rows
-    file_version_memberships.in_batches do |fvm_batch|
-      # Load out aggregates of downloads for this batch
-      downloads_by_file_resource_id = load_downloads_by_file_resource(fvm_batch)
+    downloads_by_file_resource_id = load_downloads
 
-      # Iterate through each file_version_membership in this batch, yielding the CSV row
-      fvm_batch.each do |fvm|
-        downloads = downloads_by_file_resource_id[fvm.file_resource.id] || 0
+    file_version_memberships.find_each do |fvm|
+      file_resource = fvm.file_resource
+      work_version = fvm.work_version
 
-        row = [
-          fvm.file_resource.uuid,
-          fvm.work_version.uuid,
-          fvm.file_resource.file_data['metadata']['filename'],
-          fvm.file_resource.file_data['metadata']['mime_type'],
-          fvm.file_resource.file_data['metadata']['size'],
-          downloads
-        ]
+      title = fvm.title.presence || file_resource.file.metadata['filename']
+      downloads = downloads_by_file_resource_id[file_resource.id] || 0
 
-        yield(row)
-      end
+      row = [
+        file_resource.uuid,
+        work_version.uuid,
+        title,
+        file_resource.file.metadata['mime_type'],
+        file_resource.file.metadata['size'],
+        file_resource.file.metadata['md5'],
+        file_resource.file.metadata['sha256'],
+        downloads
+      ]
+
+      yield row
     end
   end
 
@@ -43,35 +47,13 @@ class AllFilesReport
 
     def file_version_memberships
       FileVersionMembership
-        .includes(:file_resource)
-        .includes(:work_version)
+        .includes(:file_resource, :work_version)
     end
 
-    def load_downloads_by_file_resource(fvm_batch)
-      resource_ids = Set[]
-
-      fvm_batch.each do |fvm|
-        resource_ids << fvm.file_resource_id
-      end
-
-      resource_ids = resource_ids.to_a.join(', ')
-
-      query = %{
-        SELECT resource_id, sum(count)
-        FROM view_statistics
-        WHERE resource_type = 'FileResource'
-        AND resource_id in (#{resource_ids})
-        GROUP BY resource_id
-      }
-
-      results = ActiveRecord::Base.connection.execute(query)
-
-      downloads_by_file_resource = {}
-
-      results.each do |result|
-        downloads_by_file_resource[result['resource_id']] = result['sum']
-      end
-
-      downloads_by_file_resource
+    def load_downloads
+      ViewStatistic
+        .where(resource_type: 'FileResource')
+        .group(:resource_id)
+        .sum(:count)
     end
 end

--- a/app/reports/all_work_versions_report.rb
+++ b/app/reports/all_work_versions_report.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+class AllWorkVersionsReport
+  def name
+    'all_work_versions'
+  end
+
+  def headers
+    %w[
+      id
+      work_id
+      state
+      version_number
+      title
+      subtitle
+      version_name
+      keyword
+      rights
+      description
+      publisher_statement
+      resource_type
+      contributor
+      publisher
+      published_date
+      subject
+      language
+      identifier
+      based_near
+      related_url
+      source
+      downloads
+      views
+    ]
+  end
+
+  def rows
+    work_versions.in_batches do |work_version_batch|
+      # Load out aggregates of views and downloads for this batch
+      views_by_work_version_id = load_views_by_work_version(work_version_batch)
+      downloads_by_work_version_id = load_downloads_by_work_version(work_version_batch)
+
+      # Iterate through each work version in this batch, yielding the CSV row
+      work_version_batch.each do |wv|
+        # Work#latest_published_version will hit the database, which we don't want here
+        #latest_published_version = work
+        #  .versions
+        #  .filter(&:published?)
+        #  .max_by(&:version_number)
+
+        views = views_by_work_version_id[wv.id] || 0
+        downloads = downloads_by_work_version_id[wv.id] || 0
+
+        row = [
+          wv.uuid,
+          wv.work.uuid,
+          wv.aasm_state,
+          wv.version_number,
+          wv.title,
+          wv.subtitle,
+          wv.version_name,
+          wv.keyword,
+          wv.rights,
+          wv.description,
+          wv.publisher_statement,
+          wv.resource_type,
+          wv.contributor,
+          wv.publisher,
+          wv.published_date,
+          wv.subject,
+          wv.language,
+          wv.identifier,
+          wv.based_near,
+          wv.related_url,
+          wv.source,
+          downloads,
+          views
+        ]
+
+        yield(row)
+      end
+    end
+  end
+
+  private
+
+    def work_versions
+      WorkVersion.all
+    end
+
+    def works
+      Work
+        .includes(
+          :versions,
+          :depositor,
+          :access_controls
+        )
+    end
+
+    # Returns a hash of { work_version_id => num_views }
+    def load_views_by_work_version(work_version_batch)
+      ViewStatistic
+        .joins('INNER JOIN work_versions ON view_statistics.resource_id = work_versions.id')
+        .where(
+          resource_type: 'WorkVersion',
+          work_versions: { id: work_version_batch }
+        )
+        .group('work_versions.id')
+        .sum(:count)
+    end
+
+    # Returns a hash of { work_version_id => num_downloads }
+    def load_downloads_by_work_version(work_version_batch)
+      ViewStatistic
+        .joins('INNER JOIN file_version_memberships ON view_statistics.resource_id = file_version_memberships.file_resource_id')
+        .joins('INNER JOIN work_versions ON file_version_memberships.work_version_id = work_versions.id')
+        .where(
+          resource_type: 'FileResource',
+          work_versions: { id: work_version_batch }
+        )
+        .group('work_versions.id')
+        .sum(:count)
+    end
+end

--- a/app/reports/all_work_versions_report.rb
+++ b/app/reports/all_work_versions_report.rb
@@ -39,12 +39,6 @@ class AllWorkVersionsReport
 
       # Iterate through each work version in this batch, yielding the CSV row
       work_version_batch.each do |wv|
-        # Work#latest_published_version will hit the database, which we don't want here
-        # latest_published_version = work
-        #  .versions
-        #  .filter(&:published?)
-        #  .max_by(&:version_number)
-
         views = views_by_work_version_id[wv.id] || 0
 
         row = [

--- a/app/reports/all_work_versions_report.rb
+++ b/app/reports/all_work_versions_report.rb
@@ -33,12 +33,13 @@ class AllWorkVersionsReport
   end
 
   def rows
-    work_versions.in_batches do |work_version_batch|
+    work_versions.find_in_batches do |work_versions|
       # Load out aggregates of views for this batch
-      views_by_work_version_id = load_views_by_work_version(work_version_batch)
+      work_version_batch_ids = work_versions.map(&:id)
+      views_by_work_version_id = load_views_by_work_version(work_version_batch_ids)
 
       # Iterate through each work version in this batch, yielding the CSV row
-      work_version_batch.each do |wv|
+      work_versions.each do |wv|
         views = views_by_work_version_id[wv.id] || 0
 
         row = [

--- a/app/reports/all_work_versions_report.rb
+++ b/app/reports/all_work_versions_report.rb
@@ -42,7 +42,7 @@ class AllWorkVersionsReport
       # Iterate through each work version in this batch, yielding the CSV row
       work_version_batch.each do |wv|
         # Work#latest_published_version will hit the database, which we don't want here
-        #latest_published_version = work
+        # latest_published_version = work
         #  .versions
         #  .filter(&:published?)
         #  .max_by(&:version_number)

--- a/app/reports/all_works_report.rb
+++ b/app/reports/all_works_report.rb
@@ -36,6 +36,7 @@ class AllWorksReport
 
       latest_version = work
         .versions
+        .reject(&:withdrawn?)
         .max_by(&:version_number)
 
       views = views_by_work_id[work.id] || 0

--- a/app/reports/all_works_report.rb
+++ b/app/reports/all_works_report.rb
@@ -72,6 +72,7 @@ class AllWorksReport
           :depositor,
           :access_controls
         )
+        .order(id: :asc)
     end
 
     # Returns a hash of { work_id => num_views }
@@ -89,7 +90,7 @@ class AllWorksReport
     # Returns a hash of { work_id => num_downloads }
     def load_downloads_by_work(work_batch)
       ViewStatistic
-        .joins('INNER JOIN file_version_memberships ON view_statistics.resource_id = file_version_memberships.work_version_id')
+        .joins('INNER JOIN file_version_memberships ON view_statistics.resource_id = file_version_memberships.file_resource_id')
         .joins('INNER JOIN work_versions ON file_version_memberships.work_version_id = work_versions.id')
         .where(
           resource_type: 'FileResource',
@@ -97,5 +98,7 @@ class AllWorksReport
         )
         .group('work_versions.work_id')
         .sum(:count)
+
+##ViewStatistic.joins('INNER JOIN file_version_memberships ON view_statistics.resource_id = file_version_memberships.file_resource_id').joins('INNER JOIN work_versions ON file_version_memberships.work_version_id = work_versions.id').where(  resource_type: 'FileResource').group('work_versions.work_id').sum(:count)
     end
 end

--- a/app/reports/all_works_report.rb
+++ b/app/reports/all_works_report.rb
@@ -23,43 +23,40 @@ class AllWorksReport
   end
 
   def rows
-    works.in_batches do |works_batch|
-      # Load out aggregates of views and downloads for this batch
-      views_by_work_id = load_views_by_work(works_batch)
-      downloads_by_work_id = load_downloads_by_work(works_batch)
+    # Load out aggregates of views and downloads
+    views_by_work_id = load_views_by_work
+    downloads_by_work_id = load_downloads_by_work
 
-      # Iterate through each work in this batch, yielding the CSV row
-      works_batch.each do |work|
-        # Work#latest_published_version will hit the database, which we don't want here
-        latest_published_version = work
-          .versions
-          .filter(&:published?)
-          .max_by(&:version_number)
+    works.find_each do |work|
+      # Work#latest_published_version will hit the database, which we don't want here
+      latest_published_version = work
+        .versions
+        .filter(&:published?)
+        .max_by(&:version_number)
 
-        latest_version = work
-          .versions
-          .max_by(&:version_number)
+      latest_version = work
+        .versions
+        .max_by(&:version_number)
 
-        views = views_by_work_id[work.id] || 0
-        downloads = downloads_by_work_id[work.id] || 0
+      views = views_by_work_id[work.id] || 0
+      downloads = downloads_by_work_id[work.id] || 0
 
-        row = [
-          work.uuid,
-          work.depositor.psu_id,
-          work.work_type,
-          latest_version.title,
-          work.doi,
-          work.deposited_at,
-          work.deposit_agreed_at,
-          work.embargoed_until,
-          work.visibility,
-          latest_published_version&.uuid,
-          downloads,
-          views
-        ]
+      row = [
+        work.uuid,
+        work.depositor.psu_id,
+        work.work_type,
+        latest_version.title,
+        work.doi,
+        work.deposited_at,
+        work.deposit_agreed_at,
+        work.embargoed_until,
+        work.visibility,
+        latest_published_version&.uuid,
+        downloads,
+        views
+      ]
 
-        yield(row)
-      end
+      yield(row)
     end
   end
 
@@ -76,29 +73,36 @@ class AllWorksReport
     end
 
     # Returns a hash of { work_id => num_views }
-    def load_views_by_work(work_batch)
+    def load_views_by_work
       ViewStatistic
         .joins('INNER JOIN work_versions ON view_statistics.resource_id = work_versions.id')
         .where(
-          resource_type: 'WorkVersion',
-          work_versions: { work_id: work_batch }
+          resource_type: 'WorkVersion'
         )
         .group('work_versions.work_id')
         .sum(:count)
     end
 
     # Returns a hash of { work_id => num_downloads }
-    def load_downloads_by_work(work_batch)
-      ViewStatistic
-        .joins('INNER JOIN file_version_memberships ON view_statistics.resource_id = file_version_memberships.file_resource_id')
-        .joins('INNER JOIN work_versions ON file_version_memberships.work_version_id = work_versions.id')
-        .where(
-          resource_type: 'FileResource',
-          work_versions: { work_id: work_batch }
-        )
-        .group('work_versions.work_id')
-        .sum(:count)
+    def load_downloads_by_work
+      query = ActiveRecord::Base.sanitize_sql([<<-SQL.squish, resource_type: 'FileResource'])
+        SELECT unique_works.work_id AS work_id,
+               SUM(view_statistics.count) AS sum_count
+        FROM view_statistics
+        INNER JOIN (
+          SELECT
+            DISTINCT work_versions.work_id,
+            file_version_memberships.file_resource_id
+          FROM work_versions
+          INNER JOIN
+            file_version_memberships ON file_version_memberships.work_version_id = work_versions.id
+          ) unique_works ON unique_works.file_resource_id = view_statistics.resource_id
+        WHERE 
+          view_statistics.resource_type = :resource_type
+        GROUP BY work_id
+      SQL
 
-##ViewStatistic.joins('INNER JOIN file_version_memberships ON view_statistics.resource_id = file_version_memberships.file_resource_id').joins('INNER JOIN work_versions ON file_version_memberships.work_version_id = work_versions.id').where(  resource_type: 'FileResource').group('work_versions.work_id').sum(:count)
+      results = ActiveRecord::Base.connection.exec_query(query)
+      results.map { |row| [row['work_id'], row['sum_count']] }.to_h
     end
 end

--- a/app/reports/all_works_report.rb
+++ b/app/reports/all_works_report.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+class AllWorksReport
+  def headers
+    %w[
+      id
+      depositor
+      work_type
+      title
+      doi
+      deposited_at
+      deposit_agreed_at
+      embargoed_until
+      visibility
+      latest_published_version
+      downloads
+      views
+    ]
+  end
+
+  def rows
+    works.in_batches do |works_batch|
+      # Load out aggregates of views and downloads for this batch
+      views_by_work_id = load_views_by_work(works_batch)
+      downloads_by_work_id = load_downloads_by_work(works_batch)
+
+      # Iterate through each work in this batch, yielding the CSV row
+      works_batch.each do |work|
+        # Work#latest_published_version will hit the database, which we don't want here
+        latest_published_version = work
+          .versions
+          .filter(&:published?)
+          .max_by(&:version_number)
+
+        latest_version = work
+          .versions
+          .max_by(&:version_number)
+
+        views = views_by_work_id[work.id] || 0
+        downloads = downloads_by_work_id[work.id] || 0
+
+        row = [
+          work.uuid,
+          work.depositor.psu_id,
+          work.work_type,
+          latest_version.title,
+          work.doi,
+          work.deposited_at,
+          work.deposit_agreed_at,
+          work.embargoed_until,
+          work.visibility,
+          latest_published_version&.uuid,
+          downloads,
+          views
+        ]
+
+        yield(row)
+      end
+    end
+  end
+
+  private
+
+    def works
+      Work
+        .includes(
+          :versions,
+          :depositor,
+          :access_controls
+        )
+    end
+
+    # Returns a hash of { work_id => num_views }
+    def load_views_by_work(work_batch)
+      ViewStatistic
+        .joins('INNER JOIN work_versions ON view_statistics.resource_id = work_versions.id')
+        .where(
+          resource_type: 'WorkVersion',
+          work_versions: { work_id: work_batch }
+        )
+        .group('work_versions.work_id')
+        .sum(:count)
+    end
+
+    # Returns a hash of { work_id => num_downloads }
+    def load_downloads_by_work(work_batch)
+      ViewStatistic
+        .joins('INNER JOIN file_version_memberships ON view_statistics.resource_id = file_version_memberships.work_version_id')
+        .joins('INNER JOIN work_versions ON file_version_memberships.work_version_id = work_versions.id')
+        .where(
+          resource_type: 'FileResource',
+          work_versions: { work_id: work_batch }
+        )
+        .group('work_versions.work_id')
+        .sum(:count)
+    end
+end

--- a/app/reports/all_works_report.rb
+++ b/app/reports/all_works_report.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class AllWorksReport
+  def name
+    'all_works'
+  end
+
   def headers
     %w[
       id

--- a/app/reports/monthly_user_works_report.rb
+++ b/app/reports/monthly_user_works_report.rb
@@ -36,6 +36,7 @@ class MonthlyUserWorksReport < MonthlyWorksReport
     def generate_row(work:, views:, downloads:)
       latest_version = work
         .versions
+        .reject(&:withdrawn?)
         .max_by(&:version_number)
 
       title = latest_version.title

--- a/app/reports/monthly_user_works_report.rb
+++ b/app/reports/monthly_user_works_report.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class MonthlyUserWorksReport < MonthlyWorksReport
+  attr_reader :depositor
+
+  def initialize(actor:, date: Time.zone.today)
+    raise ArgumentError, 'you must give me an Actor' unless actor.is_a? Actor
+
+    super(date: date)
+    @depositor = actor
+  end
+
+  def name
+    "monthly_works_#{depositor.psu_id}_#{year}-#{month_number(leading_zero: true)}"
+  end
+
+  def headers
+    %w[
+      work_id
+      title
+      month
+      year
+      downloads
+      views
+    ]
+  end
+
+  private
+
+    def works
+      super
+        .includes(:versions)
+        .where(depositor_id: depositor)
+    end
+
+    def generate_row(work:, views:, downloads:)
+      latest_version = work
+        .versions
+        .max_by(&:version_number)
+
+      title = latest_version.title
+
+      [
+        work.uuid,
+        title,
+        month_number,
+        year,
+        downloads,
+        views
+      ]
+    end
+end

--- a/app/reports/monthly_works_report.rb
+++ b/app/reports/monthly_works_report.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+class MonthlyWorksReport
+  attr_reader :start_date,
+              :end_date
+
+  def initialize(date: Time.zone.today)
+    @start_date = date.beginning_of_month
+    @end_date = date.end_of_month
+  end
+
+  def name
+    "monthly_works_#{year}-#{month_number(leading_zero: true)}"
+  end
+
+  def headers
+    %w[
+      work_id
+      month
+      year
+      downloads
+      views
+    ]
+  end
+
+  def rows
+    works.find_in_batches do |works|
+      work_batch_ids = works.map(&:id)
+      views_by_work_id = load_views_by_work(work_batch_ids)
+      downloads_by_work_id = load_downloads_by_work(work_batch_ids)
+
+      works.each do |work|
+        views = views_by_work_id[work.id] || 0
+        downloads = downloads_by_work_id[work.id] || 0
+
+        yield(generate_row(work: work, views: views, downloads: downloads))
+      end
+    end
+  end
+
+  private
+
+    def month_number(leading_zero: false)
+      start_date.strftime(leading_zero ? '%m' : '%-m')
+    end
+
+    def year
+      start_date.strftime('%Y')
+    end
+
+    def works
+      Work
+        .includes(:access_controls)
+    end
+
+    def generate_row(work:, views:, downloads:)
+      [
+        work.uuid,
+        month_number,
+        year,
+        downloads,
+        views
+      ]
+    end
+
+    # Returns a hash of { work_id => num_views }
+    # @note this is almost duplicate of the one in AllWorksReport with
+    # additional conditionals for start and end dates. Possible refactor
+    def load_views_by_work(work_batch_ids)
+      ViewStatistic
+        .joins('INNER JOIN work_versions ON view_statistics.resource_id = work_versions.id')
+        .where(
+          resource_type: 'WorkVersion',
+          date: (start_date..end_date),
+          work_versions: { work_id: work_batch_ids }
+        )
+        .group('work_versions.work_id')
+        .sum(:count)
+    end
+
+    # Returns a hash of { work_id => num_downloads }
+    # @note this is almost duplicate of the one in AllWorksReport with
+    # additional conditionals for start and end dates. Possible refactor
+    def load_downloads_by_work(work_batch_ids)
+      raw_query = <<-SQL.squish
+        SELECT unique_works.work_id AS work_id,
+               SUM(view_statistics.count) AS sum_count
+        FROM view_statistics
+        INNER JOIN (
+          SELECT
+            DISTINCT work_versions.work_id,
+            file_version_memberships.file_resource_id
+          FROM work_versions
+          INNER JOIN
+            file_version_memberships ON file_version_memberships.work_version_id = work_versions.id
+          ) unique_works ON unique_works.file_resource_id = view_statistics.resource_id
+        WHERE 
+          view_statistics.resource_type = :resource_type
+        AND
+          work_id IN(:work_ids)
+        AND
+          view_statistics.date BETWEEN :start_date AND :end_date
+        GROUP BY work_id
+      SQL
+
+      query = ActiveRecord::Base.sanitize_sql([raw_query,
+                                               resource_type: 'FileResource',
+                                               work_ids: work_batch_ids,
+                                               start_date: start_date, end_date: end_date])
+      results = ActiveRecord::Base.connection.exec_query(query)
+      results.map { |row| [row['work_id'], row['sum_count']] }.to_h
+    end
+end

--- a/app/views/dashboard/reports/index.html.erb
+++ b/app/views/dashboard/reports/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :navbar_heading do %>
+  <h1 class="navbar-brand navbar-brand--center slab-font"><%= t('navbar.heading.reports') %></h1>
+<% end %>
+
+<div class="container">
+  <div class="row row--md-mb-3">
+    <div class="col-md">
+      <%= link_to 'All Works Report', dashboard_reports_all_works_path %>
+    </div>
+  </div>
+</div>

--- a/app/views/dashboard/reports/index.html.erb
+++ b/app/views/dashboard/reports/index.html.erb
@@ -5,7 +5,10 @@
 <div class="container">
   <div class="row row--md-mb-3">
     <div class="col-md">
-      <%= link_to 'All Works Report', dashboard_reports_all_works_path %>
+      <ul>
+        <li><%= link_to 'All Works Report', dashboard_reports_all_works_path %></li>
+        <li><%= link_to 'All Work Versions Report', dashboard_reports_all_work_versions_path %></li>
+      </ul>
     </div>
   </div>
 </div>

--- a/app/views/dashboard/reports/index.html.erb
+++ b/app/views/dashboard/reports/index.html.erb
@@ -16,14 +16,14 @@
               <%= submit_tag 'Monthly Report', class: 'btn btn-primary' %>
             <% end %>
           </li>
-          <li>
-            <%= form_tag dashboard_reports_monthly_user_work_versions_path, method: :get do |f| %>
-              <%= text_field_tag 'psu_id', '', placeholder: 'Depositor PSU ID' %>
-              <%= select_date(Date.today, prefix: 'report_date', order: [:month, :year], discard_day: true) %>
-              <%= submit_tag "User's Monthly Report", class: 'btn btn-primary' %>
-            <% end %>
-          </li>
         <% end %>
+
+        <li>
+          <%= form_tag dashboard_reports_monthly_user_work_versions_path, method: :get do |f| %>
+            <%= select_date(Date.today, prefix: 'report_date', order: [:month, :year], discard_day: true) %>
+            <%= submit_tag "User's Monthly Report", class: 'btn btn-primary' %>
+          <% end %>
+        </li>
       </ul>
     </div>
   </div>

--- a/app/views/dashboard/reports/index.html.erb
+++ b/app/views/dashboard/reports/index.html.erb
@@ -10,6 +10,19 @@
           <li><%= link_to 'All Files Report', dashboard_reports_all_files_path %></li>
           <li><%= link_to 'All Works Report', dashboard_reports_all_works_path %></li>
           <li><%= link_to 'All Work Versions Report', dashboard_reports_all_work_versions_path %></li>
+          <li>
+            <%= form_tag dashboard_reports_monthly_work_versions_path, method: :get do |f| %>
+              <%= select_date(Date.today, prefix: 'report_date', order: [:month, :year], discard_day: true) %>
+              <%= submit_tag 'Monthly Report', class: 'btn btn-primary' %>
+            <% end %>
+          </li>
+          <li>
+            <%= form_tag dashboard_reports_monthly_user_work_versions_path, method: :get do |f| %>
+              <%= text_field_tag 'psu_id', '', placeholder: 'Depositor PSU ID' %>
+              <%= select_date(Date.today, prefix: 'report_date', order: [:month, :year], discard_day: true) %>
+              <%= submit_tag "User's Monthly Report", class: 'btn btn-primary' %>
+            <% end %>
+          </li>
         <% end %>
       </ul>
     </div>

--- a/app/views/dashboard/reports/index.html.erb
+++ b/app/views/dashboard/reports/index.html.erb
@@ -5,26 +5,50 @@
 <div class="container">
   <div class="row row--md-mb-3">
     <div class="col-md">
-      <ul>
-        <% if current_user.admin? %>
-          <li><%= link_to 'All Files Report', dashboard_reports_all_files_path %></li>
-          <li><%= link_to 'All Works Report', dashboard_reports_all_works_path %></li>
-          <li><%= link_to 'All Work Versions Report', dashboard_reports_all_work_versions_path %></li>
-          <li>
-            <%= form_tag dashboard_reports_monthly_work_versions_path, method: :get do |f| %>
-              <%= select_date(Date.today, prefix: 'report_date', order: [:month, :year], discard_day: true) %>
-              <%= submit_tag 'Monthly Report', class: 'btn btn-primary' %>
-            <% end %>
-          </li>
-        <% end %>
+      <% if current_user.admin? %>
+        <h2><%= t('dashboard.reports.admin_reports') %></h2>
+        <hr>
+        <h3><%= link_to t('dashboard.reports.all_files_report'), dashboard_reports_all_files_path %></h3>
+        <h3><%= link_to t('dashboard.reports.all_works_report'), dashboard_reports_all_works_path %></h3>
+        <h3><%= link_to t('dashboard.reports.all_work_versions_report'), dashboard_reports_all_work_versions_path %></h3>
 
-        <li>
-          <%= form_tag dashboard_reports_monthly_user_work_versions_path, method: :get do |f| %>
-            <%= select_date(Date.today, prefix: 'report_date', order: [:month, :year], discard_day: true) %>
-            <%= submit_tag "User's Monthly Report", class: 'btn btn-primary' %>
-          <% end %>
-        </li>
-      </ul>
+        <%= form_tag dashboard_reports_monthly_work_versions_path, method: :get do |f| %>
+          <h3><%= t('dashboard.reports.monthly_report') %></h3>
+          <div class="row">
+            <div class="col-4">
+              <%= select_date(
+                    Date.today,
+                    options = {
+                      prefix: 'report_date',
+                      order: [:month, :year],
+                      discard_day: true
+                    },
+                    html_options = { class: 'form-control form-control-sm mb-2' }
+                  ) %>
+              <%= submit_tag 'Generate Report', class: 'btn btn-primary' %>
+            </div>
+          </div>
+        <% end %>
+        <hr>
+      <% end %>
+
+      <%= form_tag dashboard_reports_monthly_user_work_versions_path, method: :get do |f| %>
+        <h3><%= t('dashboard.reports.monthly_user_report', user: current_user.display_name) %></h3>
+        <div class="row">
+          <div class="col-4">
+            <%= select_date(
+                  Date.today,
+                  options = {
+                    prefix: 'report_date',
+                    order: [:month, :year],
+                    discard_day: true
+                  },
+                  html_options = { class: 'form-control form-control-sm mb-2' }
+                ) %>
+            <%= submit_tag 'Generate Report', class: 'btn btn-primary' %>
+          </div>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/dashboard/reports/index.html.erb
+++ b/app/views/dashboard/reports/index.html.erb
@@ -6,8 +6,11 @@
   <div class="row row--md-mb-3">
     <div class="col-md">
       <ul>
-        <li><%= link_to 'All Works Report', dashboard_reports_all_works_path %></li>
-        <li><%= link_to 'All Work Versions Report', dashboard_reports_all_work_versions_path %></li>
+        <% if current_user.admin? %>
+          <li><%= link_to 'All Files Report', dashboard_reports_all_files_path %></li>
+          <li><%= link_to 'All Works Report', dashboard_reports_all_works_path %></li>
+          <li><%= link_to 'All Work Versions Report', dashboard_reports_all_work_versions_path %></li>
+        <% end %>
       </ul>
     </div>
   </div>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -23,6 +23,7 @@
       <%= link_to_dropdown_item('Create New Collection', dashboard_form_collections_path) %>
       <% if current_user.admin? %>
         <div class="dropdown-divider"></div>
+        <%= link_to_dropdown_item('Reports', dashboard_reports_path) %>
         <%= link_to_dropdown_item('Sidekiq', admin_sidekiq_web_path, target: :_blank) %>
         <%= link_to_dropdown_item('Health Checks', '/health/all.json', target: :_blank) %>
         <%= link_to_dropdown_item('Application Settings', admin_application_settings_path) %>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -21,9 +21,9 @@
       <%= link_to_dropdown_item('Dashboard', dashboard_root_path) %>
       <%= link_to_dropdown_item('Create New Work', dashboard_form_work_versions_path) %>
       <%= link_to_dropdown_item('Create New Collection', dashboard_form_collections_path) %>
+      <%= link_to_dropdown_item('Reports', dashboard_reports_path) %>
       <% if current_user.admin? %>
         <div class="dropdown-divider"></div>
-        <%= link_to_dropdown_item('Reports', dashboard_reports_path) %>
         <%= link_to_dropdown_item('Sidekiq', admin_sidekiq_web_path, target: :_blank) %>
         <%= link_to_dropdown_item('Health Checks', '/health/all.json', target: :_blank) %>
         <%= link_to_dropdown_item('Application Settings', admin_application_settings_path) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -173,6 +173,8 @@ en:
       invalid_edtf: is not a valid date in EDTF format
       invalid_orcid: is not a valid ORCiD id
       invalid_doi: is not a properly formatted DOI from our Datacite service
+    not_authorized:
+      heading: "401: Request not authorized."
     not_found:
       heading: Resource not found or unavailable
       content: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -541,6 +541,7 @@ en:
       not_found: 'Page Not Found'
       server_error: 'Server Error'
       graphql: 'GraphQL'
+      reports: 'Reports'
   resources:
     analytics: Analytics
     collections: Collections

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -279,6 +279,13 @@ en:
         error_message: "%{error} prohibited your profile from being saved:"
       update:
         success: 'Your profile was saved successfully.'
+    reports:
+      admin_reports: 'Admin Reports'
+      all_files_report: 'All Files Report'
+      all_works_report: 'All Works Report'
+      all_work_versions_report: 'All Work Versions Report'
+      monthly_report: 'Monthly Report (All Users)'
+      monthly_user_report: "Monthly Report for %{user}"
     shared:
       editors_form:
         heading: Editors

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,7 @@ Rails.application.routes.draw do
     get 'work_search', to: 'work_search#index'
 
     get 'reports', to: 'reports#index'
+    get 'reports/all_files', to: 'reports#all_files'
     get 'reports/all_works', to: 'reports#all_works'
     get 'reports/all_work_versions', to: 'reports#all_work_versions'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,9 @@ Rails.application.routes.draw do
 
     get 'work_search', to: 'work_search#index'
 
+    get 'reports', to: 'reports#index'
+    get 'reports/all_works', to: 'reports#all_works'
+
     resources :works, only: %i[edit update] do
       resources :work_versions, except: [:new], shallow: true do
         get 'file_list', to: 'file_lists#edit'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ Rails.application.routes.draw do
 
     get 'reports', to: 'reports#index'
     get 'reports/all_works', to: 'reports#all_works'
+    get 'reports/all_work_versions', to: 'reports#all_work_versions'
 
     resources :works, only: %i[edit update] do
       resources :work_versions, except: [:new], shallow: true do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,8 @@ Rails.application.routes.draw do
     get 'reports/all_files', to: 'reports#all_files'
     get 'reports/all_works', to: 'reports#all_works'
     get 'reports/all_work_versions', to: 'reports#all_work_versions'
+    get 'reports/monthly_work_versions', to: 'reports#monthly_work_versions'
+    get 'reports/monthly_user_work_versions', to: 'reports#monthly_user_work_versions'
 
     resources :works, only: %i[edit update] do
       resources :work_versions, except: [:new], shallow: true do

--- a/spec/controllers/dashboard/reports_controller_spec.rb
+++ b/spec/controllers/dashboard/reports_controller_spec.rb
@@ -3,11 +3,192 @@
 require 'rails_helper'
 
 RSpec.describe Dashboard::ReportsController, type: :controller do
-  describe '#user_for_paper_trail' do
+  describe 'GET #index' do
+    let(:perform_request) { get :index }
+
+    context 'when the user is signed in' do
+      before { sign_in create :user }
+
+      it 'returns a success response' do
+        expect(perform_request).to be_successful
+      end
+    end
+
+    context 'when the user is not signed in' do
+      it 'redirects to the root path' do
+        expect(perform_request).to redirect_to root_path
+      end
+    end
+  end
+
+  describe 'report generation' do
+    let(:today) { Date.today }
+    let(:report_date_params) do
+      {
+        year: today.year,
+        month: today.month,
+        day: today.day
+      }
+    end
+    let(:csv) { CSV.parse(response.body) }
     let(:user) { create(:user) }
+    let!(:work1) { create(:work, depositor: user.actor) }
+    let!(:work2) { create(:work, versions_count: 2) }
 
-    before { log_in user }
+    describe 'GET #all_files' do
+      before do
+        sign_in user
+        get :all_files
+      end
 
-    its(:user_for_paper_trail) { is_expected.to eq(user.to_gid) }
+      context 'when the user is not an admin' do
+        subject { response }
+
+        its(:status) { is_expected.to eq 401 }
+        its(:body) { is_expected.to include(I18n.t!('errors.not_authorized.heading')) }
+      end
+
+      context 'when the user is an admin' do
+        subject { response }
+
+        let(:user) { create(:user, :admin) }
+
+        its(:status) { is_expected.to eq 200 }
+      end
+    end
+
+    describe 'GET #all_works' do
+      before do
+        sign_in user
+        get :all_works
+      end
+
+      context 'when the user is not an admin' do
+        subject { response }
+
+        its(:status) { is_expected.to eq 401 }
+        its(:body) { is_expected.to include(I18n.t!('errors.not_authorized.heading')) }
+      end
+
+      context 'when the user is an admin' do
+        let(:user) { create(:user, :admin) }
+
+        it 'returns the correct content type and filename' do
+          filename = "all_works_#{today}.csv"
+          expect(response.headers['Content-Type']).to eq 'text/csv'
+          expect(response.headers['Content-Disposition']).to include filename
+        end
+
+        it 'returns the correct data in the CSV' do
+          expect(response.status).to eq 200
+          expect(csv.count).to eq 3
+          expect(csv[1][0]).to eq work1.uuid
+          expect(csv[2][0]).to eq work2.uuid
+        end
+      end
+    end
+
+    describe 'GET #all_work_versions' do
+      before do
+        sign_in user
+        get :all_work_versions
+      end
+
+      context 'when the user is not an admin' do
+        subject { response }
+
+        its(:status) { is_expected.to eq 401 }
+        its(:body) { is_expected.to include(I18n.t!('errors.not_authorized.heading')) }
+      end
+
+      context 'when the user is an admin' do
+        let(:user) { create(:user, :admin) }
+
+        it 'returns the correct content type and filename' do
+          filename = "all_work_versions_#{today}.csv"
+          expect(response.headers['Content-Type']).to eq 'text/csv'
+          expect(response.headers['Content-Disposition']).to include filename
+        end
+
+        it 'returns the correct data in the CSV' do
+          expect(response.status).to eq 200
+          expect(csv.count).to eq 4
+          expect(csv[1][0]).to eq work1.versions.first.uuid
+          expect(csv[2][0]).to eq work2.versions.first.uuid
+          expect(csv[3][0]).to eq work2.versions.last.uuid
+        end
+      end
+    end
+
+    describe 'GET #monthly_work_versions' do
+      before do
+        sign_in user
+        get :monthly_work_versions, params: {
+          report_date: report_date_params
+        }
+      end
+
+      context 'when the user is not an admin' do
+        subject { response }
+
+        its(:status) { is_expected.to eq 401 }
+        its(:body) { is_expected.to include(I18n.t!('errors.not_authorized.heading')) }
+      end
+
+      context 'when the user is an admin' do
+        let(:user) { create(:user, :admin) }
+
+        it 'returns the correct content type and filename' do
+          report_month = today.strftime('%Y-%m')
+          filename = "monthly_works_#{report_month}_#{today}.csv"
+          expect(response.headers['Content-Type']).to eq 'text/csv'
+          expect(response.headers['Content-Disposition']).to include filename
+        end
+
+        it 'returns the correct data in the CSV' do
+          expect(response.status).to eq 200
+          expect(csv.count).to eq 3
+          expect(csv[1][0]).to eq work1.uuid
+          expect(csv[2][0]).to eq work2.uuid
+        end
+      end
+    end
+
+    describe 'GET #monthly_user_work_versions' do
+      context 'when the user is not signed in' do
+        before do
+          get :monthly_user_work_versions, params: {
+            report_date: report_date_params
+          }
+        end
+
+        it 'returns an error' do
+          expect(response.status).to eq 302
+          expect(response).not_to be_successful
+        end
+      end
+
+      context 'when the user is signed in' do
+        before do
+          sign_in user
+          get :monthly_user_work_versions, params: {
+            report_date: report_date_params
+          }
+        end
+
+        it 'returns the correct content type and filename' do
+          report_month = today.strftime('%Y-%m')
+          filename = "monthly_works_#{user.actor.psu_id}_#{report_month}_#{today}.csv"
+          expect(response.headers['Content-Type']).to eq 'text/csv'
+          expect(response.headers['Content-Disposition']).to include filename
+        end
+
+        it 'returns the correct data in the CSV' do
+          expect(response.status).to eq 200
+          expect(csv.count).to eq 2
+          expect(csv[1][0]).to eq work1.uuid
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/dashboard/reports_controller_spec.rb
+++ b/spec/controllers/dashboard/reports_controller_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Dashboard::ReportsController, type: :controller do
+  describe '#user_for_paper_trail' do
+    let(:user) { create(:user) }
+
+    before { log_in user }
+
+    its(:user_for_paper_trail) { is_expected.to eq(user.to_gid) }
+  end
+end

--- a/spec/features/dashboard/reports_spec.rb
+++ b/spec/features/dashboard/reports_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Reports', type: :feature, with_user: :user do
+  context 'with a standard user' do
+    let(:user) { create(:user) }
+
+    it 'only shows the monthly user report' do
+      visit dashboard_reports_path
+      display_name = "#{user.name} (#{user.access_id})"
+
+      expect(page).not_to have_selector('h2', text: I18n.t('dashboard.reports.admin_reports'))
+      expect(page).not_to have_selector('h3 a', text: I18n.t('dashboard.reports.all_files_report'))
+      expect(page).not_to have_selector('h3 a', text: I18n.t('dashboard.reports.all_works_report'))
+      expect(page).not_to have_selector('h3 a', text: I18n.t('dashboard.reports.all_work_versions_report'))
+      expect(page).not_to have_selector('h3', text: I18n.t('dashboard.reports.monthly_report'))
+      expect(page).to have_selector('h3', text: I18n.t('dashboard.reports.monthly_user_report', user: display_name))
+    end
+  end
+
+  context 'with an admin user' do
+    let(:user) { create(:user, :admin) }
+
+    it 'shows all reports' do
+      visit dashboard_reports_path
+      expect(page).to have_selector('h2', text: I18n.t('dashboard.reports.admin_reports'))
+      expect(page).to have_selector('h3 a', text: I18n.t('dashboard.reports.all_files_report'))
+      expect(page).to have_selector('h3 a', text: I18n.t('dashboard.reports.all_works_report'))
+      expect(page).to have_selector('h3 a', text: I18n.t('dashboard.reports.all_work_versions_report'))
+      expect(page).to have_selector('h3', text: I18n.t('dashboard.reports.monthly_report'))
+      expect(page).to have_selector('h3', text: I18n.t('dashboard.reports.monthly_user_report', user: 'Administrator'))
+    end
+  end
+end

--- a/spec/reports/all_files_report_spec.rb
+++ b/spec/reports/all_files_report_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AllFilesReport do
+  subject(:report) { described_class.new }
+
+  it_behaves_like 'a report' do
+    subject { report }
+  end
+
+  describe '#headers' do
+    specify { expect(report.headers).to eq %w[id version_id filename mime_type size downloads] }
+  end
+
+  describe '#name' do
+    specify { expect(report.name).to eq 'all_files' }
+  end
+
+  describe '#rows' do
+    let!(:work_published) { create :work, has_draft: false, versions_count: 2 }
+    let!(:work_published_and_draft) { create :work, has_draft: true, versions_count: 2 }
+    let!(:work_draft_only) { create :work, has_draft: true, versions_count: 1 }
+
+    before do
+      work_published.versions.each do |work_version|
+        create :view_statistic, resource: work_version, count: 1
+      end
+
+      # Set all versions of the published work to point to the same single file
+      version1_file = work_published.latest_published_version.file_resources.first
+      work_published.versions.each do |work_version|
+        work_version.file_resources = [version1_file]
+        work_version.save! 
+      end
+
+      # Create view statistics for that single file
+      create :view_statistic, resource: version1_file, count: 1
+    end
+
+    it 'yields each row to the given block' do
+      yielded_rows = []
+      report.rows do |row|
+        yielded_rows << row
+      end
+
+      work_published_row, work_published_and_draft_row, work_draft_only_row = yielded_rows
+
+      # work.uuid,
+      # work.depositor.psu_id,
+      # work.work_type,
+      # latest_version.title,
+      # work.doi,
+      # work.deposited_at,
+      # work.deposit_agreed_at,
+      # work.embargoed_until,
+      # work.visibility,
+      # latest_published_version&.uuid,
+      # downloads,
+      # views
+
+      # Test ordering by PK
+      expect(yielded_rows[0][0]).to eq work_published.uuid
+      expect(yielded_rows[1][0]).to eq work_published_and_draft.uuid
+
+      # Test row for without draft
+      expect(work_published_row[1]).to eq work_published.depositor.psu_id
+      expect(work_published_row[2]).to eq work_published.work_type
+      expect(work_published_row[3]).to eq work_published.latest_published_version.title
+      expect(work_published_row[4]).to eq work_published.doi
+      expect(work_published_row[5]).to eq work_published.deposited_at # TODO: spec the date format (iso8601?)?
+      expect(work_published_row[6]).to eq work_published.deposit_agreed_at # TODO spec date format?
+      expect(work_published_row[7]).to eq work_published.embargoed_until
+      expect(work_published_row[8]).to eq work_published.visibility
+      expect(work_published_row[9]).to eq work_published.latest_published_version.uuid
+
+      # Spot check variations on title
+      expect(work_published_row[3]).to eq work_published.latest_published_version.title
+      expect(work_published_and_draft_row[3]).to eq work_published_and_draft.draft_version.title
+      expect(work_draft_only_row[3]).to eq work_draft_only.draft_version.title
+      
+      # Spot check variations on latest_published_version
+      expect(work_published_row[9]).to eq work_published.latest_published_version.uuid
+      expect(work_published_and_draft_row[9]).to eq work_published_and_draft.latest_published_version.uuid
+      expect(work_draft_only_row[9]).to be_blank
+
+      # Spot check downloads
+      expect(work_published_row[10]).to eq 1
+      expect(work_published_and_draft_row[10]).to eq 2
+
+      # Spot check view statistics
+      expect(work_published_row[11]).to eq 2
+    end
+  end
+end

--- a/spec/reports/all_files_report_spec.rb
+++ b/spec/reports/all_files_report_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe AllFilesReport do
       version1_file = work_published.latest_published_version.file_resources.first
       work_published.versions.each do |work_version|
         work_version.file_resources = [version1_file]
-        work_version.save! 
+        work_version.save!
       end
 
       # Create view statistics for that single file
@@ -78,7 +78,7 @@ RSpec.describe AllFilesReport do
       expect(work_published_row[3]).to eq work_published.latest_published_version.title
       expect(work_published_and_draft_row[3]).to eq work_published_and_draft.draft_version.title
       expect(work_draft_only_row[3]).to eq work_draft_only.draft_version.title
-      
+
       # Spot check variations on latest_published_version
       expect(work_published_row[9]).to eq work_published.latest_published_version.uuid
       expect(work_published_and_draft_row[9]).to eq work_published_and_draft.latest_published_version.uuid

--- a/spec/reports/all_work_versions_report_spec.rb
+++ b/spec/reports/all_work_versions_report_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AllWorkVersionsReport do
+  subject(:report) { described_class.new }
+
+  it_behaves_like 'a report' do
+    subject { report }
+  end
+
+  describe '#headers' do
+    specify { expect(report.headers).to eq %w[id depositor work_type title doi deposited_at deposit_agreed_at embargoed_until visibility latest_published_version downloads views] }
+  end
+
+  describe '#name' do
+    specify { expect(report.name).to eq 'all_work_versions' }
+  end
+
+  describe '#rows' do
+    let!(:work_published) { create :work, has_draft: false, versions_count: 2 }
+    let!(:work_published_and_draft) { create :work, has_draft: true, versions_count: 2 }
+    let!(:work_draft_only) { create :work, has_draft: true, versions_count: 1 }
+
+    before do
+      work_published.versions.each do |work_version|
+        create :view_statistic, resource: work_version, count: 1
+      end
+
+      # Set all versions of the published work to point to the same single file
+      version1_file = work_published.latest_published_version.file_resources.first
+      work_published.versions.each do |work_version|
+        work_version.file_resources = [version1_file]
+        work_version.save! 
+      end
+
+      # Create view statistics for that single file
+      create :view_statistic, resource: version1_file, count: 1
+    end
+
+    it 'yields each row to the given block' do
+      yielded_rows = []
+      report.rows do |row|
+        yielded_rows << row
+      end
+
+      work_published_row, work_published_and_draft_row, work_draft_only_row = yielded_rows
+
+      # work.uuid,
+      # work.depositor.psu_id,
+      # work.work_type,
+      # latest_version.title,
+      # work.doi,
+      # work.deposited_at,
+      # work.deposit_agreed_at,
+      # work.embargoed_until,
+      # work.visibility,
+      # latest_published_version&.uuid,
+      # downloads,
+      # views
+
+      # Test ordering by PK
+      expect(yielded_rows[0][0]).to eq work_published.uuid
+      expect(yielded_rows[1][0]).to eq work_published_and_draft.uuid
+
+      # Test row for without draft
+      expect(work_published_row[1]).to eq work_published.depositor.psu_id
+      expect(work_published_row[2]).to eq work_published.work_type
+      expect(work_published_row[3]).to eq work_published.latest_published_version.title
+      expect(work_published_row[4]).to eq work_published.doi
+      expect(work_published_row[5]).to eq work_published.deposited_at # TODO: spec the date format (iso8601?)?
+      expect(work_published_row[6]).to eq work_published.deposit_agreed_at # TODO spec date format?
+      expect(work_published_row[7]).to eq work_published.embargoed_until
+      expect(work_published_row[8]).to eq work_published.visibility
+      expect(work_published_row[9]).to eq work_published.latest_published_version.uuid
+
+      # Spot check variations on title
+      expect(work_published_row[3]).to eq work_published.latest_published_version.title
+      expect(work_published_and_draft_row[3]).to eq work_published_and_draft.draft_version.title
+      expect(work_draft_only_row[3]).to eq work_draft_only.draft_version.title
+      
+      # Spot check variations on latest_published_version
+      expect(work_published_row[9]).to eq work_published.latest_published_version.uuid
+      expect(work_published_and_draft_row[9]).to eq work_published_and_draft.latest_published_version.uuid
+      expect(work_draft_only_row[9]).to be_blank
+
+      # Spot check downloads
+      expect(work_published_row[10]).to eq 1
+      expect(work_published_and_draft_row[10]).to eq 2
+
+      # Spot check view statistics
+      expect(work_published_row[11]).to eq 2
+    end
+  end
+end

--- a/spec/reports/all_work_versions_report_spec.rb
+++ b/spec/reports/all_work_versions_report_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe AllWorkVersionsReport do
       version1_file = work_published.latest_published_version.file_resources.first
       work_published.versions.each do |work_version|
         work_version.file_resources = [version1_file]
-        work_version.save! 
+        work_version.save!
       end
 
       # Create view statistics for that single file
@@ -78,7 +78,7 @@ RSpec.describe AllWorkVersionsReport do
       expect(work_published_row[3]).to eq work_published.latest_published_version.title
       expect(work_published_and_draft_row[3]).to eq work_published_and_draft.draft_version.title
       expect(work_draft_only_row[3]).to eq work_draft_only.draft_version.title
-      
+
       # Spot check variations on latest_published_version
       expect(work_published_row[9]).to eq work_published.latest_published_version.uuid
       expect(work_published_and_draft_row[9]).to eq work_published_and_draft.latest_published_version.uuid

--- a/spec/reports/all_works_report_spec.rb
+++ b/spec/reports/all_works_report_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe AllWorksReport do
       expect(work_published_row[2]).to eq work_published.work_type
       expect(work_published_row[3]).to eq work_published.latest_published_version.title
       expect(work_published_row[4]).to eq work_published.doi
-      expect(work_published_row[5]).to eq work_published.deposited_at # TODO: spec the date format (iso8601?)?
+      expect(work_published_row[5]).to be_within(1.second).of(work_published.deposited_at) # TODO: spec the date format (iso8601?)?
       expect(work_published_row[6]).to eq work_published.deposit_agreed_at # TODO spec date format?
       expect(work_published_row[7]).to eq work_published.embargoed_until
       expect(work_published_row[8]).to eq work_published.visibility

--- a/spec/reports/all_works_report_spec.rb
+++ b/spec/reports/all_works_report_spec.rb
@@ -92,8 +92,8 @@ RSpec.describe AllWorksReport do
       expect(work_published_row[2]).to eq work_published.work_type
       expect(work_published_row[3]).to eq work_published.latest_published_version.title
       expect(work_published_row[4]).to eq work_published.doi
-      expect(work_published_row[5]).to be_within(1.second).of(work_published.deposited_at) # TODO: spec the date format (iso8601?)?
-      expect(work_published_row[6]).to eq work_published.deposit_agreed_at # TODO spec date format?
+      expect(work_published_row[5]).to be_within(1.second).of(work_published.deposited_at)
+      expect(work_published_row[6]).to eq work_published.deposit_agreed_at
       expect(work_published_row[7]).to eq work_published.embargoed_until
       expect(work_published_row[8]).to eq work_published.visibility
       expect(work_published_row[9]).to eq work_published.latest_published_version.uuid

--- a/spec/reports/all_works_report_spec.rb
+++ b/spec/reports/all_works_report_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AllWorksReport do
+  subject(:report) { described_class.new }
+
+  it_behaves_like 'a report' do
+    subject { report }
+  end
+
+  describe '#headers' do
+    specify { expect(report.headers).to eq %w[id depositor work_type title doi deposited_at deposit_agreed_at embargoed_until visibility latest_published_version downloads views] }
+  end
+
+  describe '#name' do
+    specify { expect(report.name).to eq 'all_works' }
+  end
+
+  describe '#rows' do
+    let!(:work_published) { create :work, has_draft: false, versions_count: 2 }
+    let!(:work_published_and_draft) { create :work, has_draft: true, versions_count: 2 }
+    let!(:work_draft_only) { create :work, has_draft: true, versions_count: 1 }
+
+    before do
+      work_published.versions.each do |work_version|
+        create :view_statistic, resource: work_version, count: 1
+      end
+
+      # Set all versions of the published work to point to the same single file
+      version1_file = work_published.latest_published_version.file_resources.first
+      work_published.versions.each do |work_version|
+        work_version.file_resources = [version1_file]
+        work_version.save! 
+      end
+
+      # Create view statistics for that single file
+      create :view_statistic, resource: version1_file, count: 1
+    end
+
+    it 'yields each row to the given block' do
+      yielded_rows = []
+      report.rows do |row|
+        yielded_rows << row
+      end
+
+      work_published_row, work_published_and_draft_row, work_draft_only_row = yielded_rows
+
+      # work.uuid,
+      # work.depositor.psu_id,
+      # work.work_type,
+      # latest_version.title,
+      # work.doi,
+      # work.deposited_at,
+      # work.deposit_agreed_at,
+      # work.embargoed_until,
+      # work.visibility,
+      # latest_published_version&.uuid,
+      # downloads,
+      # views
+
+      # Test ordering by PK
+      expect(yielded_rows[0][0]).to eq work_published.uuid
+      expect(yielded_rows[1][0]).to eq work_published_and_draft.uuid
+
+      # Test row for without draft
+      expect(work_published_row[1]).to eq work_published.depositor.psu_id
+      expect(work_published_row[2]).to eq work_published.work_type
+      expect(work_published_row[3]).to eq work_published.latest_published_version.title
+      expect(work_published_row[4]).to eq work_published.doi
+      expect(work_published_row[5]).to eq work_published.deposited_at # TODO: spec the date format (iso8601?)?
+      expect(work_published_row[6]).to eq work_published.deposit_agreed_at # TODO spec date format?
+      expect(work_published_row[7]).to eq work_published.embargoed_until
+      expect(work_published_row[8]).to eq work_published.visibility
+      expect(work_published_row[9]).to eq work_published.latest_published_version.uuid
+
+      # Spot check variations on title
+      expect(work_published_row[3]).to eq work_published.latest_published_version.title
+      expect(work_published_and_draft_row[3]).to eq work_published_and_draft.draft_version.title
+      expect(work_draft_only_row[3]).to eq work_draft_only.draft_version.title
+      
+      # Spot check variations on latest_published_version
+      expect(work_published_row[9]).to eq work_published.latest_published_version.uuid
+      expect(work_published_and_draft_row[9]).to eq work_published_and_draft.latest_published_version.uuid
+      expect(work_draft_only_row[9]).to be_blank
+
+      # Spot check downloads
+      expect(work_published_row[10]).to eq 1
+      expect(work_published_and_draft_row[10]).to eq 2
+
+      # Spot check view statistics
+      expect(work_published_row[11]).to eq 2
+    end
+  end
+end

--- a/spec/reports/monthly_user_works_report_spec.rb
+++ b/spec/reports/monthly_user_works_report_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MonthlyUserWorksReport do
+  subject(:report) { described_class.new(actor: depositor, date: Date.parse('2022-02-16')) }
+
+  let(:depositor) { create :actor }
+
+  it_behaves_like 'a report' do
+    subject { report }
+  end
+
+  describe '#new' do
+    context 'when given an actor that is not actually an Actor' do
+      specify do
+        expect { described_class.new(actor: build(:user), date: Date.today) }
+          .to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe '#headers' do
+    specify { expect(report.headers).to eq %w[
+      work_id
+      title
+      month
+      year
+      downloads
+      views
+    ] }
+  end
+
+  describe '#name' do
+    it 'includes the depositor, year, and month in question' do
+      expect(report.name).to eq "monthly_works_#{depositor.psu_id}_2022-02"
+    end
+  end
+
+  describe '#rows' do
+    let!(:work_published) { create :work, has_draft: false, versions_count: 2, depositor: depositor }
+    let!(:work_published_and_draft) { create :work, has_draft: true, versions_count: 2, depositor: depositor }
+    let!(:other_users_work) { create :work, has_draft: false, versions_count: 1, depositor: build(:actor) }
+
+    before do
+      #
+      # Create some test data for work views
+      #
+
+      # Create some views for every version of a work
+      work_published.versions.each do |work_version|
+        create :view_statistic, resource: work_version, count: 1, date: Date.parse('2022-02-01')
+        create :view_statistic, resource: work_version, count: 1, date: Date.parse('2022-02-16')
+        create :view_statistic, resource: work_version, count: 1, date: Date.parse('2022-02-28')
+
+        # Should not be included in the counts
+        create :view_statistic, resource: work_version, count: 1, date: Date.parse('2022-01-31')
+        create :view_statistic, resource: work_version, count: 1, date: Date.parse('2022-03-01')
+      end
+
+      #
+      # Create some test data for file downloads
+      #
+
+      # Set all versions of the published work to point to the same single file
+      # which more accurately reflects our real production data
+      version1_file = work_published.latest_published_version.file_resources.first
+      work_published.versions.each do |work_version|
+        work_version.file_resources = [version1_file]
+        work_version.save!
+      end
+
+      # Create downloads (stored as view statistics) for that single file created above
+      create :view_statistic, resource: version1_file, count: 1, date: Date.parse('2022-02-01')
+      create :view_statistic, resource: version1_file, count: 1, date: Date.parse('2022-02-16')
+      create :view_statistic, resource: version1_file, count: 1, date: Date.parse('2022-02-28')
+
+      # Should not be included in the counts
+      create :view_statistic, resource: version1_file, count: 1, date: Date.parse('2022-01-31')
+      create :view_statistic, resource: version1_file, count: 1, date: Date.parse('2022-03-01')
+
+      # Make another file on the latest version of the work above
+      another_file = create :file_resource
+      work_published.latest_published_version.file_resources << another_file
+      work_published.save!
+      create :view_statistic, resource: another_file, count: 100, date: Date.parse('2022-02-16')
+
+      # Create a download for another work
+      create :view_statistic,
+             resource: work_published_and_draft.latest_published_version.file_resources.first,
+             count: 5,
+             date: Date.parse('2022-02-16')
+    end
+
+    it 'yields each row to the given block' do
+      yielded_rows = []
+      report.rows do |row|
+        yielded_rows << row
+      end
+
+      # Test that it generates one row for each work
+      # Note that order is not guaranteed with `find_each` or `find_in_batches`
+      expect(yielded_rows.map { |r| r[0] })
+        .to contain_exactly(work_published.uuid, work_published_and_draft.uuid)
+
+      expect(yielded_rows.map { |r| r[0] }).not_to include(other_users_work.uuid)
+
+      work_published_row = yielded_rows.find { |r| r[0] == work_published.uuid }
+      work_published_and_draft_row = yielded_rows.find { |r| r[0] == work_published_and_draft.uuid }
+
+      # Test row for without draft
+      expect(work_published_row[1]).to eq work_published.latest_published_version.title
+      expect(work_published_row[2]).to eq '2'
+      expect(work_published_row[3]).to eq '2022'
+      expect(work_published_row[4]).to eq 103 # downloads
+      expect(work_published_row[5]).to eq 6
+
+      # Spot check downloads
+      expect(work_published_row[4]).to eq 103
+      expect(work_published_and_draft_row[4]).to eq 5
+
+      # Spot check views
+      expect(work_published_and_draft_row[5]).to eq 0
+    end
+  end
+end

--- a/spec/reports/monthly_works_report_spec.rb
+++ b/spec/reports/monthly_works_report_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MonthlyWorksReport do
+  subject(:report) { described_class.new(date: Date.parse('2022-02-16')) }
+
+  it_behaves_like 'a report' do
+    subject { report }
+  end
+
+  describe '#headers' do
+    specify { expect(report.headers).to eq %w[
+      work_id
+      month
+      year
+      downloads
+      views
+    ] }
+  end
+
+  describe '#name' do
+    it 'includes the year and month in question' do
+      expect(report.name).to eq 'monthly_works_2022-02'
+    end
+  end
+
+  describe '#rows' do
+    let!(:work_published) { create :work, has_draft: false, versions_count: 2 }
+    let!(:work_published_and_draft) { create :work, has_draft: true, versions_count: 2 }
+    let!(:work_draft_only) { create :work, has_draft: true, versions_count: 1 }
+
+    before do
+      #
+      # Create some test data for work views
+      #
+
+      # Create some views for every version of a work
+      work_published.versions.each do |work_version|
+        create :view_statistic, resource: work_version, count: 1, date: Date.parse('2022-02-01')
+        create :view_statistic, resource: work_version, count: 1, date: Date.parse('2022-02-16')
+        create :view_statistic, resource: work_version, count: 1, date: Date.parse('2022-02-28')
+
+        # Should not be included in the counts
+        create :view_statistic, resource: work_version, count: 1, date: Date.parse('2022-01-31')
+        create :view_statistic, resource: work_version, count: 1, date: Date.parse('2022-03-01')
+      end
+
+      #
+      # Create some test data for file downloads
+      #
+
+      # Set all versions of the published work to point to the same single file
+      # which more accurately reflects our real production data
+      version1_file = work_published.latest_published_version.file_resources.first
+      work_published.versions.each do |work_version|
+        work_version.file_resources = [version1_file]
+        work_version.save!
+      end
+
+      # Create downloads (stored as view statistics) for that single file created above
+      create :view_statistic, resource: version1_file, count: 1, date: Date.parse('2022-02-01')
+      create :view_statistic, resource: version1_file, count: 1, date: Date.parse('2022-02-16')
+      create :view_statistic, resource: version1_file, count: 1, date: Date.parse('2022-02-28')
+
+      # Should not be included in the counts
+      create :view_statistic, resource: version1_file, count: 1, date: Date.parse('2022-01-31')
+      create :view_statistic, resource: version1_file, count: 1, date: Date.parse('2022-03-01')
+
+      # Make another file on the latest version of the work above
+      another_file = create :file_resource
+      work_published.latest_published_version.file_resources << another_file
+      work_published.save!
+      create :view_statistic, resource: another_file, count: 100, date: Date.parse('2022-02-16')
+
+      # Create a download for another work
+      create :view_statistic,
+             resource: work_published_and_draft.latest_published_version.file_resources.first,
+             count: 5,
+             date: Date.parse('2022-02-16')
+    end
+
+    it 'yields each row to the given block' do
+      yielded_rows = []
+      report.rows do |row|
+        yielded_rows << row
+      end
+
+      # Test that it generates one row for each work
+      # Note that order is not guaranteed with `find_each` or `find_in_batches`
+      expect(yielded_rows.map { |r| r[0] })
+        .to contain_exactly(work_published.uuid, work_published_and_draft.uuid, work_draft_only.uuid)
+
+      work_published_row = yielded_rows.find { |r| r[0] == work_published.uuid }
+      work_published_and_draft_row = yielded_rows.find { |r| r[0] == work_published_and_draft.uuid }
+
+      # Test row for without draft
+      expect(work_published_row[1]).to eq '2'
+      expect(work_published_row[2]).to eq '2022'
+      expect(work_published_row[3]).to eq 103 # downloads
+      expect(work_published_row[4]).to eq 6
+
+      # Spot check downloads
+      expect(work_published_row[3]).to eq 103
+      expect(work_published_and_draft_row[3]).to eq 5
+
+      # Spot check views
+      expect(work_published_and_draft_row[4]).to eq 0
+    end
+  end
+end

--- a/spec/support/shared/a_report.rb
+++ b/spec/support/shared/a_report.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'a report' do 
-  it { is_expected.to respond_to :headers}
-  it { is_expected.to respond_to :name}
-  it { is_expected.to respond_to :rows}
+RSpec.shared_examples 'a report' do
+  it { is_expected.to respond_to :headers }
+  it { is_expected.to respond_to :name }
+  it { is_expected.to respond_to :rows }
 end

--- a/spec/support/shared/a_report.rb
+++ b/spec/support/shared/a_report.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a report' do 
+  it { is_expected.to respond_to :headers}
+  it { is_expected.to respond_to :name}
+  it { is_expected.to respond_to :rows}
+end


### PR DESCRIPTION
This has all the basics for the reports to close #1210 

It has some opportunity for improvement:
`AllWorksReport` and `MonthlyUserWorksReport` currently have some code like this: 
```ruby
      latest_version = work
        .versions
        .max_by(&:version_number)
```
These should be updated to only look at draft or published works and/or ignore withdrawn ones.

Other areas for improvement:
Some of the fields can have multiple values (example: keyword). Right now what happens is these multiple values get encoded like json when being inserted into the CSV row. Seth had mentioned that he would like it double encoded as quotated csv. That's something that should not happen in the Report classes (they know nothing about CSV and should not—what if we wanted to offer reports in json?), it should happen in the controller that encodes the csv. 

The UI needs work, I just did the absolute minimum to demo all of them. Obviously for the User one, we would not have a field for their access id, it would pull `current_user` from the controller.

