### PR TITLE
redirect to the location from which the login is initiated

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,10 @@ class ApplicationController < ActionController::Base
     Rack::MiniProfiler.authorize_request if current_user.admin?
   end
 
+  # The callback which stores the current location must be added before you authenticate the user
+  # as `authenticate_user!`  will halt the filter chain and redirect before the location can be stored.
+  before_action :store_user_location!, if: :storable_location?
+
   def current_user
     return User.guest if Rails.application.read_only?
 
@@ -24,4 +28,20 @@ class ApplicationController < ActionController::Base
   def show_footer?
     true
   end
+
+  private
+
+    # Its important that the location is NOT stored if:
+    # - The request method is not GET (non idempotent)
+    # - The request is handled by a Devise controller such as Devise::SessionsController as that could cause an
+    #    infinite redirect loop.
+    # - The request is an Ajax request as this can lead to very unexpected behaviour.
+    def storable_location?
+      request.get? && is_navigational_format? && !devise_controller? && !request.xhr?
+    end
+
+    def store_user_location!
+      # :user is the scope we are authenticating
+      store_location_for(:user, request.fullpath)
+    end
 end

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -20,16 +20,37 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
 
   describe '#azure_oauth' do
     context 'when the user persists correctly' do
-      before do
-        get :azure_oauth
+      context 'when the login is not initiated from a storable location' do
+        before do
+          get :azure_oauth
+        end
+
+        it 'signs in the user' do
+          expect(warden.authenticated?(:user)).to eq true
+        end
+
+        it 'sets current_user' do
+          expect(controller.current_user).to eq user
+        end
+
+        it { is_expected.to redirect_to root_path }
       end
 
-      it 'signs in the user' do
-        expect(warden.authenticated?(:user)).to eq true
-      end
+      context 'when the login is initiated from a storable location' do
+        before do
+          controller.store_location_for(:user, about_path)
+          get :azure_oauth
+        end
 
-      it 'sets current_user' do
-        expect(controller.current_user).to eq user
+        it 'signs in the user' do
+          expect(warden.authenticated?(:user)).to eq true
+        end
+
+        it 'sets current_user' do
+          expect(controller.current_user).to eq user
+        end
+
+        it { is_expected.to redirect_to about_path }
       end
     end
 


### PR DESCRIPTION
Closes #1223 

This change is taken from the [docs](https://github.com/heartcombo/devise/wiki/How-To:-Redirect-back-to-current-page-after-sign-in,-sign-out,-sign-up,-update) , thanks @whereismyjetpack  for sending this along.