### PR TITLE
always test publish, run trivy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,9 @@ jobs:
           image: library/scholarsphere
           registry: harbor.k8s.libraries.psu.edu
       - run:
+          name: "Scan Image with Trivy"
           command: |
-            echo "Digest is: $(</tmp/digest.txt)"
+            trivy image --skip-dirs "/usr/local/lib/ruby" --exit-code 1 --ignore-unfixed --no-progress harbor.k8s.libraries.psu.edu/library/scholarsphere:$CIRCLE_SHA1
   deploy:
     docker:
       - image: harbor.k8s.libraries.psu.edu/library/ci-utils:$CI_UTILS_IMAGE_TAG
@@ -176,11 +177,6 @@ workflows:
       - publish:
           context: 
             - org-global
-          filters:
-            branches:
-              only:
-                - main
-                - /preview\/.*/
       - deploy:
           context: 
             - org-global


### PR DESCRIPTION
Adds a trivy step to CI, known vulnerabilities will fail a deployment. This is a bit heavy handed, and if it causes problems we can change the exit code parameter to 0