### PR TITLE
Track external apps

### DIFF
--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -52,7 +52,8 @@ module Api::V1
           metadata: metadata_params,
           depositor_access_id: depositor_params,
           content: content_params,
-          permissions: permission_params
+          permissions: permission_params,
+          external_app: api_token.application
         )
       end
 

--- a/app/models/external_app.rb
+++ b/app/models/external_app.rb
@@ -6,6 +6,9 @@ class ExternalApp < ApplicationRecord
            foreign_key: 'application_id',
            inverse_of: 'application'
 
+  has_many :work_versions,
+           dependent: :nullify
+
   validates :name,
             presence: true,
             uniqueness: true

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -36,6 +36,9 @@ class WorkVersion < ApplicationRecord
   belongs_to :work,
              inverse_of: :versions
 
+  belongs_to :external_app,
+             optional: true
+
   has_many :file_version_memberships,
            dependent: :destroy
 

--- a/app/services/api/v1/work_publisher.rb
+++ b/app/services/api/v1/work_publisher.rb
@@ -10,15 +10,17 @@ module Api
         publisher
       end
 
-      attr_reader :metadata, :depositor, :content, :permissions
+      attr_reader :metadata, :depositor, :content, :permissions, :external_app
 
       # @param [ActionController::Parameters] metadata
       # @param [String] depositor
       # @param [Array<ActionController::Parameters>] content
       # @param [ActionController::Parameters] permissions
-      def initialize(metadata:, depositor_access_id:, content:, permissions: {})
+      # @param [ExternalApp] external_app
+      def initialize(metadata:, depositor_access_id:, content:, permissions: {}, external_app: nil)
         @metadata = metadata
         @depositor = BuildNewActor.call(psu_id: depositor_access_id)
+        @external_app = external_app
         @content = content
         @permissions = permissions
       end
@@ -51,7 +53,10 @@ module Api
           deposited_at: metadata.delete(:deposited_at),
           doi: metadata.delete(:doi),
           versions_attributes: [
-            metadata.merge!('creators' => build_authorships)
+            metadata.merge!(
+              'creators' => build_authorships,
+              'external_app' => external_app
+            )
           ]
         )
       end

--- a/app/services/populate_external_apps.rb
+++ b/app/services/populate_external_apps.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# When SSv3 works were migrated across to v4 (this app), the only record of
+# where those works came from was in PaperTrail. The same is true for any
+# WorkVersion created by the API. We decided to make this linkage explicit with
+# a foreign key on WorkVersion, and this class backports all our old Versions
+# by crawling through the PaperTrail versions and trying to sleuth out this
+# information.
+#
+# This class will be run once to migrate the old data over, then can (and
+# should) be deleted
+class PopulateExternalApps
+  class << self
+    def call
+      work_versions.each do |wv|
+        first_external_app_global_id = wv
+          .versions
+          .map(&:whodunnit)
+          .map { |gid| GlobalID.parse(gid) }
+          .filter { |global_id| global_id&.model_class == ExternalApp }
+          .first
+
+        wv.update(external_app_id: first_external_app_global_id.model_id) if first_external_app_global_id.present?
+      end
+    end
+
+    def work_versions
+      WorkVersion
+        .includes(:versions) # This unfortunately-named association is the paper trail interface
+    end
+  end
+end

--- a/db/migrate/20220221170447_add_external_app_id_to_work_versions.rb
+++ b/db/migrate/20220221170447_add_external_app_id_to_work_versions.rb
@@ -1,0 +1,5 @@
+class AddExternalAppIdToWorkVersions < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :work_versions, :external_app, index: true, foreign_key: true, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_07_221742) do
+ActiveRecord::Schema.define(version: 2022_02_21_170447) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -238,6 +238,8 @@ ActiveRecord::Schema.define(version: 2022_02_07_221742) do
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }
     t.integer "version_number", null: false
     t.string "doi"
+    t.bigint "external_app_id"
+    t.index ["external_app_id"], name: "index_work_versions_on_external_app_id"
     t.index ["work_id", "version_number"], name: "index_work_versions_on_work_id_and_version_number", unique: true
     t.index ["work_id"], name: "index_work_versions_on_work_id"
   end
@@ -270,6 +272,7 @@ ActiveRecord::Schema.define(version: 2022_02_07_221742) do
   add_foreign_key "user_group_memberships", "groups"
   add_foreign_key "user_group_memberships", "users"
   add_foreign_key "users", "actors"
+  add_foreign_key "work_versions", "external_apps"
   add_foreign_key "work_versions", "works"
   add_foreign_key "works", "actors", column: "depositor_id"
   add_foreign_key "works", "actors", column: "proxy_id"

--- a/spec/models/external_app_spec.rb
+++ b/spec/models/external_app_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ExternalApp, type: :model do
 
   describe 'associations' do
     it { is_expected.to have_many(:api_tokens) }
+    it { is_expected.to have_many(:work_versions).dependent(:nullify) }
   end
 
   describe 'validations' do

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -417,6 +417,7 @@ RSpec.describe Work, type: :model do
           thumbnail_url_ssi
           auto_generate_thumbnail_tesim
           notify_editors_tesim
+          external_app_id_isi
         )
       end
 

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe WorkVersion, type: :model do
     it { is_expected.to have_db_column(:metadata).of_type(:jsonb) }
     it { is_expected.to have_db_column(:version_number).of_type(:integer) }
     it { is_expected.to have_db_column(:doi).of_type(:string) }
