### PR TITLE
Set thumbnail_selection to 'auto_generated' for Works and Collections that have an autogenerated thumbnail upon creation

### DIFF
--- a/app/components/thumbnail_component.rb
+++ b/app/components/thumbnail_component.rb
@@ -11,7 +11,7 @@ class ThumbnailComponent < ApplicationComponent
   end
 
   def display_thumbnail?
-    !resource.default_thumbnail?
+    !resource.default_thumbnail? && thumbnail_url.present?
   end
 
   def thumbnail_url

--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -25,6 +25,8 @@ module Dashboard
         # save again--this time using the published validations. That way the
         # appropriate error messages will appear on the form when it's re-rendered
         if publish?
+          # WorkVersion#set_thumbnail_selection may be unreliable if the Shrine::ThumbnailJob is delayed
+          @resource.set_thumbnail_selection
           @resource.indexing_source = Proc.new { nil }
           @resource.save
           @resource.publish

--- a/app/models/collection_work_membership.rb
+++ b/app/models/collection_work_membership.rb
@@ -16,4 +16,15 @@ class CollectionWorkMembership < ApplicationRecord
             uniqueness: {
               scope: :work_id
             }
+
+  after_create :set_thumbnail_selection
+
+  private
+
+    def set_thumbnail_selection
+      # collection.works.blank? lets us know if the collection has just been created
+      if collection.works.blank? && work.auto_generated_thumbnail_url.present?
+        collection.update thumbnail_selection: ThumbnailSelections::AUTO_GENERATED
+      end
+    end
 end

--- a/app/models/collection_work_membership.rb
+++ b/app/models/collection_work_membership.rb
@@ -22,7 +22,8 @@ class CollectionWorkMembership < ApplicationRecord
   private
 
     def set_thumbnail_selection
-      # collection.works.blank? lets us know if the collection has just been created
+      # The MembersController accepts_nested_attributes_for all WorKCollectionMembers before the Collection is saved
+      # Therefore collection.works.blank? lets us know if the collection has just been created
       if collection.works.blank? && work.auto_generated_thumbnail_url.present?
         collection.update thumbnail_selection: ThumbnailSelections::AUTO_GENERATED
       end

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -293,6 +293,13 @@ class WorkVersion < ApplicationRecord
     super
   end
 
+  def set_thumbnail_selection
+    # work.versions.published.blank? lets us know if the work has just been created
+    if work.versions.published.blank? && file_resources.map(&:thumbnail_url).compact.present?
+      work.update thumbnail_selection: ThumbnailSelections::AUTO_GENERATED
+    end
+  end
+
   delegate :deposited_at,
            :depositor,
            :embargoed?,

--- a/app/views/resources/_heading_display.html.erb
+++ b/app/views/resources/_heading_display.html.erb
@@ -1,9 +1,10 @@
+<% thumbnail_component = ThumbnailComponent.new(resource: resource) %>
 <div class="row mb-3 no-gutters d-flex flex-row flex-nowrap">
   <div class="col">
-    <% unless resource.default_thumbnail? %>
+    <% if thumbnail_component.display_thumbnail? %>
       <div class="thumbnail-card d-none d-md-flex align-items-center mb-1">
         <div class="resource-page-thumbnail">
-          <div><%= render ThumbnailComponent.new(resource: resource) %></div>
+          <div><%= render thumbnail_component %></div>
         </div>
       </div>
     <% end %>

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'csv'
+require_relative '../../app/models/concerns/thumbnail_selections'
 
 namespace :migration do
   desc 'Import statistics from Scholarsphere 3'
@@ -8,6 +9,19 @@ namespace :migration do
     path = Rails.root.join(args[:file])
     CSV.foreach(path) do |row|
       ImportStatisticsJob.perform_later(row)
+    end
+  end
+
+  # TODO: This can be deleted after it is done (if we decide to use it)
+  desc "Set Work and Collection's #thumbnail_selection to #{ThumbnailSelections::AUTO_GENERATED}
+        if an #auto_generated_thumbnail_url is present"
+  task set_thumbnail_selections: :environment do
+    Work.find_each do |w|
+      w.update(thumbnail_selection: ThumbnailSelections::AUTO_GENERATED) if w.auto_generated_thumbnail_url.present?
+    end
+
+    Collection.find_each do |c|
+      c.update(thumbnail_selection: ThumbnailSelections::AUTO_GENERATED) if c.auto_generated_thumbnail_url.present?
     end
   end
 end

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -523,6 +523,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
       # On the review page, change all the details metadata to ensure the params
       # are submitted correctly
