### PR TITLE
adds matomo_download class

### DIFF
--- a/app/views/shared/_work_version_files.html.erb
+++ b/app/views/shared/_work_version_files.html.erb
@@ -9,6 +9,7 @@
           <h3>
             <%= link_to resource_download_path(file.id, resource_id: work_version.uuid),
                         title: t('resources.download', name: file.title),
+                        class: 'matomo_download',
                         rel: 'nofollow' do %>
               <%= file.title %>
             <% end %>


### PR DESCRIPTION
Adds `matomo_download` to the download button so that matomo tracks as a download.