### PR TITLE
Restore admin ability to change visibility for all work types

### DIFF
--- a/app/controllers/dashboard/works_controller.rb
+++ b/app/controllers/dashboard/works_controller.rb
@@ -38,7 +38,7 @@ module Dashboard
 
       def initialize_forms
         @work = WorkDecorator.new(@undecorated_work)
-        @work.attributes = work_params if deposit_pathway.allows_visibility_change?
+        @work.attributes = work_params if policy(@work).edit_visibility?
 
         @embargo_form = EmbargoForm.new(work: @undecorated_work, params: embargo_params)
         @editors_form = EditorsForm.new(resource: @undecorated_work, user: current_user, params: editors_params)

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -59,6 +59,6 @@ class WorkPolicy < ApplicationPolicy
     end
 
     def deposit_pathway
-      @pathway ||= WorkDepositPathway.new(record)
+      @deposit_pathway ||= WorkDepositPathway.new(record)
     end
 end

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -31,7 +31,7 @@ class WorkPolicy < ApplicationPolicy
   def edit_visibility?
     return true if user.admin?
 
-    (editable? && !published?) || (editable? && !open_access?)
+    ((editable? && !published?) || (editable? && !open_access?)) && deposit_pathway.allows_visibility_change?
   end
 
   private
@@ -56,5 +56,9 @@ class WorkPolicy < ApplicationPolicy
 
     def open_access?
       record.open_access?
+    end
+
+    def deposit_pathway
+      @pathway ||= WorkDepositPathway.new(record)
     end
 end

--- a/app/views/dashboard/works/edit.html.erb
+++ b/app/views/dashboard/works/edit.html.erb
@@ -70,7 +70,7 @@
         <h2 id="<%= t('.visibility.heading').parameterize %>" class="h4"><%= t('.visibility.heading') %></h2>
       </div>
 
-      <% if policy(@work).edit_visibility? && deposit_pathway.allows_visibility_change? %>
+      <% if policy(@work).edit_visibility? %>
         <p><%= t('.visibility.explanation') %></p>
 
         <%- visibility_form_id = "edit_visibility_#{dom_id @work}" %>

--- a/spec/policies/work_policy_spec.rb
+++ b/spec/policies/work_policy_spec.rb
@@ -196,79 +196,166 @@ RSpec.describe WorkPolicy, type: :policy do
   end
 
   permissions :edit_visibility? do
-    context 'when the work is draft' do
-      let(:work) do
-        create :work,
-               has_draft: true,
-               versions_count: 1,
-               depositor: depositor_actor,
-               proxy_depositor: proxy_actor,
-               discover_users: [discover_user],
-               edit_users: [edit_user]
+    let(:pathway) { instance_double WorkDepositPathway, allows_visibility_change?: change_allowed }
+    before { allow(WorkDepositPathway).to receive(:new).with(work).and_return pathway }
+
+    context 'when the deposit pathway for the work allows visibility to be changed' do
+      let(:change_allowed) { true }
+
+      context 'when the work is draft' do
+        let(:work) do
+          create :work,
+                 has_draft: true,
+                 versions_count: 1,
+                 depositor: depositor_actor,
+                 proxy_depositor: proxy_actor,
+                 discover_users: [discover_user],
+                 edit_users: [edit_user]
+        end
+
+        context 'when the work is Open access' do
+          before { work.grant_open_access }
+
+          it { is_expected.to permit(depositor, work) }
+          it { is_expected.to permit(proxy, work) }
+          it { is_expected.to permit(edit_user, work) }
+          it { is_expected.not_to permit(discover_user, work) }
+          it { is_expected.not_to permit(other_user, work) }
+          it { is_expected.not_to permit(public, work) }
+          it { is_expected.to permit(admin, work) }
+          it { is_expected.to permit(application, work) }
+        end
+
+        context 'when the work is Penn State Only' do
+          before { work.grant_authorized_access }
+
+          it { is_expected.to permit(depositor, work) }
+          it { is_expected.to permit(proxy, work) }
+          it { is_expected.to permit(edit_user, work) }
+          it { is_expected.not_to permit(discover_user, work) }
+          it { is_expected.not_to permit(other_user, work) }
+          it { is_expected.not_to permit(public, work) }
+          it { is_expected.to permit(admin, work) }
+          it { is_expected.to permit(application, work) }
+        end
       end
 
-      context 'when the work is Open access' do
-        before { work.grant_open_access }
+      context 'when the work is published' do
+        let(:work) do
+          create :work,
+                 has_draft: false,
+                 versions_count: 1,
+                 depositor: depositor_actor,
+                 proxy_depositor: proxy_actor,
+                 discover_users: [discover_user],
+                 edit_users: [edit_user]
+        end
 
-        it { is_expected.to permit(depositor, work) }
-        it { is_expected.to permit(proxy, work) }
-        it { is_expected.to permit(edit_user, work) }
-        it { is_expected.not_to permit(discover_user, work) }
-        it { is_expected.not_to permit(other_user, work) }
-        it { is_expected.not_to permit(public, work) }
-        it { is_expected.to permit(admin, work) }
-        it { is_expected.to permit(application, work) }
-      end
+        context 'when the work is Open access' do
+          before { work.grant_open_access }
 
-      context 'when the work is Penn State Only' do
-        before { work.grant_authorized_access }
+          it { is_expected.not_to permit(depositor, work) }
+          it { is_expected.not_to permit(proxy, work) }
+          it { is_expected.not_to permit(edit_user, work) }
+          it { is_expected.not_to permit(discover_user, work) }
+          it { is_expected.not_to permit(other_user, work) }
+          it { is_expected.not_to permit(public, work) }
+          it { is_expected.to permit(admin, work) }
+          it { is_expected.to permit(application, work) }
+        end
 
