### PR TITLE
Hide the navbar toggle button in blue nav when there are no nav items

### DIFF
--- a/app/javascript/frontend/styles/_common.scss
+++ b/app/javascript/frontend/styles/_common.scss
@@ -288,6 +288,8 @@ h4,
 }
 
 .main-nav {
+  min-height: 53px;
+
   @include media-breakpoint-down(md) {
     &:not(.main-nav--no-pad) {
       padding: ($spacer * .5) 0;

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,13 +1,15 @@
 <nav class="navbar main-nav navbar-expand-lg navbar-dark bg-dark-blue pr-0">
-  <button class="navbar-toggler"
-          type="button"
-          data-toggle="collapse"
-          data-target="#navbar-toggle"
-          aria-controls="navbar-toggle"
-          aria-expanded="false"
-          aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-  </button>
+  <% if content_for? :navbar_items %>
+    <button class="navbar-toggler"
+            type="button"
+            data-toggle="collapse"
+            data-target="#navbar-toggle"
+            aria-controls="navbar-toggle"
+            aria-expanded="false"
+            aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+  <% end %>
 
   <%= yield :navbar_heading %>
 

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'Home page', type: :feature do
 
       within('nav.main-nav') do
         expect(page).to have_content('Welcome to ScholarSphere')
+        expect(page).not_to have_selector('button')
       end
 
       expect(page).to have_selector('h2', text: 'ScholarSphere Updates')

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -46,6 +46,11 @@ RSpec.describe 'Public Resources', type: :feature do
           expect(page).not_to have_content(I18n.t!('resources.settings_button.text', type: 'Work'))
         end
 
+        # Does not have a menu toggle button
+        within('nav.main-nav') do
+          expect(page).not_to have_selector('button')
+        end
+
         ## Ensure we cannot navigate to the draft version
         within('.version-navigation .list-group') do
           expect(page).not_to have_content 'V3'
@@ -117,6 +122,11 @@ RSpec.describe 'Public Resources', type: :feature do
 
             expect(page).to have_content(I18n.t!('resources.edit_button.text', type: 'Work'))
               .and have_content(I18n.t!('resources.settings_button.text', type: 'Work'))
+          end
+
+          # Has a menu toggle button
+          within('nav.main-nav') do
+            expect(page).to have_selector('button.navbar-toggler')
           end
         end
       end


### PR DESCRIPTION
Closes #1273.

### Before
<img width="434" alt="Screen Shot 2022-03-10 at 12 52 34 PM" src="https://user-images.githubusercontent.com/639920/157724892-6c3ee3b1-aff7-4623-97e3-b5c90799c3b5.png">

### After
<img width="437" alt="Screen Shot 2022-03-10 at 12 52 25 PM" src="https://user-images.githubusercontent.com/639920/157724921-413b60c9-8187-477a-8f5f-ed995f55674a.png">

