### PR TITLE
Use `after_commit` instead of `after_save`

### DIFF
--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -72,7 +72,7 @@ class Actor < ApplicationRecord
             presence: true,
             unless: -> { psu_id.present? }
 
-  after_save :reindex_if_display_name_changed
+  after_commit :reindex_if_display_name_changed, on: [:create, :update]
 
   after_destroy :update_index_async
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -76,7 +76,7 @@ class Collection < ApplicationRecord
                                 allow_destroy: true
   after_initialize :set_defaults
 
-  after_save :perform_update_index
+  after_commit :perform_update_index, on: [:create, :update]
 
   after_destroy { SolrDeleteJob.perform_now(uuid) }
 

--- a/app/models/concerns/updating_dois.rb
+++ b/app/models/concerns/updating_dois.rb
@@ -6,7 +6,7 @@ module UpdatingDois
   included do
     attr_writer :update_doi
 
-    after_save :perform_update_doi
+    after_commit :perform_update_doi, on: [:create, :update]
   end
 
   def update_doi?

--- a/app/models/file_resource.rb
+++ b/app/models/file_resource.rb
@@ -19,7 +19,7 @@ class FileResource < ApplicationRecord
           required: false,
           dependent: :destroy
 
-  after_save :perform_update_index
+  after_commit :perform_update_index, on: [:create, :update]
 
   def self.reindex_all(relation: all, async: false)
     relation.find_each do |file|

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -167,7 +167,7 @@ class WorkVersion < ApplicationRecord
   validates_with ChangedWorkVersionValidator,
                  if: :published?
 
-  after_save :perform_update_index
+  after_commit :perform_update_index, on: [:create, :update]
 
   attr_accessor :force_destroy
 

--- a/spec/models/actor_spec.rb
+++ b/spec/models/actor_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Actor, type: :model do
     end
   end
 
-  describe 'after_save' do
+  describe 'after_commit' do
     let(:actor) { create :actor }
 
     before { allow(actor).to receive(:update_index_async) }


### PR DESCRIPTION
Swapped out `after_save`s with `after_commit`s.  The `after_save`s were kicking off jobs looking for records in the db that weren't yet committed — leading to a race condition.

The original intent behind using `after_save` may have been so the indexing was bundled in with the database transaction back when the indexing was not async?  Just a guess, but now that it's async I don't think it's useful bundling that all together.

The `updating_dois` one is a little different since it looks like it does more than just indexing.  However, it's still async and gets passed off the SideKiq.

closes #1125 