-        it { is_expected.to permit(depositor, work) }
-        it { is_expected.to permit(proxy, work) }
-        it { is_expected.to permit(edit_user, work) }
-        it { is_expected.not_to permit(discover_user, work) }
-        it { is_expected.not_to permit(other_user, work) }
-        it { is_expected.not_to permit(public, work) }
-        it { is_expected.to permit(admin, work) }
-        it { is_expected.to permit(application, work) }
+        context 'when the work is Penn State Only' do
+          before { work.grant_authorized_access }
+
+          it { is_expected.to permit(depositor, work) }
+          it { is_expected.to permit(proxy, work) }
+          it { is_expected.to permit(edit_user, work) }
+          it { is_expected.not_to permit(discover_user, work) }
+          it { is_expected.not_to permit(other_user, work) }
+          it { is_expected.not_to permit(public, work) }
+          it { is_expected.to permit(admin, work) }
+          it { is_expected.to permit(application, work) }
+        end
       end
     end
 
-    context 'when the work is published' do
-      let(:work) do
-        create :work,
-               has_draft: false,
-               versions_count: 1,
-               depositor: depositor_actor,
-               proxy_depositor: proxy_actor,
-               discover_users: [discover_user],
-               edit_users: [edit_user]
+    context 'when the deposit pathway for the work does not allow visibility to be changed' do
+      let(:change_allowed) { false }
+
+      context 'when the work is draft' do
+        let(:work) do
+          create :work,
+                 has_draft: true,
+                 versions_count: 1,
+                 depositor: depositor_actor,
+                 proxy_depositor: proxy_actor,
+                 discover_users: [discover_user],
+                 edit_users: [edit_user]
+        end
+
+        context 'when the work is Open access' do
+          before { work.grant_open_access }
+
+          it { is_expected.not_to permit(depositor, work) }
+          it { is_expected.not_to permit(proxy, work) }
+          it { is_expected.not_to permit(edit_user, work) }
+          it { is_expected.not_to permit(discover_user, work) }
+          it { is_expected.not_to permit(other_user, work) }
+          it { is_expected.not_to permit(public, work) }
+          it { is_expected.to permit(admin, work) }
+          it { is_expected.to permit(application, work) }
+        end
+
+        context 'when the work is Penn State Only' do
+          before { work.grant_authorized_access }
+
+          it { is_expected.not_to permit(depositor, work) }
+          it { is_expected.not_to permit(proxy, work) }
+          it { is_expected.not_to permit(edit_user, work) }
+          it { is_expected.not_to permit(discover_user, work) }
+          it { is_expected.not_to permit(other_user, work) }
+          it { is_expected.not_to permit(public, work) }
+          it { is_expected.to permit(admin, work) }
+          it { is_expected.to permit(application, work) }
+        end
       end
 
-      context 'when the work is Open access' do
-        before { work.grant_open_access }
+      context 'when the work is published' do
+        let(:work) do
+          create :work,
+                 has_draft: false,
+                 versions_count: 1,
+                 depositor: depositor_actor,
+                 proxy_depositor: proxy_actor,
+                 discover_users: [discover_user],
+                 edit_users: [edit_user]
+        end
 
-        it { is_expected.not_to permit(depositor, work) }
-        it { is_expected.not_to permit(proxy, work) }
-        it { is_expected.not_to permit(edit_user, work) }
-        it { is_expected.not_to permit(discover_user, work) }
-        it { is_expected.not_to permit(other_user, work) }
-        it { is_expected.not_to permit(public, work) }
-        it { is_expected.to permit(admin, work) }
-        it { is_expected.to permit(application, work) }
-      end
+        context 'when the work is Open access' do
+          before { work.grant_open_access }
 
-      context 'when the work is Penn State Only' do
-        before { work.grant_authorized_access }
+          it { is_expected.not_to permit(depositor, work) }
+          it { is_expected.not_to permit(proxy, work) }
+          it { is_expected.not_to permit(edit_user, work) }
+          it { is_expected.not_to permit(discover_user, work) }
+          it { is_expected.not_to permit(other_user, work) }
+          it { is_expected.not_to permit(public, work) }
+          it { is_expected.to permit(admin, work) }
+          it { is_expected.to permit(application, work) }
+        end
 
-        it { is_expected.to permit(depositor, work) }
-        it { is_expected.to permit(proxy, work) }
-        it { is_expected.to permit(edit_user, work) }
-        it { is_expected.not_to permit(discover_user, work) }
-        it { is_expected.not_to permit(other_user, work) }
-        it { is_expected.not_to permit(public, work) }
-        it { is_expected.to permit(admin, work) }
-        it { is_expected.to permit(application, work) }
+        context 'when the work is Penn State Only' do
+          before { work.grant_authorized_access }
+
+          it { is_expected.not_to permit(depositor, work) }
+          it { is_expected.not_to permit(proxy, work) }
+          it { is_expected.not_to permit(edit_user, work) }
+          it { is_expected.not_to permit(discover_user, work) }
+          it { is_expected.not_to permit(other_user, work) }
+          it { is_expected.not_to permit(public, work) }
+          it { is_expected.to permit(admin, work) }
+          it { is_expected.to permit(application, work) }
+        end
       end
     end
   end


### PR DESCRIPTION
I changed this authorization behavior previously without intending to, and I think that we probably still want admins to have this ability regardless of the deposit pathway used by the work. This also moves logic out of the view and into the authorization policy and tightens up the authorization in the controller for changing visibility (which I assume we would want).