### PR TITLE
remove updates section from home page

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -8,16 +8,7 @@
 
 <div class="container-fluid">
   <div class="row row--md-mb-3">
-    <div class="col-md">
-      <h2 class="h4 mb-2"><%= t('home.intro.heading') %></h2>
-      <div class="surface">
-        <%= t('home.intro.content') %>
-        <%= link_to t('home.intro.read_more'), about_path %>.
-      </div>
-    </div>
-
     <%= render 'shared/search_or_browse' %>
-
   </div>
 </div>
 

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -22,11 +22,8 @@ RSpec.describe 'Home page', type: :feature do
         expect(page).not_to have_selector('button')
       end
 
-      expect(page).to have_selector('h2', text: 'ScholarSphere Updates')
       expect(page).to have_selector('h2', text: 'Browse and search for works')
       expect(page).to have_selector('h2', text: 'Featured Works')
-
-      expect(page).to have_link('Read more about ScholarSphere')
 
       within('div.search') do
         expect(page).to have_selector('form')
@@ -52,7 +49,6 @@ RSpec.describe 'Home page', type: :feature do
     it 'displays the landing page without any featured resources' do
       visit(root_path)
 
-      expect(page).to have_selector('h2', text: 'ScholarSphere Updates')
       expect(page).to have_selector('h2', text: 'Browse and search for works')
       expect(page).not_to have_selector('h2', text: 'Featured Works')
     end


### PR DESCRIPTION
Fixes #1473 

I'm leaving the translations in `en.yml` so when we do have updates, that structure is already there.