### PR TITLE
fix for notify users checkbox

### DIFF
--- a/app/forms/editors_form.rb
+++ b/app/forms/editors_form.rb
@@ -47,7 +47,7 @@ class EditorsForm
     resource.notify_editors = notify_editors
     resource.save!
 
-    send_emails(new_users: new_users) if notify_editors
+    send_emails(new_users: new_users) if resource.notify_editors
 
     true
   rescue ActiveRecord::RecordInvalid

--- a/app/views/dashboard/shared/_editors_form.html.erb
+++ b/app/views/dashboard/shared/_editors_form.html.erb
@@ -27,7 +27,7 @@
 
   <div class="form-group mb-3">
     <div class="form-check">
-      <%= form.check_box :notify_editors, class: 'form-check-input' %>
+      <%= form.check_box :notify_editors, { class: 'form-check-input' } %>
       <%= form.label :notify_editors, t('.notify_editors'), class: 'form-check-label' %>
     </div>
   </div>

--- a/spec/fixtures/vcr_cassettes/Work_Settings_Page/Updating_Editors/when_adding_a_new_editor/does_not_notify_editors_if_send_notification_email_is_not_checked.yml
+++ b/spec/fixtures/vcr_cassettes/Work_Settings_Page/Updating_Editors/when_adding_a_new_editor/does_not_notify_editors_if_send_notification_email_is_not_checked.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people/userid/agw13
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Feb 2022 21:36:57 GMT
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Content-Length:
+      - '358'
+      Connection:
+      - keep-alive
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      Set-Cookie:
+      - JSESSIONID=eM0saiLnKAIloX6MVQN17BQ1v9YTh3fXt2L_eLlH.search-service-97b86d9d6-rnk5k;
+        path=/search-service
+      X-Request-Id:
+      - 5d959d9d5f1bfd50296320851c847859
+      X-Frame-Options:
+      - DENY
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Uniqueid:
+      - 5d959d9d5f1bfd50296320851c847859
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"userid":"agw13","cprid":"2784093","givenName":"Adam","middleName":"Garner","familyName":"Wead","preferredGivenName":"Adam","preferredFamilyName":"Wead","active":true,"confHold":false,"universityEmail":"agw13@psu.edu","serviceAccount":false,"affiliation":["MEMBER"],"link":{"href":"https://dev.apps.psu.edu/cpr/resources/2784093"},"displayName":"Adam
+        Wead"}'
+  recorded_at: Wed, 23 Feb 2022 21:36:57 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Work_Settings_Page/Updating_Editors/when_adding_a_new_editor/notify_editors_if_send_notification_email_is_checked.yml
+++ b/spec/fixtures/vcr_cassettes/Work_Settings_Page/Updating_Editors/when_adding_a_new_editor/notify_editors_if_send_notification_email_is_checked.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people/userid/agw13
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Feb 2022 21:29:15 GMT
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Content-Length:
+      - '358'
+      Connection:
+      - keep-alive
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      Set-Cookie:
+      - JSESSIONID=IN8jDvY_cwCYdA9lL4WtjzIZQ8vqxyvlRKKmuVHE.search-service-97b86d9d6-rnk5k;
+        path=/search-service
+      X-Request-Id:
+      - 799352daf8326790e903ca80fc6acbd2
+      X-Frame-Options:
+      - DENY
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Uniqueid:
+      - 799352daf8326790e903ca80fc6acbd2
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"userid":"agw13","cprid":"2784093","givenName":"Adam","middleName":"Garner","familyName":"Wead","preferredGivenName":"Adam","preferredFamilyName":"Wead","active":true,"confHold":false,"universityEmail":"agw13@psu.edu","serviceAccount":false,"affiliation":["MEMBER"],"link":{"href":"https://dev.apps.psu.edu/cpr/resources/2784093"},"displayName":"Adam
+        Wead"}'
+  recorded_at: Wed, 23 Feb 2022 21:29:15 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
Closes #1250

I was able to recreate this bug with a feature spec I just added. The checkbox values was "1" and "0" which was failing the check, changed it to be true, false.