+      expect_any_instance_of(WorkVersion).to receive(:set_thumbnail_selection).once
       FeatureHelpers::DashboardForm.fill_in_work_details(different_metadata)
       FeatureHelpers::DashboardForm.fill_in_publishing_details(metadata)
       FeatureHelpers::DashboardForm.publish

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -190,30 +190,62 @@ RSpec.describe 'Public Resources', type: :feature do
     end
 
     context 'when work has a thumbnail' do
-      before do
-        allow_any_instance_of(Work).to receive(:default_thumbnail?).and_return false
-        allow_any_instance_of(ThumbnailComponent).to receive(:display_thumbnail?).and_return true
-        allow_any_instance_of(ThumbnailComponent).to receive(:thumbnail_url).and_return 'url.com/path/file'
-        visit resource_path(work.uuid)
+      let(:collection) { create :collection }
+
+      context 'when work#default_thumbnail? is true' do
+        before do
+          allow_any_instance_of(Work).to receive(:default_thumbnail?).and_return true
+          allow_any_instance_of(ThumbnailComponent).to receive(:thumbnail_url).and_return 'url.com/path/file'
+          visit resource_path(work.uuid)
+        end
+
+        it 'does not display thumbnail' do
+          expect(page).not_to have_css("img[src='url.com/path/file']")
+          expect(page).not_to have_css('.thumbnail-card')
+        end
       end
 
-      it 'displays the thumbnail' do
-        expect(page).to have_css("img[src='url.com/path/file']")
-        expect(page).to have_css('.thumbnail-card')
+      context 'when work#default_thumbnail? is false' do
+        before do
+          allow_any_instance_of(Work).to receive(:default_thumbnail?).and_return false
+          allow_any_instance_of(ThumbnailComponent).to receive(:thumbnail_url).and_return 'url.com/path/file'
+          visit resource_path(work.uuid)
+        end
+
+        it 'displays the thumbnail' do
+          expect(page).to have_css("img[src='url.com/path/file']")
+          expect(page).to have_css('.thumbnail-card')
+        end
       end
     end
 
     context 'when work does not have a thumbnail' do
+      let(:work) { create :work }
+
       before do
-        allow_any_instance_of(Work).to receive(:default_thumbnail?).and_return true
-        allow_any_instance_of(ThumbnailComponent).to receive(:display_thumbnail?).and_return true
-        allow_any_instance_of(ThumbnailComponent).to receive(:thumbnail_url).and_return 'url.com/path/file'
-        visit resource_path(work.uuid)
+        allow_any_instance_of(ThumbnailComponent).to receive(:thumbnail_url).and_return nil
       end
 
-      it 'does not display thumbnail' do
-        expect(page).not_to have_css("img[src='url.com/path/file']")
-        expect(page).not_to have_css('.thumbnail-card')
+      context 'when work#default_thumbnail? is true' do
+        before do
+          allow_any_instance_of(Work).to receive(:default_thumbnail?).and_return true
+          visit resource_path(work.uuid)
+        end
+
+        it 'does not display thumbnail' do
+          expect(page).not_to have_css('.thumbnail-image')
+        end
+      end
+
+      context 'when work#default_thumbnail? is false' do
+        before do
+          allow_any_instance_of(Work).to receive(:default_thumbnail?).and_return false
+          visit resource_path(work.uuid)
+        end
+
+        it 'does not display thumbnail' do
+          expect(page).not_to have_css('.thumbnail-image')
+        end
       end
     end
   end
@@ -286,16 +318,30 @@ RSpec.describe 'Public Resources', type: :feature do
     context 'when collection has a thumbnail' do
       let(:collection) { create :collection }
 
-      before do
-        allow_any_instance_of(Collection).to receive(:default_thumbnail?).and_return false
-        allow_any_instance_of(ThumbnailComponent).to receive(:display_thumbnail?).and_return true
-        allow_any_instance_of(ThumbnailComponent).to receive(:thumbnail_url).and_return 'url.com/path/file'
-        visit resource_path(collection.uuid)
+      context 'when collection#default_thumbnail? is true' do
+        before do
+          allow_any_instance_of(Collection).to receive(:default_thumbnail?).and_return true
+          allow_any_instance_of(ThumbnailComponent).to receive(:thumbnail_url).and_return 'url.com/path/file'
+          visit resource_path(collection.uuid)
+        end
+
+        it 'does not display thumbnail' do
+          expect(page).not_to have_css("img[src='url.com/path/file']")
+          expect(page).not_to have_css('.thumbnail-card')
+        end
       end
 
