### PR TITLE
remove CI for previews

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,4 +183,3 @@ workflows:
             branches:
               only:
                 - main
-                - /preview\/.*/


### PR DESCRIPTION
We've migrated to the PR generator for previews in scholarsphere. Now, when you issue a PR with a branch that starts with `preview/*` a preview environment will be created, and deleted when the PR is removed. 

We can issue a PR and put it in `draft` mode to mirror the old behavior