### PR TITLE
Only render matomo code in production environment

### DIFF
--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -15,22 +15,24 @@
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
 
-    <!-- Matomo -->
-    <script type="text/javascript">
-      var _paq = window._paq || [];
-      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-      _paq.push(['trackPageView']);
-      _paq.push(['setSecureCookie', true]);
-      _paq.push(['enableLinkTracking']);
-      (function() {
-        var u = "<%= ENV.fetch('MATOMO_URL', 'https://analytics.libraries.psu.edu/matomo/') %>";
-        _paq.push(['setTrackerUrl', u+'matomo.php']);
-        _paq.push(['setSiteId', '<%= ENV.fetch('MATOMO_SITE_ID', '18') %>']);
-        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-      })();
-    </script>
-    <!-- End Matomo Code -->
+    <% if Rails.env.production? || (Rails.env.test? && ENV['MATOMO_TEST']) %>
+      <!-- Matomo -->
+      <script type="text/javascript">
+        var _paq = window._paq || [];
+        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+        _paq.push(['trackPageView']);
+        _paq.push(['setSecureCookie', true]);
+        _paq.push(['enableLinkTracking']);
+        (function() {
+          var u = "<%= ENV.fetch('MATOMO_URL', 'https://analytics.libraries.psu.edu/matomo/') %>";
+          _paq.push(['setTrackerUrl', u+'matomo.php']);
+          _paq.push(['setSiteId', '<%= ENV.fetch('MATOMO_SITE_ID', '18') %>']);
+          var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+          g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+        })();
+      </script>
+      <!-- End Matomo Code -->
+    <% end %>
   </head>
 
   <body <%= yield :body_attributes %>>

--- a/spec/features/matomo_spec.rb
+++ b/spec/features/matomo_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'Matomo Traking Code' do
   end
 
   after do
+    ENV.delete("MATOMO_TEST")
     Capybara.ignore_hidden_elements = true
-    ENV.reject! { |k, _v| k == 'MATOMO_TEST' }
   end
 
   it 'has the default configuration' do

--- a/spec/features/matomo_spec.rb
+++ b/spec/features/matomo_spec.rb
@@ -3,9 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe 'Matomo Traking Code' do
-  before { Capybara.ignore_hidden_elements = false }
+  before do
+    ENV['MATOMO_TEST'] = 'true'
+    Capybara.ignore_hidden_elements = false
+  end
 
-  after { Capybara.ignore_hidden_elements = true }
+  after do
+    Capybara.ignore_hidden_elements = true
+    ENV.reject! { |k, _v| k == 'MATOMO_TEST' }
+  end
 
   it 'has the default configuration' do
     visit(blacklight_path)

--- a/spec/features/matomo_spec.rb
+++ b/spec/features/matomo_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Matomo Traking Code' do
   end
 
   after do
-    ENV.delete("MATOMO_TEST")
+    ENV.delete('MATOMO_TEST')
     Capybara.ignore_hidden_elements = true
   end
 


### PR DESCRIPTION
Matomo was blowing up our test suite in CI with a `Net::ReadTimeout` error.  The matomo code does not need rendered in any environment outside of production, so I wrapped the code in some logic to reflect that.