### PR TITLE
Migrate view statistics with collection ids

### DIFF
--- a/app/services/merge_collection.rb
+++ b/app/services/merge_collection.rb
@@ -205,7 +205,6 @@ class MergeCollection
       version.metadata = canonical_work_version.metadata
       version.creators = canonical_work_version.creators.map(&:dup)
       version.file_resources = all_file_resources
-      version.view_statistics = aggregate_view_statistics
       version.title = collection.title
       version.description = collection.description
       version.metadata['keyword'] = collection.metadata['keyword']
@@ -228,18 +227,5 @@ class MergeCollection
         num_work_versions: work.versions.count,
         num_files: work.representative_version&.file_resources&.count
       }
-    end
-
-    def aggregate_view_statistics
-      models_to_aggregate = [
-        collection,
-        collection.works.map(&:representative_version)
-      ].flatten
-
-      aggregated_stats = AggregateViewStatistics.call(models: models_to_aggregate)
-
-      aggregated_stats.map do |date, count, _running_total|
-        ViewStatistic.new(date: date, count: count)
-      end
     end
 end

--- a/app/services/migrate_collection_ids.rb
+++ b/app/services/migrate_collection_ids.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class MigrateCollectionIds
-  attr_reader :collection_uuid, :work_uuid
+  attr_reader :collection_uuid,
+              :work_uuid,
+              :version
 
   def self.call(collection_uuid, work_uuid)
     instance = new(collection_uuid, work_uuid)
@@ -12,6 +14,7 @@ class MigrateCollectionIds
   def initialize(collection_uuid, work_uuid)
     @collection_uuid = collection_uuid
     @work_uuid = work_uuid
+    @version = work&.latest_version
     @successful = false # updated by #migrate
   end
 
@@ -22,12 +25,14 @@ class MigrateCollectionIds
     work.doi = collection.doi
     work.uuid = collection.uuid
     legacy_ids = collection.legacy_identifiers.map(&:dup)
+    view_statistics_attrs = aggregate_view_statistics
 
     ActiveRecord::Base.transaction do
       delete_result = DeleteCollection.call(collection.uuid)
 
       if delete_result.successful?
         migrate_legacy_identifiers(legacy_ids)
+        migrate_view_statistics(view_statistics_attrs)
         work.save!
         work.update_index
         IndexingService.delete_document(original_work_uuid, commit: true)
@@ -57,5 +62,32 @@ class MigrateCollectionIds
         legacy_id.resource = work
         legacy_id.save!
       end
+    end
+
+    def aggregate_view_statistics
+      models_to_aggregate = [
+        collection,
+        collection.works.map(&:representative_version)
+      ].flatten
+
+      aggregated_stats = AggregateViewStatistics.call(models: models_to_aggregate)
+
+      # Return an array of attributes for a bulk insert, rather than ActiveRecords, for speed
+      aggregated_stats.map do |date, count, _running_total|
+        {
+          date: date,
+          count: count,
+          resource_type: version.class,
+          resource_id: version.id,
+          created_at: Time.zone.now,
+          updated_at: Time.zone.now
+        }
+      end
+    end
+
+    def migrate_view_statistics(view_stats_attrs)
+      return if view_stats_attrs.empty?
+
+      ViewStatistic.insert_all!(view_stats_attrs)
     end
 end

--- a/spec/services/merge_collection_spec.rb
+++ b/spec/services/merge_collection_spec.rb
@@ -185,12 +185,6 @@ describe MergeCollection do
   end
 
   context 'when the works in the collection are eligible to be merged' do
-    before do
-      create(:view_statistic, resource: collection, date: Date.parse('2022-02-06'), count: 1)
-      create(:view_statistic, resource: collection, date: Date.parse('2022-02-07'), count: 1)
-      create(:view_statistic, resource: work1.versions.first, date: Date.parse('2022-02-07'), count: 1)
-    end
-
     it 'merges the works into a single work' do
       expect(merge_result).to be_successful
 
@@ -223,14 +217,6 @@ describe MergeCollection do
 
       # check creators
       expect(version.creators.map(&:display_name)).to match_array(work1.versions.first.creators.map(&:display_name))
-
-      # check view stats
-      expect(
-        version.view_statistics.map { |vs| [vs.date, vs.count] }
-      ).to match_array([
-                         [Date.parse('2022-02-06'), 1],
-                         [Date.parse('2022-02-07'), 2]
-                       ])
     end
   end
 end


### PR DESCRIPTION
Originally, we were migrating the view statistics inside the `MergeCollection` service. However, now we have split that process into two different actions, one to merge a collection into a work, and another to actually flip the switch and remove the old collection. It makes sense to move the view statistics over during that latter process so we don't miss any view stats that occurred between the first step and the second.

I also went a little nuts and used ActiveRecord's `insert_all` feature to do a batch insert of all the newly migrated view statistics.

Closes #1267 