### PR TITLE
Doi api endpoint to return Work uuids for WorkVersions with dois

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -7,7 +7,7 @@ class Work < ApplicationRecord
   include GeneratedUuids
   include ThumbnailSelections
 
-  fields_with_dois :doi
+  fields_with_dois :doi, :latest_published_version_dois
 
   belongs_to :depositor,
              class_name: 'Actor',
@@ -206,6 +206,10 @@ class Work < ApplicationRecord
 
   def thumbnail_present?
     uploaded_thumbnail_url.present? || auto_generated_thumbnail_urls.present?
+  end
+
+  def latest_published_version_dois
+    latest_published_version.all_dois
   end
 
   private

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -287,12 +287,6 @@ class WorkVersion < ApplicationRecord
     super && latest_published_version?
   end
 
-  def all_dois
-    return [] if !latest_published_version? || (latest_published_version? && work.all_dois.any?)
-
-    super
-  end
-
   def set_thumbnail_selection
     # work.versions.published.blank? lets us know if the work has just been created
     if work.versions.published.blank? && file_resources.map(&:thumbnail_url).compact.present?
@@ -333,7 +327,6 @@ class WorkVersion < ApplicationRecord
         CreatorSchema,
         PublishedDateSchema,
         FacetSchema,
-        DoiSchema,
         TitleSchema,
         MemberFilesSchema
       )

--- a/spec/models/concerns/all_dois_spec.rb
+++ b/spec/models/concerns/all_dois_spec.rb
@@ -41,50 +41,10 @@ RSpec.describe AllDois do
   end
 
   describe '#all_dois' do
-    context 'when resource is not a WorkVersion' do
-      it 'filters all values returned by #fields_with_dois and returns canonical DOIs' do
-        expect(instance.all_dois).to match_array(['doi:10.18113/3ln3-2by1',
-                                                  'doi:10.1515/pol-2020-2011',
-                                                  'doi:10.1007/s10570-013-0029-x'])
-      end
-    end
-
-    context 'when resource is a WorkVersion' do
-      subject(:instance) { work.versions.last }
-
-      let!(:work) { create :work, versions_count: 2, has_draft: false }
-
-      before do
-        instance.update doi: '10.18113/s9k3-x5gh'
-      end
-
-      context 'when WorkVersion is not the lastest published version' do
-        before do
-          instance.update aasm_state: 'draft'
-        end
-
-        it 'returns an empty array' do
-          expect(instance.all_dois).to eq []
-        end
-      end
-
-      context 'when WorkVersion is the lastest published version' do
-        context "when WorkVersion's Work has a DOI" do
-          before do
-            instance.work.doi = '10.18113/44md-dj4'
-          end
-
-          it 'returns an empty array' do
-            expect(instance.all_dois).to eq []
-          end
-        end
-
-        context "when WorkVersion's Work does not have a DOI" do
-          it 'filters all values returned by #fields_with_dois and returns canonical DOIs' do
-            expect(instance.all_dois).to match_array(['doi:10.18113/s9k3-x5gh'])
-          end
-        end
-      end
+    it 'filters all values returned by #fields_with_dois and returns canonical DOIs' do
+      expect(instance.all_dois).to match_array(['doi:10.18113/3ln3-2by1',
+                                                'doi:10.1515/pol-2020-2011',
+                                                'doi:10.1007/s10570-013-0029-x'])
     end
   end
 end

--- a/spec/models/doi_search_spec.rb
+++ b/spec/models/doi_search_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe DoiSearch do
     it 'returns all unique DOIs in the index' do
       expect(described_class.all).to match(
         {
-          'doi:10.26207/rb4s-33xs' => [work_version_1.uuid],
+          'doi:10.26207/rb4s-33xs' => [work_version_1.work.uuid],
+          'doi:10.26207/jjd7-0is4' => [work_1.uuid],
           'doi:10.26207/upw2-pkx3' => [collection_1.uuid],
           'doi:10.18113/dmnf-6dzs' => a_collection_containing_exactly(work_1.uuid, collection_1.uuid),
           'doi:10.18113/qi03-b693' => [collection_2.uuid]
@@ -34,13 +35,13 @@ RSpec.describe DoiSearch do
       expect(described_class.new(doi: collection_2.doi).results)
         .to contain_exactly(collection_2.uuid)
 
-      # Find work version 1 because it is the latest published version and its work has no doi
+      # Find work version 1's work because it is the latest published version
       expect(described_class.new(doi: work_version_1.doi).results)
-        .to contain_exactly(work_version_1.uuid)
+        .to contain_exactly(work_version_1.work.uuid)
 
-      # Cannot find work version 2 because work 1 has a doi
+      # Find work 1 with work version 2's doi
       expect(described_class.new(doi: work_version_2.doi).results)
-        .to eq []
+        .to eq [work_1.uuid]
 
       # Find a collection, with non-canonical formatting
       expect(described_class.new(doi: 'https://doi.org/10.18113/qi03-b693').results)

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -555,6 +555,7 @@ RSpec.describe Work, type: :model do
              doi: '10.26207/utaj-jfhi',
              identifier: '10.26207/xyz-lmno'
     end
+
     before do
       work.versions << work_version
       work.save!

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Work, type: :model do
 
   it_behaves_like 'a resource with a deposited at timestamp'
 
-  it_behaves_like 'a resource that can provide all DOIs in', [:doi]
+  it_behaves_like 'a resource that can provide all DOIs in', [:doi, :latest_published_version_dois]
 
   it_behaves_like 'a resource with a thumbnail url' do
     let!(:work) { create :work, versions_count: 2 }
@@ -545,6 +545,23 @@ RSpec.describe Work, type: :model do
         expect(work.send(:auto_generated_thumbnail_urls).class).to eq Array
         expect(work.send(:auto_generated_thumbnail_urls).last).to eq 'url.com/path/file'
       end
+    end
+  end
+
+  describe '#latest_published_version_dois' do
+    let!(:work) { create :work }
+    let(:work_version) do
+      create :work_version, :published,
+             doi: '10.26207/utaj-jfhi',
+             identifier: '10.26207/xyz-lmno'
+    end
+    before do
+      work.versions << work_version
+      work.save!
+    end
+
+    it "returns an array of dois from the works's latest published version" do
+      expect(work.latest_published_version_dois).to eq([work_version.doi, work_version.identifier].flatten.collect { |n| 'doi:' + n })
     end
   end
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -562,7 +562,7 @@ RSpec.describe Work, type: :model do
     end
 
     it "returns an array of dois from the works's latest published version" do
-      expect(work.latest_published_version_dois).to eq([work_version.doi, work_version.identifier].flatten.collect { |n| 'doi:' + n })
+      expect(work.latest_published_version_dois).to eq([work_version.doi, work_version.identifier].flatten.map { |n| "doi:#{n}" })
     end
   end
 end

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -393,7 +393,6 @@ RSpec.describe WorkVersion, type: :model do
 
     its(:to_solr) do
       is_expected.to include(
-        all_dois_ssim: an_instance_of(Array),
         depositor_id_isi: work_version.work.depositor.id,
         discover_groups_ssim: [Group::PUBLIC_AGENT_NAME],
         discover_users_ssim: [],


### PR DESCRIPTION
DoiSchema removed from WorkVersion.  If a latest published work version has dois, they will be lumped with the associated work in the all dois solr query.