### PR TITLE
unpin imagemagick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ USER root
 RUN apt-get update && \
    apt-get install --no-install-recommends -y \
    shared-mime-info \
-   imagemagick=8:6.9.10.23+dfsg-2.1+deb10u5 \
+   imagemagick \
    ghostscript\
    libreoffice && \
    rm -rf /var/lib/apt/lists*


### PR DESCRIPTION
this version of imagemagick is no longer available in apt repositories, we don't pin in CI, we can always re-pin if we run into issues.