-      it 'displays the thumbnail' do
-        expect(page).to have_css("img[src='url.com/path/file']")
-        expect(page).to have_css('.thumbnail-card')
+      context 'when collection#default_thumbnail? is false' do
+        before do
+          allow_any_instance_of(Collection).to receive(:default_thumbnail?).and_return false
+          allow_any_instance_of(ThumbnailComponent).to receive(:thumbnail_url).and_return 'url.com/path/file'
+          visit resource_path(collection.uuid)
+        end
+
+        it 'displays the thumbnail' do
+          expect(page).to have_css("img[src='url.com/path/file']")
+          expect(page).to have_css('.thumbnail-card')
+        end
       end
     end
 
@@ -303,15 +349,29 @@ RSpec.describe 'Public Resources', type: :feature do
       let(:collection) { create :collection }
 
       before do
-        allow_any_instance_of(Collection).to receive(:default_thumbnail?).and_return true
-        allow_any_instance_of(ThumbnailComponent).to receive(:display_thumbnail?).and_return true
-        allow_any_instance_of(ThumbnailComponent).to receive(:thumbnail_url).and_return 'url.com/path/file'
-        visit resource_path(collection.uuid)
+        allow_any_instance_of(ThumbnailComponent).to receive(:thumbnail_url).and_return nil
       end
 
-      it 'does not display thumbnail' do
-        expect(page).not_to have_css("img[src='url.com/path/file']")
-        expect(page).not_to have_css('.thumbnail-card')
+      context 'when collection#default_thumbnail? is true' do
+        before do
+          allow_any_instance_of(Collection).to receive(:default_thumbnail?).and_return true
+          visit resource_path(collection.uuid)
+        end
+
+        it 'does not display thumbnail' do
+          expect(page).not_to have_css('.thumbnail-image')
+        end
+      end
+
+      context 'when collection#default_thumbnail? is false' do
+        before do
+          allow_any_instance_of(Collection).to receive(:default_thumbnail?).and_return false
+          visit resource_path(collection.uuid)
+        end
+
+        it 'does not display thumbnail' do
+          expect(page).not_to have_css('.thumbnail-image')
+        end
       end
     end
   end

--- a/spec/models/collection_work_membership_spec.rb
+++ b/spec/models/collection_work_membership_spec.rb
@@ -34,4 +34,42 @@ RSpec.describe CollectionWorkMembership, type: :model do
       expect(second_one).not_to be_valid
     end
   end
+
+  describe 'after_create' do
+    context 'when the associated collection has just been created (does not have any collection_work_memberships)' do
+      let(:collection) { create :collection }
+      let(:work) { create :work }
+
+      context 'when the associated work has an auto_generated_thumbnail_url' do
+        it "updates the associated collection's thumbnail_selection to '#{ThumbnailSelections::AUTO_GENERATED}'}" do
+          allow_any_instance_of(Work).to receive(:auto_generated_thumbnail_url).and_return 'url.com/path/file'
+          expect(collection.thumbnail_selection).to eq ThumbnailSelections::DEFAULT_ICON
+          collection.attributes = {
+              "collection_work_memberships_attributes"=>{
+                  "0"=>{"work_id"=>"#{work.id}",
+                        "_destroy"=>"false",
+                        "position"=>"1"}
+              }
+          }
+          collection.save
+          expect(collection.reload.thumbnail_selection).to eq ThumbnailSelections::AUTO_GENERATED
+        end
+      end
+
+      context 'when the associated work does not have an auto_generated_thumbnail_url' do
+        it "the associated collection's thumbnail_selection remains as '#{ThumbnailSelections::DEFAULT_ICON}" do
+          expect(collection.thumbnail_selection).to eq ThumbnailSelections::DEFAULT_ICON
+          collection.attributes = {
+              "collection_work_memberships_attributes"=>{
+                  "0"=>{"work_id"=>"#{work.id}",
+                        "_destroy"=>"false",
+                        "position"=>"1"}
+              }
+          }
+          collection.save
+          expect(collection.reload.thumbnail_selection).to eq ThumbnailSelections::DEFAULT_ICON
+        end
+      end
+    end
+  end
 end

--- a/spec/models/collection_work_membership_spec.rb
+++ b/spec/models/collection_work_membership_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe CollectionWorkMembership, type: :model do
           allow_any_instance_of(Work).to receive(:auto_generated_thumbnail_url).and_return 'url.com/path/file'
           expect(collection.thumbnail_selection).to eq ThumbnailSelections::DEFAULT_ICON
           collection.attributes = {
-              "collection_work_memberships_attributes"=>{
-                  "0"=>{"work_id"=>"#{work.id}",
-                        "_destroy"=>"false",
-                        "position"=>"1"}
-              }
+            'collection_work_memberships_attributes' => {
+              '0' => { 'work_id' => work.id.to_s,
+                       '_destroy' => 'false',
+                       'position' => '1' }
+            }
           }
           collection.save
           expect(collection.reload.thumbnail_selection).to eq ThumbnailSelections::AUTO_GENERATED
