### PR TITLE
Increase # of works requested from Solr as collection size grows

### DIFF
--- a/app/controllers/dashboard/work_search_controller.rb
+++ b/app/controllers/dashboard/work_search_controller.rb
@@ -3,8 +3,9 @@
 class Dashboard::WorkSearchController < Dashboard::BaseController
   def index
     query = "#{params[:q]}*"
+    max_documents = params[:max_documents].present? ? params[:max_documents].to_i : 50
 
-    (member_works, _deprecated_document_list) = search_service(query).search_results
+    (member_works, _deprecated_document_list) = search_service(query, max_documents).search_results
 
     results = member_works.documents.map { |d| { id: d.work_id, text: d.title } }
 
@@ -13,12 +14,12 @@ class Dashboard::WorkSearchController < Dashboard::BaseController
 
   private
 
-    def search_service(query)
+    def search_service(query, max_documents)
       @search_service ||= ::Blacklight::SearchService.new(
         config: Blacklight::Configuration.new,
         search_builder_class: Dashboard::MemberWorksSearchBuilder,
         current_user: current_user,
-        max_documents: 50,
+        max_documents: max_documents,
         user_params: { q: query }
       )
     end

--- a/app/javascript/controllers/search-works_controller.js
+++ b/app/javascript/controllers/search-works_controller.js
@@ -11,12 +11,11 @@ export default class extends Controller {
       ajax: {
         delay: 250,
         url: endpoint,
+        data: (params) => this.buildParams(params),
         dataType: 'json',
         processResults: (data) => {
           // filter out works already in the collection from the search results
-          const workWrappers = $('.js-work-wrapper[data-work-id]:visible')
-          const workIdsInCollection = [...workWrappers].map(w => w.dataset.workId)
-          const filteredWorks = data.filter(d => !workIdsInCollection.includes(`${d.id}`))
+          const filteredWorks = data.filter(d => !this.workIdsInCollection().includes(`${d.id}`))
 
           return {
             results: filteredWorks
@@ -40,5 +39,20 @@ export default class extends Controller {
 
   afterSelectedEvent (suggestion) {
     return new CustomEvent('autocomplete:after-selected', { bubbles: true, detail: { suggestion: suggestion } })
+  }
+
+  buildParams (params) {
+    const maxDocuments = 50 + this.workIdsInCollection().length
+
+    const queryParameters = {
+      q: params.term,
+      max_documents: maxDocuments
+    }
+    return queryParameters
+  }
+
+  workIdsInCollection () {
+    const workWrappers = $('.js-work-wrapper[data-work-id]:visible')
+    return [...workWrappers].map(w => w.dataset.workId)
   }
 }

--- a/spec/controllers/dashboard/work_search_controller_spec.rb
+++ b/spec/controllers/dashboard/work_search_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Dashboard::WorkSearchController, type: :controller do
   let(:user) { create :user }
 
   describe 'GET #index' do
-    let(:perform_request) { get :index, params: { q: 'test query' } }
+    let(:perform_request) { get :index, params: { q: 'test query', max_documents: 20 } }
 
     let(:mock_search_service) { instance_spy('Blacklight::SearchService') }
     let(:mock_results) { [
@@ -38,7 +38,7 @@ RSpec.describe Dashboard::WorkSearchController, type: :controller do
           expect(params[:current_user]).to be_an_instance_of(UserDecorator)
           expect(params[:current_user].id).to eq user.id
           expect(params[:user_params]).to eq({ q: 'test query*' })
-          expect(params[:max_documents]).to be_an_instance_of(Integer)
+          expect(params[:max_documents]).to eq 20
         end
 
         expect(mock_search_service).to have_received(:search_results)
@@ -49,6 +49,16 @@ RSpec.describe Dashboard::WorkSearchController, type: :controller do
             { 'id' => 456, 'text' => 'title2' }
           ]
         )
+      end
+
+      context 'when the max_documents param is not provided in the request' do
+        let(:perform_request) { get :index, params: { q: 'test query' } }
+
+        it 'requests the default number of documents from the search service' do
+          expect(Blacklight::SearchService).to have_received(:new) do |params|
+            expect(params[:max_documents]).to eq 50
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Closes #1249.

To prevent users from seeing 'No results found' when searching for works to add to a collection, we now request 50 + the number of works that are currently in the collection. This ensures that if there are any eligible works to be added to the collection, we will show them in the dropdown without the user needing to type anything into the search box.