### PR TITLE
Remove Trivy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,6 @@ jobs:
           digest-path: /tmp/digest.txt
           image: library/scholarsphere
           registry: harbor.k8s.libraries.psu.edu
-      - run:
-          name: "Scan Image with Trivy"
-          command: |
-            trivy image --skip-dirs "/usr/local/lib/ruby" --exit-code 0 --ignore-unfixed --no-progress harbor.k8s.libraries.psu.edu/library/scholarsphere:$CIRCLE_SHA1
   deploy:
     docker:
       - image: harbor.k8s.libraries.psu.edu/library/ci-utils:$CI_UTILS_IMAGE_TAG


### PR DESCRIPTION
trivy was causing problems in CI & hasn't been run for a long time anyway, so we're removing it