### PR TITLE
Cache download counts per session, per day

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -111,6 +111,7 @@ RSpec/VerifiedDoubles:
     - 'spec/components/work_versions/version_navigation_component_spec.rb'
     - 'spec/components/work_histories/work_history_component_spec.rb'
     - 'spec/controllers/dashboard/work_search_controller_spec.rb'
+    - 'spec/services/session_view_stats_cache_spec.rb'
 
 Style/ClassVars:
   Exclude:

--- a/app/services/session_view_stats_cache.rb
+++ b/app/services/session_view_stats_cache.rb
@@ -3,7 +3,7 @@
 class SessionViewStatsCache
   def self.call(session:, resource:)
     redis = Redis.new(Rails.configuration.redis)
-    digest = Digest::MD5.hexdigest("#{session.id}#{resource.id}")[0..6]
+    digest = Digest::MD5.hexdigest("#{session.id}#{resource.class.name}#{resource.id}")[0..6]
     key = "vs:#{digest}"
 
     return false if redis.get(key)

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -82,4 +82,23 @@ RSpec.describe DownloadsController, type: :controller do
       end
     end
   end
+
+  context 'when downloading a file twice' do
+    let(:work_version) { create(:work_version, :published, :with_files, file_count: 2) }
+
+    it 'counts the download once' do
+      expect {
+        2.times {
+          get :content, params: { resource_id: work_version.uuid, id: work_version.file_version_memberships[0].id }
+        }
+      }.to(
+        change {
+          ViewStatistic.find_by(
+            resource_type: 'FileResource',
+            resource_id: work_version.file_version_memberships[0].file_resource_id
+          )&.count || 0
+        }.by(1)
+      )
+    end
+  end
 end

--- a/spec/services/session_view_stats_cache_spec.rb
+++ b/spec/services/session_view_stats_cache_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SessionViewStatsCache do
+  let(:session) { double('session', id: 1) }
+  let(:another_session) { double('session', id: 2) }
+  let(:work) { build_stubbed :work, id: 1 }
+  let(:collection) { build_stubbed :collection, id: 1 }
+
+  it 'retuns false if the given session/resource combo is in the cache already' do
+    expect(described_class.call(session: session, resource: work)).to eq true
+    expect(described_class.call(session: session, resource: work)).to eq false
+
+    expect(described_class.call(session: session, resource: collection)).to eq true
+    expect(described_class.call(session: session, resource: collection)).to eq false
+
+    expect(described_class.call(session: another_session, resource: work)).to eq true
+    expect(described_class.call(session: another_session, resource: collection)).to eq true
+  end
+end


### PR DESCRIPTION
As my [comment](https://github.com/psu-libraries/scholarsphere/issues/1222#issuecomment-1047966253) in #1222 states, we are not deduping the download counts in the same way that we are with views. If the same person views the same work twice in one day, it is counted as one single view. However if the same person downloads the same file twice in one day, it is counted as two downloads. This PR dedups the download counts to match the same way we are doing it in the views.

Also while I was investigating this issue, I found a bug in the stats cache code! So this PR fixes that too. 

I don't know if this PR should _close_ the issue linked to above, so I did not do the GitHub auto closing magic. I guess that should be up to @srerickson to decide. Update: closes #1222 