### PR TITLE
Service to migrate identifiers from a collection to a work

### DIFF
--- a/app/services/migrate_collection_ids.rb
+++ b/app/services/migrate_collection_ids.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class MigrateCollectionIds
+  attr_reader :collection_uuid, :work_uuid
+
+  def self.call(collection_uuid, work_uuid)
+    instance = new(collection_uuid, work_uuid)
+    instance.migrate
+    instance
+  end
+
+  def initialize(collection_uuid, work_uuid)
+    @collection_uuid = collection_uuid
+    @work_uuid = work_uuid
+    @successful = false # updated by #migrate
+  end
+
+  def migrate
+    return false if collection.nil? || work.nil?
+
+    original_work_uuid = work.uuid
+    work.doi = collection.doi
+    work.uuid = collection.uuid
+    legacy_ids = collection.legacy_identifiers.map(&:dup)
+
+    ActiveRecord::Base.transaction do
+      delete_result = DeleteCollection.call(collection.uuid)
+
+      if delete_result.successful?
+        migrate_legacy_identifiers(legacy_ids)
+        work.save!
+        work.update_index
+        IndexingService.delete_document(original_work_uuid, commit: true)
+      end
+    end
+
+    @successful = true
+    true
+  end
+
+  def successful?
+    @successful
+  end
+
+  private
+
+    def collection
+      @collection ||= Collection.find_by(uuid: collection_uuid)
+    end
+
+    def work
+      @work ||= Work.find_by(uuid: work_uuid)
+    end
+
+    def migrate_legacy_identifiers(legacy_ids)
+      legacy_ids.each do |legacy_id|
+        legacy_id.resource_type = 'Work'
+        legacy_id.resource_id = work.id
+        legacy_id.save!
+      end
+    end
+end

--- a/app/services/migrate_collection_ids.rb
+++ b/app/services/migrate_collection_ids.rb
@@ -54,8 +54,7 @@ class MigrateCollectionIds
 
     def migrate_legacy_identifiers(legacy_ids)
       legacy_ids.each do |legacy_id|
-        legacy_id.resource_type = 'Work'
-        legacy_id.resource_id = work.id
+        legacy_id.resource = work
         legacy_id.save!
       end
     end

--- a/lib/tasks/resource.rake
+++ b/lib/tasks/resource.rake
@@ -43,4 +43,18 @@ namespace :resource do
       puts 'Failed to delete collection.'
     end
   end
+
+  desc 'Deletes a collection and its works + migrates its identifiers to a target work'
+  task :migrate_collection_ids, [:collection_uuid, :work_uuid] => :environment do |_task, args|
+    collection_uuid = args[:collection_uuid]
+    work_uuid = args[:work_uuid]
+
+    result = MigrateCollectionIds.call(collection_uuid, work_uuid)
+
+    if result.successful?
+      puts 'Collection IDs migrated successfully.'
+    else
+      puts 'Failed to migrate collection IDs.'
+    end
+  end
 end

--- a/spec/services/migrate_collection_ids_spec.rb
+++ b/spec/services/migrate_collection_ids_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe MigrateCollectionIds do
+  subject(:migrate_result) { described_class.call(collection.uuid, target_work.uuid) }
+
+  let(:collection) { create(:collection, :with_a_doi, works: [work1, work2]) }
+
+  let!(:work1) { create(:work, has_draft: false, versions_count: 1) }
+  let!(:work2) { create(:work, has_draft: false, versions_count: 2) }
+  let!(:target_work) { create(:work, has_draft: false, versions_count: 1) }
+
+  let!(:legacy_id) { create(:legacy_identifier,
+                            old_id: 'tb09j581r',
+                            resource: collection,
+                            version: 3) }
+
+  context 'when the collection cannot be found' do
+    it 'returns false' do
+      result = described_class.call('123', work1.uuid)
+
+      expect(result.successful?).to be false
+    end
+  end
+
+  context 'when the work cannot be found' do
+    it 'returns false' do
+      result = described_class.call(collection.uuid, '123')
+
+      expect(result.successful?).to be false
+    end
+  end
+
+  context 'when the collection and work are found' do
+    context 'when the ids are eligible to be merged' do
+      before { migrate_result }
+
+      it 'returns a successful result' do
+        expect(migrate_result).to be_successful
+      end
+
+      it 'deletes the original collection + works + legacy identifiers' do
+        expect { collection.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { work1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { work2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { legacy_id.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'copies IDs from the collection to the work' do
+        target_work.reload
+
+        expect(target_work.uuid).to eq collection.uuid
+        expect(target_work.doi).not_to be_nil
+        expect(target_work.doi).to eq collection.doi
+
+        expect(target_work.legacy_identifiers.count).to eq 1
+
+        legacy_id = target_work.legacy_identifiers.first
+
+        expect(legacy_id.old_id).to eq 'tb09j581r'
+        expect(legacy_id.resource_type).to eq 'Work'
+        expect(legacy_id.resource_id).to eq target_work.id
+        expect(legacy_id.version).to eq 3
+      end
+    end
+
+    context 'when the database transaction fails' do
+      before do
+        allow(IndexingService).to receive(:delete_document).and_raise(StandardError)
+      end
+
+      it 'rolls back all changes' do
+        expect {
+          begin
+            migrate_result
+          rescue StandardError
+            # noop
+          end
+        }.not_to change(WorkVersion, :count)
+
+        expect(work1.reload).to be_present
+        expect(work2.reload).to be_present
+        expect(collection.reload).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #1242.

This service will delete the collection + it works, and then copy the following identifiers over to a specified target work:

- DOI
- UUID
- Legacy Identifiers