### PR TITLE
discard UnknownFormat

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -3,4 +3,6 @@
 Bugsnag.configure do |config|
   config.app_version = ENV.fetch('APP_VERSION', nil)
   config.release_stage = ENV.fetch('BUGSNAG_RELEASE_STAGE', 'development')
+
+  config.discard_classes << 'ActionController::UnknownFormat'
 end


### PR DESCRIPTION
This is one way to bypass sending events to bugsnag, bots will hit /catalog.rss and throw the UnknownFormat error. 

We could also return something like a 204 in the controller perhaps?