### PR TITLE
Rendering fixes for thumbnail on work details page

### DIFF
--- a/app/views/resources/_heading_display.html.erb
+++ b/app/views/resources/_heading_display.html.erb
@@ -1,13 +1,16 @@
-<div class="row mb-3 no-gutters d-inline-block">
-  <% if resource.default_thumbnail? %>
-    <h1 class="h2 mb-3"><%= resource.title %></h1>
-  <% else %>
-    <div class="thumbnail-card d-flex align-items-center">
-      <div class="resource-page-thumbnail">
-        <div><%= render ThumbnailComponent.new(resource: resource) %></div>
+<div class="row mb-3 no-gutters d-flex flex-row flex-nowrap">
+  <div class="col">
+    <% unless resource.default_thumbnail? %>
+      <div class="thumbnail-card d-none d-md-flex align-items-center mb-1">
+        <div class="resource-page-thumbnail">
+          <div><%= render ThumbnailComponent.new(resource: resource) %></div>
+        </div>
       </div>
+    <% end %>
+
+    <div>
+      <h1 class="h2 mb-3"><%= resource.title %></h1>
+      <%= resource.description_html %>
     </div>
-    <h1 class="h2 mt-1 mb-3"><%= resource.title %></h1>
-  <% end %>
-  <%= resource.description_html %>
+  </div>
 </div>


### PR DESCRIPTION
- short titles + descriptions now show up to the right of the thumbnail
- the thumbnail is hidden on small screen sizes

### Long Title
<img width="1463" alt="Screen Shot 2022-03-09 at 10 49 03 AM" src="https://user-images.githubusercontent.com/639920/157477621-d64ef7b9-f9a7-4454-84d4-2b01d6b0f3cf.png">

### Short Title
<img width="1463" alt="Screen Shot 2022-03-09 at 10 49 11 AM" src="https://user-images.githubusercontent.com/639920/157477691-a154821b-aa8b-43ee-82a9-faa5b1fb24d0.png">

### No thumbnail
<img width="1470" alt="Screen Shot 2022-03-09 at 10 50 10 AM" src="https://user-images.githubusercontent.com/639920/157477796-e8a9ef54-d1f4-4403-89d5-ae6ec67676ca.png">

### Wrapping
<img width="789" alt="Screen Shot 2022-03-09 at 10 52 24 AM" src="https://user-images.githubusercontent.com/639920/157478274-1137a36e-bb2b-461c-8002-61aaea94b061.png">

### Mobile View
<img width="543" alt="Screen Shot 2022-03-09 at 10 52 30 AM" src="https://user-images.githubusercontent.com/639920/157478304-45b56a8d-7f9e-4d3b-9e7f-41726c0a78d3.png">

