### PR TITLE
Using id for file_version_memberships, not file_resource_id

### DIFF
--- a/app/components/google_scholar_metadata_component.rb
+++ b/app/components/google_scholar_metadata_component.rb
@@ -36,7 +36,7 @@ class GoogleScholarMetadataComponent < ApplicationComponent
       .includes(:file_resource)
       .select { |f| f.mime_type == 'application/pdf' }
       .min
-      &.file_resource_id
+      &.id
   end
 
   private


### PR DESCRIPTION
@banukutlu Sorry I had one thing wrong with the last PR.  I'm not the owner for ScholarSphere so I need an approval before I can commit this.