### PR TITLE
Split work type selection out into a separate step in deposit workflow

### DIFF
--- a/app/components/form_tabs_component.rb
+++ b/app/components/form_tabs_component.rb
@@ -30,6 +30,13 @@ class FormTabsComponent < ApplicationComponent
     def work_version_tabs
       [
         OpenStruct.new(
+          label: I18n.t('dashboard.form.tabs.work_version_type'),
+          url: links_enabled && dashboard_form_work_version_type_path(resource),
+          controller: 'work_version_type',
+          active: false,
+          classes: []
+        ),
+        OpenStruct.new(
           label: I18n.t('dashboard.form.tabs.work_version_details'),
           url: links_enabled && dashboard_form_work_version_details_path(resource),
           controller: 'work_version_details',

--- a/app/controllers/dashboard/form/work_version_type_controller.rb
+++ b/app/controllers/dashboard/form/work_version_type_controller.rb
@@ -2,9 +2,18 @@
 
 module Dashboard
   module Form
-    class WorkVersionDetailsController < BaseController
+    class WorkVersionTypeController < BaseController
       def self._prefixes
-        ['application', 'dashboard/form', 'dashboard/form/details']
+        ['application', 'dashboard/form', 'dashboard/form/type']
+      end
+
+      def new
+        @resource = WorkVersion.build_with_empty_work(depositor: current_user.actor)
+      end
+
+      def create
+        @resource = WorkVersion.build_with_empty_work(work_version_params, depositor: current_user.actor)
+        process_response(on_error: :new)
       end
 
       def edit
@@ -25,26 +34,16 @@ module Dashboard
           params
             .require(:work_version)
             .permit(
-              :description,
-              :publisher_statement,
-              :subtitle,
-              :rights,
-              :version_name,
-              :published_date,
-              keyword: [],
-              contributor: [],
-              publisher: [],
-              subject: [],
-              language: [],
-              identifier: [],
-              based_near: [],
-              related_url: [],
-              source: []
+              :title,
+              work_attributes: [
+                :id,
+                :work_type
+              ]
             )
         end
 
         def next_page_path
-          dashboard_form_contributors_path('work_version', @resource.id)
+          dashboard_form_work_version_details_path(@resource.id)
         end
     end
   end

--- a/app/views/dashboard/form/details/_work_version_fields.html.erb
+++ b/app/views/dashboard/form/details/_work_version_fields.html.erb
@@ -1,19 +1,5 @@
 <div class="form-wrapper form-wrapper--wide">
   <div class="keyline keyline--left mb-3">
-    <h4><%= t 'dashboard.form.details.required_metadata' %></h4>
-  </div>
-</div>
-
-<div class="form-wrapper">
-  <%= render 'form_fields/text', form: form, attribute: :title, required: true %>
-
-  <%= form.fields_for :work do |work_form| %>
-    <%= render 'form_fields/select', form: work_form, attribute: :work_type, options_for_select: Work::Types.options_for_select_box %>
-  <% end %>
-</div>
-
-<div class="form-wrapper form-wrapper--wide">
-  <div class="keyline keyline--left mb-3">
     <h4><%= t 'dashboard.form.details.required_to_publish_metadata' %></h4>
   </div>
 </div>

--- a/app/views/dashboard/form/publish/edit.html.erb
+++ b/app/views/dashboard/form/publish/edit.html.erb
@@ -23,6 +23,7 @@
                   heading: t('.error_message', error: pluralize(form.object.errors.count, 'issue'))
                 ) %>
 
+            <%= render 'dashboard/form/type/work_version_fields', form: form %>
             <%= render 'dashboard/form/details/work_version_fields', form: form %>
 
             <%= render 'dashboard/form/contributors/creators', form: form, resource_klass: 'work_version' %>

--- a/app/views/dashboard/form/type/_form.html.erb
+++ b/app/views/dashboard/form/type/_form.html.erb
@@ -1,0 +1,8 @@
+<%= form_with(model: @resource, url: url, local: true, data: { target: 'unsaved-changes.form' }) do |form| %>
+
+  <%= render FormErrorMessageComponent.new(form: form) %>
+
+  <%= render "#{param_key}_fields", form: form %>
+
+  <%= render 'dashboard/form/shared/action_footer', form: form %>
+<% end %>

--- a/app/views/dashboard/form/type/_work_version_fields.html.erb
+++ b/app/views/dashboard/form/type/_work_version_fields.html.erb
@@ -1,0 +1,13 @@
+<div class="form-wrapper form-wrapper--wide">
+  <div class="keyline keyline--left mb-3">
+    <h4><%= t 'dashboard.form.details.required_metadata' %></h4>
+  </div>
+</div>
+
+<div class="form-wrapper">
+  <%= render 'form_fields/text', form: form, attribute: :title, required: true %>
+
+  <%= form.fields_for :work do |work_form| %>
+    <%= render 'form_fields/select', form: work_form, attribute: :work_type, options_for_select: Work::Types.options_for_select_box %>
+  <% end %>
+</div>

--- a/app/views/dashboard/form/type/edit.html.erb
+++ b/app/views/dashboard/form/type/edit.html.erb
@@ -1,0 +1,14 @@
+<div class="container">
+  <div class="row">
+    <div class="col" data-controller="unsaved-changes" data-unsaved-changes-prompt="<%= t 'dashboard.form.unsaved_changes_prompt' %>">
+      <h4 class="text-center mb-4"><%= t("dashboard.form.heading.#{param_key}.edit") %></h4>
+
+      <%= render FormTabsComponent.new(resource: @resource, current_controller: controller_name) %>
+
+      <div class="tab-content">
+        <div class="tab-pane active show">
+          <%= render 'form', url: send("dashboard_form_#{param_key}_type_path", @resource) %>
+        </div>
+      </div>
+    </div>
+</div>

--- a/app/views/dashboard/form/type/new.html.erb
+++ b/app/views/dashboard/form/type/new.html.erb
@@ -1,0 +1,13 @@
+<div class="container">
+  <div class="row">
+    <div class="col">
+      <h4 class="text-center mb-4"><%= t("dashboard.form.heading.#{param_key}.new") %></h4>
+      <%= render FormTabsComponent.new(resource: @resource, current_controller: controller_name) %>
+
+      <div class="tab-content">
+        <div class="tab-pane active show">
+          <%= render 'form', url: send("dashboard_form_#{@resource.model_name.plural}_path") %>
+        </div>
+      </div>
+    </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -367,6 +367,7 @@ en:
           new: "Create New Collection"
           edit: "Edit Collection"
       tabs:
+        work_version_type: Work Type
         work_version_details: Work Details
         collection_details: Collection Details
         contributors: Contributors

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,8 +112,11 @@ Rails.application.routes.draw do
 
     namespace :form do
       scope 'work_versions' do
-        get   'new', to: 'work_version_details#new', as: 'work_versions'
-        match 'new', to: 'work_version_details#create', via: :post, as: nil
+        get   'new', to: 'work_version_type#new', as: 'work_versions'
+        match 'new', to: 'work_version_type#create', via: :post, as: nil
+
+        get   ':id/type', to: 'work_version_type#edit', as: 'work_version_type'
+        match ':id/type', to: 'work_version_type#update', via: %i[patch put], as: nil
 
         get   ':id/details', to: 'work_version_details#edit', as: 'work_version_details'
         match ':id/details', to: 'work_version_details#update', via: %i[patch put], as: nil

--- a/spec/components/form_tabs_component_spec.rb
+++ b/spec/components/form_tabs_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe FormTabsComponent, type: :component do
 
     it 'does NOT render the tabs as links' do
       expect(tabs.css('a')).to be_empty
-      expect(tabs.css('.nav-item.disabled').length).to eq 4
+      expect(tabs.css('.nav-item.disabled').length).to eq 5
     end
 
     it "renders the current controller's tab as active" do
@@ -25,7 +25,7 @@ RSpec.describe FormTabsComponent, type: :component do
     let(:resource) { build_stubbed :work_version }
 
     it 'renders the inactive tabs as links' do
-      expect(tabs.css('a.nav-item').length).to eq 3
+      expect(tabs.css('a.nav-item').length).to eq 4
       expect(tabs.css('a.nav-item').map(&:text)).not_to include(I18n.t!('dashboard.form.tabs.work_version_details'))
     end
 

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         visit dashboard_form_work_versions_path
 
+        FeatureHelpers::DashboardForm.fill_in_minimal_work_details_for_draft(metadata)
+        FeatureHelpers::DashboardForm.save_and_continue
         FeatureHelpers::DashboardForm.fill_in_work_details(metadata)
         FeatureHelpers::DashboardForm.save_and_continue
 
@@ -77,6 +79,8 @@ RSpec.describe 'Publishing a work', with_user: :user do
       it 'returns to the resource page' do
         visit dashboard_form_work_versions_path
 
+        FeatureHelpers::DashboardForm.fill_in_minimal_work_details_for_draft(metadata)
+        FeatureHelpers::DashboardForm.save_and_continue
         FeatureHelpers::DashboardForm.fill_in_work_details(metadata)
         FeatureHelpers::DashboardForm.save_and_continue
 
@@ -95,7 +99,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
       it 'creates a new work with all fields provided' do
         initial_work_count = Work.count
 
-        visit dashboard_form_work_version_details_path(work_version)
+        visit dashboard_form_work_version_type_path(work_version)
 
         FeatureHelpers::DashboardForm.fill_in_minimal_work_details_for_draft(metadata)
         FeatureHelpers::DashboardForm.save_as_draft_and_exit
@@ -111,8 +115,10 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
     context 'when saving and_continuing' do
       it 'creates a new work with all fields provided' do
-        visit dashboard_form_work_version_details_path(work_version)
+        visit dashboard_form_work_version_type_path(work_version)
 
+        FeatureHelpers::DashboardForm.fill_in_minimal_work_details_for_draft(metadata)
+        FeatureHelpers::DashboardForm.save_and_continue
         FeatureHelpers::DashboardForm.fill_in_work_details(metadata)
         FeatureHelpers::DashboardForm.save_and_continue
 
@@ -134,13 +140,13 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(work_version.source).to eq [metadata[:source]]
 
         expect(page).to have_current_path(dashboard_form_contributors_path('work_version', work_version))
-        expect(SolrIndexingJob).to have_received(:perform_later).once
+        expect(SolrIndexingJob).to have_received(:perform_later).twice
       end
     end
 
     context 'when navigating away from unsaved changes', js: true do
       it 'warns the user' do
-        visit dashboard_form_work_version_details_path(work_version)
+        visit dashboard_form_work_version_type_path(work_version)
 
         fill_in 'work_version_title', with: "Changed #{metadata[:title]}"
 
@@ -148,7 +154,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
           click_on I18n.t!('dashboard.form.tabs.contributors')
         end
 
-        expect(page).to have_current_path(dashboard_form_work_version_details_path(work_version))
+        expect(page).to have_current_path(dashboard_form_work_version_type_path(work_version))
 
         accept_confirm(I18n.t!('dashboard.form.unsaved_changes_prompt')) do
           click_on I18n.t!('dashboard.form.tabs.contributors')
@@ -519,6 +525,8 @@ RSpec.describe 'Publishing a work', with_user: :user do
     it 'routes the user through the workflow' do
       visit dashboard_form_work_versions_path
 
+      FeatureHelpers::DashboardForm.fill_in_minimal_work_details_for_draft(metadata)
+      FeatureHelpers::DashboardForm.save_and_continue
       FeatureHelpers::DashboardForm.fill_in_work_details(metadata)
       FeatureHelpers::DashboardForm.save_and_continue
 
@@ -547,6 +555,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
       # On the review page, change all the details metadata to ensure the params
       # are submitted correctly
       expect_any_instance_of(WorkVersion).to receive(:set_thumbnail_selection).once
+      FeatureHelpers::DashboardForm.fill_in_minimal_work_details_for_draft(different_metadata)
       FeatureHelpers::DashboardForm.fill_in_work_details(different_metadata)
       FeatureHelpers::DashboardForm.fill_in_publishing_details(metadata)
       FeatureHelpers::DashboardForm.publish
@@ -588,6 +597,8 @@ RSpec.describe 'Publishing a work', with_user: :user do
     it 'routes the user through the workflow' do
       visit dashboard_form_work_versions_path
 
+      FeatureHelpers::DashboardForm.fill_in_minimal_work_details_for_draft(metadata)
+      FeatureHelpers::DashboardForm.save_and_continue
       FeatureHelpers::DashboardForm.fill_in_work_details(metadata)
       FeatureHelpers::DashboardForm.save_and_continue
 
@@ -604,6 +615,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
       # On the review page, change all the details metadata to ensure the params
       # are submitted correctly
+      FeatureHelpers::DashboardForm.fill_in_minimal_work_details_for_draft(different_metadata)
       FeatureHelpers::DashboardForm.fill_in_work_details(different_metadata)
 
       # Pick the wrong license

--- a/spec/support/feature_helpers/dashboard_form.rb
+++ b/spec/support/feature_helpers/dashboard_form.rb
@@ -10,8 +10,6 @@ module FeatureHelpers
     end
 
     def self.fill_in_work_details(work_version_metadata)
-      fill_in_minimal_work_details_for_draft(work_version_metadata)
-
       fill_in 'work_version_description', with: work_version_metadata[:description]
       fill_in 'work_version_publisher_statement', with: work_version_metadata[:publisher_statement]
       fill_in 'work_version_published_date', with: work_version_metadata[:published_date]


### PR DESCRIPTION
A couple of decisions that I made here that weren't explicitly discussed:

cc @bdezray 

1. Instead of pulling just the work type selection out into its own step in the deposit workflow, I pulled out the whole "required metadata" section of the original form which includes the title as well. I did this because it was the cleaner/easier thing to do, and because I think that it makes sense - every type of work needs to have a title.
2. The link for editing an existing work took you to the form for editing all of the work details/metadata since that used to be the first step in the deposit workflow. Now the first step is title and work type editing, and all of the rest of the metadata is still in the original form (which is now the second step in the workflow). I left the edit link so that it still takes you to the form with the bulk of the metadata in the second step instead of updating it to take you to the new form in the first step. My reasoning is that if someone is editing a work, I assume that it's a lot less likely that they would be editing the title or the work type and much more likely that they'd be editing some other bit of metadata. If that assumption is wrong, or if that's just now how we want it to work, then I can change that.