@@ -60,15 +60,39 @@ RSpec.describe CollectionWorkMembership, type: :model do
         it "the associated collection's thumbnail_selection remains as '#{ThumbnailSelections::DEFAULT_ICON}" do
           expect(collection.thumbnail_selection).to eq ThumbnailSelections::DEFAULT_ICON
           collection.attributes = {
-              "collection_work_memberships_attributes"=>{
-                  "0"=>{"work_id"=>"#{work.id}",
-                        "_destroy"=>"false",
-                        "position"=>"1"}
-              }
+            'collection_work_memberships_attributes' => {
+              '0' => { 'work_id' => work.id.to_s,
+                       '_destroy' => 'false',
+                       'position' => '1' }
+            }
           }
           collection.save
           expect(collection.reload.thumbnail_selection).to eq ThumbnailSelections::DEFAULT_ICON
         end
+      end
+    end
+
+    context 'when the associated collection already has associated works' do
+      let(:collection) { create :collection }
+      let(:work) { create :work }
+
+      before do
+        collection.works << (create :work)
+        collection.save
+      end
+
+      it "the associated collection's thumbnail_selection remains as '#{ThumbnailSelections::DEFAULT_ICON}" do
+        allow_any_instance_of(Work).to receive(:auto_generated_thumbnail_url).and_return 'url.com/path/file'
+        expect(collection.thumbnail_selection).to eq ThumbnailSelections::DEFAULT_ICON
+        collection.attributes = {
+          'collection_work_memberships_attributes' => {
+            '0' => { 'work_id' => work.id.to_s,
+                     '_destroy' => 'false',
+                     'position' => '1' }
+          }
+        }
+        collection.save
+        expect(collection.reload.thumbnail_selection).to eq ThumbnailSelections::DEFAULT_ICON
       end
     end
   end

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -631,4 +631,44 @@ RSpec.describe WorkVersion, type: :model do
       end
     end
   end
+
+  describe '#set_thumbnail_selection' do
+    context 'when associated work does not have any published versions' do
+      let(:work) { create :work, has_draft: true }
+
+      before do
+        work.versions.last.file_resources << (create :file_resource)
+        work.versions.last.save
+      end
+
+      context 'when the work_version has a file_resource with a thumbnail_url' do
+        it "updates the work's thumbnail_selection to #{ThumbnailSelections::AUTO_GENERATED}" do
+          allow_any_instance_of(FileResource).to receive(:thumbnail_url).and_return 'url.com/path/file'
+          expect { work.versions.last.set_thumbnail_selection }
+            .to change { work.reload.thumbnail_selection }.to ThumbnailSelections::AUTO_GENERATED
+        end
+      end
+
+      context 'when the work_version has a file_resource without a thumbnail_url' do
+        it "doesn't update the work's thumbnail_selection" do
+          allow_any_instance_of(FileResource).to receive(:thumbnail_url).and_return nil
+          expect { work.versions.last.set_thumbnail_selection }.not_to(change { work.reload.thumbnail_selection })
+        end
+      end
+    end
+
+    context 'when associated work does have a published version' do
+      let(:work) { create :work, versions_count: 1, has_draft: false }
+
+      before do
+        work.versions.last.file_resources << (create :file_resource)
+        work.versions.last.save
+      end
+
+      it "doesn't update the work's thumbnail_selection" do
+        allow_any_instance_of(FileResource).to receive(:thumbnail_url).and_return 'url.com/path/file'
+        expect { work.versions.last.set_thumbnail_selection }.not_to(change { work.reload.thumbnail_selection })
+      end
+    end
+  end
 end


### PR DESCRIPTION
This was a little more complicated than I expected.  Since Works and Collections aren't created on a single form, I had to find a way to update the `thumbnail_selection`s at the right moment.  Also, generating thumbnail URLs in an asynchronous job added some more nuance to Works.  I also had to take into account that we don't want this happening every time someone edits a Collection or adds another version to a Work.  I used different patterns for Collections and Works.  I didn't want to stuff anything in the controllers, so I used the `after_save` hook in CollectionWorkMemberships to handle Collections.  However, I needed to put some code in the PublishController to handle Works properly.

I also realized that someone could delete a Work from a Collection or a Version from a Work containing their auto-generated thumbnail _after_ setting their `thumbnail_selection` to use the auto-generated thumbnail.  I added some logic in the `ThumbnailComponent` to display the generic icon in these instances.

closes #1281 