### PR TITLE
`-L` flag to follow redirect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
         name: "Update Node.js and npm"
         command: |
           curl -sSL "https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v16.13.1-linux-x64/bin/node
-          curl https://npmjs.com/install.sh | sudo bash
+          curl -L https://npmjs.com/install.sh | sudo bash
     - run:
         name: "Install dependencies for thumbnails"
         command: | 


### PR DESCRIPTION
Was getting this response when pulling the `install.sh` script from npmjs.org:

`<head><title>301 Moved Permanently</title></head>`


The `-L` flag follows the redirect.  Not sure if this is the best way to handle this.