### PR TITLE
Remove identifier field from work metadata form in data & code pathway

### DIFF
--- a/app/forms/work_deposit_pathway.rb
+++ b/app/forms/work_deposit_pathway.rb
@@ -60,7 +60,6 @@ class WorkDepositPathway
         subtitle
         keyword
         publisher
-        identifier
         related_url
         subject
         language
@@ -130,6 +129,7 @@ class WorkDepositPathway
           WorkVersionFormBase::COMMON_FIELDS.union(
             %w{
               publisher_statement
+              identifier
               based_near
               source
               version_name
@@ -152,6 +152,7 @@ class WorkDepositPathway
           WorkVersionFormBase::COMMON_FIELDS.union(
             %w{
               publisher_statement
+              identifier
             }
           ).freeze
         end

--- a/app/views/dashboard/form/details/_common_work_version_optional_fields.html.erb
+++ b/app/views/dashboard/form/details/_common_work_version_optional_fields.html.erb
@@ -1,5 +1,4 @@
   <%= render 'form_fields/multi_text', form: form, attribute: :keyword %>
-  <%= render 'form_fields/multi_text', form: form, attribute: :publisher %>
   <%= render 'form_fields/multi_text', form: form, attribute: :related_url %>
   <%= render 'form_fields/multi_text', form: form, attribute: :subject %>
   <%= render 'form_fields/multi_text', form: form, attribute: :language %>

--- a/app/views/dashboard/form/details/_common_work_version_optional_fields.html.erb
+++ b/app/views/dashboard/form/details/_common_work_version_optional_fields.html.erb
@@ -1,6 +1,5 @@
   <%= render 'form_fields/multi_text', form: form, attribute: :keyword %>
   <%= render 'form_fields/multi_text', form: form, attribute: :publisher %>
-  <%= render 'form_fields/multi_text', form: form, attribute: :identifier %>
   <%= render 'form_fields/multi_text', form: form, attribute: :related_url %>
   <%= render 'form_fields/multi_text', form: form, attribute: :subject %>
   <%= render 'form_fields/multi_text', form: form, attribute: :language %>

--- a/app/views/dashboard/form/details/_data_and_code_work_version_fields.html.erb
+++ b/app/views/dashboard/form/details/_data_and_code_work_version_fields.html.erb
@@ -2,6 +2,7 @@
 
 <div class="form-wrapper">
   <%= render 'form_fields/text', form: form, attribute: :subtitle %>
+  <%= render 'form_fields/multi_text', form: form, attribute: :publisher %>
   <%= render 'dashboard/form/details/common_work_version_optional_fields', form: form %>
   <%= render 'form_fields/multi_text', form: form, attribute: :based_near %>
   <%= render 'form_fields/multi_text', form: form, attribute: :source %>

--- a/app/views/dashboard/form/details/_scholarly_works_work_version_fields.html.erb
+++ b/app/views/dashboard/form/details/_scholarly_works_work_version_fields.html.erb
@@ -3,5 +3,6 @@
 <div class="form-wrapper">
   <%= render 'form_fields/text', form: form, attribute: :subtitle %>
   <%= render 'form_fields/text_area', form: form, attribute: :publisher_statement %>
+  <%= render 'form_fields/multi_text', form: form, attribute: :identifier %>
   <%= render 'dashboard/form/details/common_work_version_optional_fields', form: form %>
 </div>

--- a/app/views/dashboard/form/details/_scholarly_works_work_version_fields.html.erb
+++ b/app/views/dashboard/form/details/_scholarly_works_work_version_fields.html.erb
@@ -2,6 +2,7 @@
 
 <div class="form-wrapper">
   <%= render 'form_fields/text', form: form, attribute: :subtitle %>
+  <%= render 'form_fields/multi_text', form: form, attribute: :publisher %>
   <%= render 'form_fields/text_area', form: form, attribute: :publisher_statement %>
   <%= render 'form_fields/multi_text', form: form, attribute: :identifier %>
   <%= render 'dashboard/form/details/common_work_version_optional_fields', form: form %>

--- a/app/views/dashboard/form/details/_work_version_fields.html.erb
+++ b/app/views/dashboard/form/details/_work_version_fields.html.erb
@@ -2,6 +2,7 @@
 
 <div class="form-wrapper">
   <%= render 'form_fields/text', form: form, attribute: :subtitle %>
+  <%= render 'form_fields/multi_text', form: form, attribute: :publisher %>
   <%= render 'form_fields/text_area', form: form, attribute: :publisher_statement %>
   <%= render 'form_fields/multi_text', form: form, attribute: :identifier %>
   <%= render 'dashboard/form/details/common_work_version_optional_fields', form: form %>

--- a/app/views/dashboard/form/details/_work_version_fields.html.erb
+++ b/app/views/dashboard/form/details/_work_version_fields.html.erb
@@ -3,6 +3,7 @@
 <div class="form-wrapper">
   <%= render 'form_fields/text', form: form, attribute: :subtitle %>
   <%= render 'form_fields/text_area', form: form, attribute: :publisher_statement %>
+  <%= render 'form_fields/multi_text', form: form, attribute: :identifier %>
   <%= render 'dashboard/form/details/common_work_version_optional_fields', form: form %>
   <%= render 'form_fields/multi_text', form: form, attribute: :based_near %>
   <%= render 'form_fields/multi_text', form: form, attribute: :source %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,7 @@ en:
         email: Email
         psu_id: Access Account
         orcid: ORCiD
-      work_version:
+      work_version: &work_version_attributes
         title: Work Title
         version_name: Semantic Version
         subtitle: Subtitle
@@ -109,6 +109,7 @@ en:
         psu_id: Access Account
       curator_form:
         access_id: Access Account
+      work_version: *work_version_attributes
     errors:
       models:
         editors_form:

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -81,4 +81,8 @@ FactoryBot.define do
   trait(:article) do
     work_type { 'article' }
   end
+
+  trait(:general) do
+    work_type { 'audio' }
+  end
 end

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -252,6 +252,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         FeatureHelpers::DashboardForm.save_and_continue
 
         expect(page).not_to have_field('publisher_statement')
+        expect(page).not_to have_field('work_version_identifier')
       end
 
       context 'when saving as draft and exiting' do
@@ -306,7 +307,6 @@ RSpec.describe 'Publishing a work', with_user: :user do
           expect(new_work_version.subject).to eq [metadata[:subject]]
           expect(new_work_version.language).to eq [metadata[:language]]
           expect(new_work_version.related_url).to eq [metadata[:related_url]]
-          expect(new_work_version.identifier).to eq [metadata[:identifier]]
 
           expect(page).to have_current_path(dashboard_form_contributors_path('work_version', new_work_version))
           expect(SolrIndexingJob).to have_received(:perform_later).at_least(:twice)
@@ -839,6 +839,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(page).to have_field('work_version_source')
         expect(page).to have_field('work_version_version_name')
         expect(page).not_to have_field('work_version_publisher_statement')
+        expect(page).not_to have_field('work_version_identifier')
         expect(page).not_to have_field('work_version_work_attributes_visibility_open')
         expect(page).not_to have_field('work_version_work_attributes_visibility_authenticated')
       end

--- a/spec/features/edit_multiple_fields_spec.rb
+++ b/spec/features/edit_multiple_fields_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Editing multiple fields' do
   let(:user) { create(:user) }
-  let(:work) { create(:work, depositor: user.actor, has_draft: true) }
+  let(:work) { create(:work, :general, depositor: user.actor, has_draft: true) }
   let(:attributes_1) { attributes_for(:work_version, :with_complete_metadata) }
   let(:attributes_2) { attributes_for(:work_version, :with_complete_metadata) }
 

--- a/spec/forms/work_deposit_pathways/data_and_code/details_form_spec.rb
+++ b/spec/forms/work_deposit_pathways/data_and_code/details_form_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe WorkDepositPathway::DataAndCode::DetailsForm, type: :model do
         'subtitle' => 'test subtitle',
         'keyword' => 'test keyword',
         'publisher' => 'test publisher',
-        'identifier' => 'test identifier',
         'related_url' => 'test related_url',
         'subject' => 'test subject',
         'language' => 'test language',
@@ -40,7 +39,6 @@ RSpec.describe WorkDepositPathway::DataAndCode::DetailsForm, type: :model do
         subtitle
         keyword
         publisher
-        identifier
         related_url
         subject
         language
@@ -68,7 +66,6 @@ RSpec.describe WorkDepositPathway::DataAndCode::DetailsForm, type: :model do
           subtitle: 'test subtitle',
           keyword: ['test keyword'],
           publisher: ['test publisher'],
-          identifier: ['test identifier'],
           related_url: ['test related_url'],
           subject: ['test subject'],
           language: ['test language'],

--- a/spec/forms/work_deposit_pathways/data_and_code/publish_form_spec.rb
+++ b/spec/forms/work_deposit_pathways/data_and_code/publish_form_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe WorkDepositPathway::DataAndCode::PublishForm, type: :model do
         'publisher_statement' => 'test publisher_statement',
         'keyword' => 'test keyword',
         'publisher' => 'test publisher',
-        'identifier' => 'test identifier',
         'related_url' => 'test related_url',
         'subject' => 'test subject',
         'language' => 'test language',
@@ -99,7 +98,6 @@ RSpec.describe WorkDepositPathway::DataAndCode::PublishForm, type: :model do
         subtitle
         keyword
         publisher
-        identifier
         related_url
         subject
         language
@@ -125,7 +123,6 @@ RSpec.describe WorkDepositPathway::DataAndCode::PublishForm, type: :model do
           subtitle: 'test subtitle',
           keyword: ['test keyword'],
           publisher: ['test publisher'],
-          identifier: ['test identifier'],
           related_url: ['test related_url'],
           subject: ['test subject'],
           language: ['test language'],

--- a/spec/support/feature_helpers/dashboard_form.rb
+++ b/spec/support/feature_helpers/dashboard_form.rb
@@ -29,11 +29,11 @@ module FeatureHelpers
       fill_in 'work_version_subject', with: work_version_metadata[:subject]
       fill_in 'work_version_language', with: work_version_metadata[:language]
       fill_in 'work_version_related_url', with: work_version_metadata[:related_url]
-      fill_in 'work_version_identifier', with: work_version_metadata[:identifier]
     end
 
     def self.fill_in_work_details(work_version_metadata)
       fill_in_common_work_details(work_version_metadata)
+      fill_in 'work_version_identifier', with: work_version_metadata[:identifier]
       fill_in 'work_version_publisher_statement', with: work_version_metadata[:publisher_statement]
       fill_in 'work_version_based_near', with: work_version_metadata[:based_near]
       fill_in 'work_version_source', with: work_version_metadata[:source]
@@ -47,6 +47,7 @@ module FeatureHelpers
 
     def self.fill_in_scholarly_works_work_details(work_version_metadata)
       fill_in_common_work_details(work_version_metadata)
+      fill_in 'work_version_identifier', with: work_version_metadata[:identifier]
       fill_in 'work_version_publisher_statement', with: work_version_metadata[:publisher_statement]
     end
 


### PR DESCRIPTION
Fixes https://github.com/psu-libraries/scholarsphere/issues/1508

One thing to note here:  I rearranged the order of the optional work version metadata form fields slightly since that was the easiest thing to do. I don't know if that matters. If anyone thinks that the order of the fields should stay the same as it was before, I can do that - it'll just take a little more tweaking.