### PR TITLE
fix draft_curation_request bug

### DIFF
--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -53,7 +53,6 @@ module Dashboard
             logger.error(e)
             flash[:error] = t('dashboard.form.publish.curation.error')
           ensure
-            @resource.update_column(:draft_curation_requested, false)
             @resource.aasm_state = initial_state
           end
         end

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -1154,7 +1154,10 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         click_on 'Request Curation & Save as Draft'
 
+        work_version.reload
+
         expect(CurationTaskExporter).to have_received(:call).with(work_version.id)
+        expect(work_version.draft_curation_requested).to be true
       end
     end
 
@@ -1180,6 +1183,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         work_version.reload
         expect(work_version.title).to eq('Changed Title')
+        expect(work_version.draft_curation_requested).not_to be true
       end
     end
 


### PR DESCRIPTION
During the go script work, I realized users could still publish after requesting draft curation. By setting `draft_curation_requested` to false in the ensure block, it could never update to true & buttons for publish & request curation were always rendered. If I remember correctly, the initial idea for having it there was for error handling, but I think rescuing the CurationError does an adequate job of handling that scenario.