### PR TITLE
download, proccess, delete

### DIFF
--- a/app/jobs/shrine/signature_job.rb
+++ b/app/jobs/shrine/signature_job.rb
@@ -8,12 +8,14 @@ class Shrine::SignatureJob < ApplicationJob
     file_resource.with_lock do
       attacher = file_resource.file_attacher
       io = Shrine.uploaded_file(attacher.file_data)
+      tmp = io.download
       attacher.file.add_metadata(
-        'sha256' => Shrine.signature(io, :sha256),
-        'md5' => Shrine.signature(io, :md5)
+        'sha256' => Shrine.signature(tmp, :sha256),
+        'md5' => Shrine.signature(tmp, :md5)
       )
       attacher.write
       file_resource.save
+      tmp.delete
     end
   end
 end


### PR DESCRIPTION
Previously, io object was in memory -- for large files this was causing disk issues, this change downloads them to a tmp space, the we process on that file 