### PR TITLE
updates sidekiq

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -450,7 +450,7 @@ GEM
     shrine (3.3.0)
       content_disposition (~> 1.0)
       down (~> 5.1)
-    sidekiq (6.4.0)
+    sidekiq (6.4.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)


### PR DESCRIPTION
sidekiq 6.4.0 and below throw pipelining errors when using redis > 5. 

https://github.com/mperham/sidekiq/blob/main/Changes.md

This addresses that.