+    it { is_expected.to have_db_column(:external_app_id) }
     it { is_expected.to have_jsonb_accessor(:title).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:subtitle).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:version_name).of_type(:string) }
@@ -50,6 +51,7 @@ RSpec.describe WorkVersion, type: :model do
 
   describe 'associations' do
     it { is_expected.to belong_to(:work) }
+    it { is_expected.to belong_to(:external_app).optional(true) }
     it { is_expected.to have_many(:file_version_memberships) }
     it { is_expected.to have_many(:file_resources).through(:file_version_memberships) }
     it { is_expected.to have_many(:creators) }

--- a/spec/services/api/v1/work_publisher_spec.rb
+++ b/spec/services/api/v1/work_publisher_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Api::V1::WorkPublisher do
   let(:depositor) { build(:person) }
   let(:mock_client) { instance_spy(PsuIdentity::SearchService::Client) }
   let(:new_work) { publisher.work }
+  let(:external_app) { build(:external_app) }
 
   before do
     allow(PsuIdentity::SearchService::Client).to receive(:new).and_return(mock_client)
@@ -35,7 +36,8 @@ RSpec.describe Api::V1::WorkPublisher do
         content: [
           HashWithIndifferentAccess.new(file: fixture_file_upload(File.join(fixture_path, 'image.png'))),
           HashWithIndifferentAccess.new(file: fixture_file_upload(File.join(fixture_path, 'ipsum.pdf')))
-        ]
+        ],
+        external_app: external_app
       )
     end
 
@@ -57,6 +59,10 @@ RSpec.describe Api::V1::WorkPublisher do
 
     it 'does NOT create a User record for the depositor' do
       expect { new_work }.not_to change(User, :count)
+    end
+
+    it 'links the created WorkVersion to the given ExternalApp' do
+      expect(new_work.latest_version.external_app).to eq external_app
     end
   end
 

--- a/spec/services/build_new_work_version_spec.rb
+++ b/spec/services/build_new_work_version_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe BuildNewWorkVersion, type: :model do
       end
     end
 
+    it "doesn't copy over the ExternalApp, if present" do
+      initial_work_version.external_app = build(:external_app)
+      expect(new_version.external_app).to be_nil
+    end
+
     it "doesn't change the database" do
       expect { new_version }.not_to change(WorkVersion, :count)
       expect { new_version }.not_to change(FileResource, :count)

--- a/spec/services/populate_external_apps_spec.rb
+++ b/spec/services/populate_external_apps_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PopulateExternalApps, type: :model, versioning: true do
+  subject(:call_service) { described_class.call }
+
+  let(:external_app) { create :external_app }
+  let(:some_user) { create :user }
+
+  # Note that I am using instance vars (`@work`) instead of the preferred
+  # `let(:work)` syntax here because I need exact control over when and where
+  # these records are created
+  before do
+    # Create a WorkVersion with PaperTrail set to the external app, to simulate
+    # how the ingest controller worked historially
+    PaperTrail.request(whodunnit: external_app.to_gid) do
+      @work = create :work, versions_count: 1, has_draft: false
+      @first_version = @work.versions.first
+    end
+
+    # Now create some edits and a new version with PaperTrail set to a User to
+    # simulate how the regular controllers behave
+    PaperTrail.request(whodunnit: some_user.to_gid) do
+      @second_version = BuildNewWorkVersion.call(@first_version)
+      @second_version.save!
+
+      @work_created_by_user = create :work, versions_count: 2, has_draft: true
+    end
+
+    # Create a work with a totally invalid `whodunnit` gid, to test error handling
+    PaperTrail.request(whodunnit: 'invalid_gid') do
+      @work_with_invalid_whodunnit = create :work, versions_count: 1
+    end
+  end
+
+  it 'migrates any external app ids found in PaperTrail to WorkVersion#external_app' do
+    call_service
+
+    # Correctly migrates a record with an external app in papertail
+    expect(@first_version.reload.external_app).to eq external_app
+
+    # Does not affect others
+    expect(@second_version.reload.external_app).to be_nil
+    expect(@work_created_by_user.reload.versions.map(&:external_app)).to eq [nil, nil]
+    expect(@work_with_invalid_whodunnit.reload.versions.map(&:external_app)).to eq [nil]
+  end
+end


### PR DESCRIPTION
A little bit of background: we have a table/model called ExternalApps that links to all of our API keys. When our API is hit with a certain key, we can tell which "external app" is performing the action. Previously, if a work was created via the ingest API, either from the ScholarSphere3 migration (or coming in from RMD?), the only record of said external app was buried way down in our auditing package, called PaperTrail. Seth wants the linkage to be a little more explicit, so it's easy to tell which WorkVersions were created by SSv3 migration, RMD, or by active ScholarSphere users.

This PR does a few things: creates an optional FK from the work version to the external app that may have created it. It also updates the service object used by the ingest api to pass the external app through to the new work version that it creates. Finally there is a migration to backport all of the old data to use this new fk.

The key to understanding the migration code is this fact: PaperTrail tracks the user that made the change by the `whodunnit` string. Because actions in SS could either be performed by `User`s or by `ExternalApp`s, we store a `GlobalID` in this column, which looks like `"gid://scholarsphere/User/23"` for a `User` with id 23 or `"gid://scholarsphere/ExternalApp/2"` for an `ExternalApp` with id 2. The migration loads out every PaperTrail version for every WorkVersion, looks for _any_ versions that were performed by an `ExternalApp`, and if it finds any, it stores the first one as the `external_app` on that WorkVersion. The code is actually remarkably small, but pretty dense.

Closes #1214 