### PR TITLE
Allow depositors to request accessibility remediation and save as draft

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,7 +59,7 @@ Rails/ApplicationController:
 
 Rails/SkipsModelValidations:
   Exclude:
-    - 'app/controllers/dashboard/form/publish_controller.rb'
+    - 'app/services/depositor_request_service.rb'
     - 'app/models/api_token.rb'
     - 'app/services/migrate_collection_ids.rb'
     - 'app/services/doi_service.rb'

--- a/app/controllers/dashboard/form/base_controller.rb
+++ b/app/controllers/dashboard/form/base_controller.rb
@@ -41,6 +41,10 @@ module Dashboard
           params.key?(:request_curation)
         end
 
+        def request_accessibility_remediation?
+          params.key?(:request_remediation)
+        end
+
         def create?
           @resource.new_record?
         end
@@ -54,7 +58,7 @@ module Dashboard
         end
 
         def redirect_upon_success
-          if save_and_exit? || finish? || request_curation?
+          if save_and_exit? || finish? || request_curation? || request_accessibility_remediation?
             redirect_to resource_path(@resource.uuid),
                         notice: I18n.t('dashboard.form.notices.success', resource: @resource.model_name.human)
           elsif publish?
@@ -83,6 +87,11 @@ module Dashboard
           deposit_pathway.allows_curation_request? && in_publish_edit_action?
         end
 
+        helper_method :allow_accessibility_remediation?
+        def allow_accessibility_remediation?
+          deposit_pathway.allows_accessibility_remediation_request? && in_publish_edit_action?
+        end
+
         helper_method :allow_mint_doi?
         def allow_mint_doi?
           deposit_pathway.allows_mint_doi_request?
@@ -91,7 +100,7 @@ module Dashboard
         helper_method :allow_publish?
         def allow_publish?
           if deposit_pathway.work?
-            !@resource.draft_curation_requested || current_user.admin?
+            (!@resource.draft_curation_requested && !@resource.accessibility_remediation_requested) || current_user.admin?
           else
             true
           end

--- a/app/forms/work_deposit_pathway.rb
+++ b/app/forms/work_deposit_pathway.rb
@@ -30,7 +30,13 @@ class WorkDepositPathway
   end
 
   def allows_curation_request?
-    data_and_code? && !@resource.draft_curation_requested
+    data_and_code? && !@resource.draft_curation_requested && !@resource.accessibility_remediation_requested
+  end
+
+  def allows_accessibility_remediation_request?
+    work? && !@resource.accessibility_remediation_requested && !@resource.draft_curation_requested
+    # will need to add on to this once the autochecker is in place
+    # remediation request allowed if any of the files have failed (or did not undergo) validation
   end
 
   def allows_mint_doi_request?
@@ -121,6 +127,7 @@ class WorkDepositPathway
                :update_doi=,
                :work_type,
                :draft_curation_requested,
+               :accessibility_remediation_requested,
                :mint_doi_requested,
                to: :work_version, prefix: false
 
@@ -263,6 +270,7 @@ class WorkDepositPathway
                  :aasm,
                  :update_column,
                  :draft_curation_requested=,
+                 :accessibility_remediation_requested=,
                  :mint_doi_requested=,
                  :set_thumbnail_selection,
                  to: :work_version,

--- a/app/forms/work_deposit_pathway.rb
+++ b/app/forms/work_deposit_pathway.rb
@@ -34,9 +34,10 @@ class WorkDepositPathway
   end
 
   def allows_accessibility_remediation_request?
-    work? && !@resource.accessibility_remediation_requested && !@resource.draft_curation_requested
+    work? && !@resource.accessibility_remediation_requested && !@resource.draft_curation_requested && !data_and_code?
     # will need to add on to this once the autochecker is in place
     # remediation request allowed if any of the files have failed (or did not undergo) validation
+    # don't allow for instruments
   end
 
   def allows_mint_doi_request?

--- a/app/services/curation_task_client.rb
+++ b/app/services/curation_task_client.rb
@@ -5,12 +5,13 @@ require 'airrecord'
 class CurationTaskClient
   class CurationError < RuntimeError; end
 
-  def self.send_curation(work_version_id, requested: false, updated_version: false)
+  def self.send_curation(work_version_id, requested: false, remediation_requested: false, updated_version: false)
     submission = WorkVersion.find(work_version_id)
     labels = []
     labels << 'Curation Requested' if requested
     labels << 'Embargoed' if submission.embargoed?
     labels << 'Updated Version' if updated_version
+    labels << 'Accessibility Remediation Requested' if remediation_requested
 
     record =
       {

--- a/app/services/depositor_request_service.rb
+++ b/app/services/depositor_request_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class DepositorRequestService
+  class RequestError < RuntimeError; end
+  class InvalidResourceError < RuntimeError; end
+
+  def initialize(resource)
+    @resource = resource
+  end
+
+  def request_action(curation_requested)
+    column = curation_requested ? :draft_curation_requested : :accessibility_remediation_requested
+    @resource.update_column(column, true)
+    #     # We want validation errors to block curation requests and keep users on the edit page
+    #     # so WorkVersion needs to temporarily act like it's being published. It's returned to it's
+    #     # initial state before being saved.
+    begin
+      @resource.save
+      initial_state = @resource.aasm_state
+      @resource.publish
+      if @resource.valid?
+        CurationTaskClient.send_curation(@resource.id, requested: curation_requested, remediation_requested: !curation_requested)
+        curation_requested ? @resource.draft_curation_requested = true : @resource.accessibility_remediation_requested = true
+      else
+        @resource.update_column(column, false)
+        @resource.aasm_state = initial_state
+        raise InvalidResourceError
+      end
+    rescue CurationTaskClient::CurationError
+      @resource.update_column(column, false)
+      raise RequestError
+    ensure
+      @resource.aasm_state = initial_state
+    end
+  end
+end

--- a/app/views/dashboard/form/publish/_fields.html.erb
+++ b/app/views/dashboard/form/publish/_fields.html.erb
@@ -30,6 +30,10 @@
       <%= render 'curation', form: form %>
     <% end %>
 
+    <% if allow_accessibility_remediation? || @resource.accessibility_remediation_requested %>
+      <%= render 'remediation', form: form %>
+    <% end %>
+
     <% if allow_mint_doi? %>
       <%= render 'doi', form: form %>
     <% end %>

--- a/app/views/dashboard/form/publish/_remediation.html.erb
+++ b/app/views/dashboard/form/publish/_remediation.html.erb
@@ -1,0 +1,18 @@
+<div class="form-group mt-5">
+  <div class="keyline keyline--left">
+    <h4><%= t '.header' %></h4>
+  </div>
+  <div>
+    <% unless @resource.accessibility_remediation_requested %>
+      <div>
+        <%= t '.remediation_description' %>
+      </div>
+      <br>
+      <div>
+        <%= t '.publish_description' %>
+      </div>
+    <% else %>
+      <strong><%= t '.remediation_requested' %> <a href="/incidents/new"><%= t '.contact' %></a></strong>
+    <% end %>
+  </div>
+</div>

--- a/app/views/dashboard/form/shared/_action_footer.html.erb
+++ b/app/views/dashboard/form/shared/_action_footer.html.erb
@@ -7,6 +7,10 @@
       <%= form.submit t('dashboard.form.actions.request_curation'), name: 'request_curation', class: 'btn btn-primary btn--rounded' %>
     <% end %>
 
+    <% if allow_accessibility_remediation? %>
+      <%= form.submit t('dashboard.form.actions.request_remediation'), name: 'request_remediation', class: 'btn btn-primary btn--rounded' %>
+    <% end %>
+
     <% if allow_publish? || primary_action == :save_and_continue %>
     <%= form.submit t("dashboard.form.actions.#{primary_action}"), name: primary_action, class: 'btn btn-primary btn--rounded' %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -407,9 +407,10 @@ en:
         finish: Finish
         save_and_exit:
           collection: Save and Exit
-          work_version: Save as Draft & Exit
+          work_version: Save Draft & Exit
           admin_save: Save and Exit
-        request_curation: Request Curation & Save as Draft
+        request_curation: Request Curation
+        request_remediation: Request Accessibility Remediation
         destroy:
           button: Delete
           collection: Collection
@@ -480,10 +481,17 @@ en:
           publishing_details: Publishing Details
         curation:
           header: Request Curation (Optional)
-          request_description: Select 'Request Curation & Save as Draft' below if you would like ScholarSphere curators to review your work assessing its findability, accessibility, interoperability, and reusability prior to publication (recommended).
+          request_description: Select 'Request Curation' below if you would like ScholarSphere curators to review your work assessing its findability, accessibility, interoperability, and reusability prior to publication (recommended). Your work will be saved as a draft while being curated.
           publish_description: Select 'Publish' if you would like to self-submit your deposit to Scholarsphere and make it immediately public. ScholarSphere curators will review your work after publication. Note, because curatorial review occurs after publication, any changes or updates may result in a versioned work.
           curation_requested: Curation has been requested. We will notify you when curation is complete and your work is ready to be published. If you have any questions in the meantime, please contact ScholarSphere curators via our 
           error: There was an error with your curation request. Please try again later or contact us if the problem persists.
+          contact: contact form
+        remediation:
+          header: Request Accessibiility Remediation (Optional)
+          remediation_description: Test Description
+          publish_description: Select 'Publish' if you would like to self-submit your deposit to Scholarsphere and make it immediately public. ScholarSphere curators will review your work after publication. Note, because curatorial review occurs after publication, any changes or updates may result in a versioned work.
+          remediation_requested: Remediation has been requested. We will notify you when accessibility remediation is complete and your work is ready to be published. If you have any questions in the meantime, please contact ScholarSphere curators via our 
+          error: There was an error with your accessibility remediation request. Please try again later or contact us if the problem persists.
           contact: contact form
         doi:
           header: Mint DOI (Optional)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -481,14 +481,14 @@ en:
           publishing_details: Publishing Details
         curation:
           header: Request Curation (Optional)
-          request_description: Select 'Request Curation' below if you would like ScholarSphere curators to review your work assessing its findability, accessibility, interoperability, and reusability prior to publication (recommended). Your work will be saved as a draft while being curated.
+          request_description: "Recommended: Select ‘Request Curation’ below to have the ScholarSphere Curation Team review your work ensuring its findability, interoperability, accessibility, and reusability prior to publication. The curatorial review will focus on enhancing metadata quality, recommending improvements for deposit interoperability and reusability, and remediating files as necessary for accessibility. While under review, your work will remain saved as a draft. Once approved by the curator, the work will be published, and if applicable, a DOI will be minted."
           publish_description: Select 'Publish' if you would like to self-submit your deposit to Scholarsphere and make it immediately public. ScholarSphere curators will review your work after publication. Note, because curatorial review occurs after publication, any changes or updates may result in a versioned work.
           curation_requested: Curation has been requested. We will notify you when curation is complete and your work is ready to be published. If you have any questions in the meantime, please contact ScholarSphere curators via our 
           error: There was an error with your curation request. Please try again later or contact us if the problem persists.
           contact: contact form
         remediation:
           header: Request Accessibiility Remediation (Optional)
-          remediation_description: Test Description
+          remediation_description: "Recommended: Select ‘Request Accessibility Remediation’ below to have the Adaptive Technologies Team review and improve the accessibility of your work before publication. While your work is being remediated it will remain saved as a draft and will be published upon completion of this work."
           publish_description: Select 'Publish' if you would like to self-submit your deposit to Scholarsphere and make it immediately public. ScholarSphere curators will review your work after publication. Note, because curatorial review occurs after publication, any changes or updates may result in a versioned work.
           remediation_requested: Remediation has been requested. We will notify you when accessibility remediation is complete and your work is ready to be published. If you have any questions in the meantime, please contact ScholarSphere curators via our 
           error: There was an error with your accessibility remediation request. Please try again later or contact us if the problem persists.

--- a/db/migrate/20241002144039_add_accessibility_remediation_requested_to_work_versions.rb
+++ b/db/migrate/20241002144039_add_accessibility_remediation_requested_to_work_versions.rb
@@ -1,0 +1,5 @@
+class AddAccessibilityRemediationRequestedToWorkVersions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :work_versions, :accessibility_remediation_requested, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_09_10_195820) do
+ActiveRecord::Schema.define(version: 2024_10_02_144039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -265,6 +265,7 @@ ActiveRecord::Schema.define(version: 2024_09_10_195820) do
     t.boolean "draft_curation_requested"
     t.datetime "sent_for_curation_at"
     t.boolean "mint_doi_requested"
+    t.boolean "accessibility_remediation_requested"
     t.index ["external_app_id"], name: "index_work_versions_on_external_app_id"
     t.index ["work_id", "version_number"], name: "index_work_versions_on_work_id_and_version_number", unique: true
     t.index ["work_id"], name: "index_work_versions_on_work_id"

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         expect(page).to have_current_path(resource_path(work_version.uuid))
         expect(Work.count).to eq(initial_work_count)
-        expect(page).not_to have_button('Request Curation & Save as Draft')
+        expect(page).not_to have_button('Request Curation')
 
         work_version.reload
         expect(work_version.title).to eq metadata[:title]
@@ -457,7 +457,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
           expect(page).to have_content("Access Account: #{actor.psu_id}".upcase)
         end
 
-        expect(page).not_to have_button('Request Curation & Save as Draft')
+        expect(page).not_to have_button('Request Curation')
 
         fill_in 'work_version_contributor', with: metadata[:contributor]
 
@@ -736,7 +736,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         end
       end
 
-      expect(page).not_to have_button('Request Curation & Save as Draft')
+      expect(page).not_to have_button('Request Curation')
     end
 
     context 'when a work is in the data & code pathway' do
@@ -1106,7 +1106,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
   describe 'Requesting curation', js: true do
     let(:user) { work_version.work.depositor.user }
-    let(:request_description) { "Select 'Request Curation & Save as Draft' below if you would like ScholarSphere curators to review your work assessing its findability, accessibility, interoperability, and reusability prior to publication (recommended)." }
+    let(:request_description) { "Select 'Request Curation' below if you would like ScholarSphere curators to review your work assessing its findability, accessibility, interoperability, and reusability prior to publication (recommended)." }
     let(:publish_description) { "Select 'Publish' if you would like to self-submit your deposit to Scholarsphere and make it immediately public. ScholarSphere curators will review your work after publication. Note, because curatorial review occurs after publication, any changes or updates may result in a versioned work." }
 
     context 'with a draft eligible for curation request' do
@@ -1115,7 +1115,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
       it 'renders buttons for requesting curation and publish and shows helper text explaing requesting curation' do
         visit dashboard_form_publish_path(work_version)
 
-        expect(page).to have_button('Request Curation & Save as Draft')
+        expect(page).to have_button('Request Curation')
         expect(page).to have_button('Publish')
 
         expect(page).to have_content(request_description)
@@ -1130,7 +1130,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
       it 'does not render a button for requesting curation but does render publish and does not show helper text about requesting curation' do
         visit dashboard_form_publish_path(work_version)
 
-        expect(page).not_to have_button('Request Curation & Save as Draft')
+        expect(page).not_to have_button('Request Curation')
         expect(page).to have_button('Publish')
         expect(page).not_to have_content(request_description)
       end
@@ -1159,7 +1159,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         it 'does not render buttons for requesting curation or publish & shows text that curation has been requested' do
           visit dashboard_form_publish_path(work_version)
 
-          expect(page).not_to have_button('Request Curation & Save as Draft')
+          expect(page).not_to have_button('Request Curation')
           expect(page).not_to have_button('Publish')
           expect(page).to have_content(curation_requested)
           expect(page).to have_link('contact form')
@@ -1179,7 +1179,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         check 'I have read and agree to the deposit agreement.'
 
-        click_on 'Request Curation & Save as Draft'
+        click_on 'Request Curation'
 
         work_version.reload
 
@@ -1199,8 +1199,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         fill_in 'work_version_title', with: ''
         fill_in 'work_version_title', with: 'Changed Title'
         check 'I have read and agree to the deposit agreement.'
-
-        click_on 'Request Curation & Save as Draft'
+        click_on 'Request Curation'
 
         within('.alert-danger') do
           expect(page).to have_content('There was an error with your curation request')
@@ -1223,7 +1222,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         fill_in 'work_version_published_date', with: 'this is not a valid date'
         check 'I have read and agree to the deposit agreement.'
 
-        click_on 'Request Curation & Save as Draft'
+        click_on 'Request Curation'
 
         expect(CurationTaskClient).not_to have_received(:send_curation).with(work_version.id, requested: true)
 
@@ -1239,6 +1238,144 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(work_version).not_to be_published
         expect(work_version.published_date).to eq 'this is not a valid date'
         expect(work_version.draft_curation_requested).to eq false
+      end
+    end
+  end
+
+  describe 'Requesting accessibility remediation', js: true do
+    let(:user) { work_version.work.depositor.user }
+    let(:request_description) { 'Test Description' }
+    let(:publish_description) { "Select 'Publish' if you would like to self-submit your deposit to Scholarsphere and make it immediately public. ScholarSphere curators will review your work after publication. Note, because curatorial review occurs after publication, any changes or updates may result in a versioned work." }
+
+    context 'with a draft eligible for remediation request' do
+      let(:work_version) { create :work_version, :draft, accessibility_remediation_requested: nil }
+
+      it 'renders buttons for requesting remediation and publish and shows helper text explaing requesting curation' do
+        visit dashboard_form_publish_path(work_version)
+
+        expect(page).to have_button('Request Accessibility Remediation')
+        expect(page).to have_button('Publish')
+
+        expect(page).to have_content(request_description)
+        expect(page).to have_content(publish_description)
+      end
+    end
+
+    context 'with a draft not eligible for remediation request' do
+      let(:work_version) { create :work_version, :draft, draft_curation_requested: true }
+
+      it 'does not render a button for requesting remediation does not show helper text about requesting remediation' do
+        visit dashboard_form_publish_path(work_version)
+
+        expect(page).not_to have_button('Request Accessibility Remediation')
+        expect(page).not_to have_content(request_description)
+      end
+    end
+
+    context 'with a draft that already has remediation requested' do
+      let(:work_version) { create :work_version, :dataset_able_to_be_published, accessibility_remediation_requested: true }
+      let(:remediation_requested) { 'Remediation has been requested. We will notify you when accessibility remediation is complete and your work is ready to be published. If you have any questions in the meantime, please contact ScholarSphere curators via our ' }
+
+      context 'when user is an admin' do
+        let(:user) { create(:user, :admin) }
+
+        it 'allows admin to publish' do
+          visit dashboard_form_publish_path(work_version)
+
+          expect(page).to have_button('Publish')
+
+          check 'I have read and agree to the deposit agreement.'
+          click_on 'Publish'
+
+          expect(work_version.reload.aasm_state).to eq 'published'
+        end
+      end
+
+      context 'when user is not an admin' do
+        it 'does not render buttons for requesting remediation, requesting curation, or publish & shows text that remediation has been requested' do
+          visit dashboard_form_publish_path(work_version)
+
+          expect(page).not_to have_button('Request Accessibility Remediation')
+          expect(page).not_to have_button('Request Curation')
+          expect(page).not_to have_button('Publish')
+          expect(page).to have_content(remediation_requested)
+          expect(page).to have_link('contact form')
+        end
+      end
+    end
+
+    context 'when remediation is successfully requested' do
+      let(:work_version) { create :work_version, :dataset_able_to_be_published, accessibility_remediation_requested: nil }
+
+      before do
+        allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, remediation_requested: true)
+      end
+
+      it 'creates a Submission' do
+        visit dashboard_form_publish_path(work_version)
+
+        check 'I have read and agree to the deposit agreement.'
+
+        click_on 'Request Accessibility Remediation'
+
+        work_version.reload
+
+        expect(CurationTaskClient).to have_received(:send_curation).with(work_version.id, remediation_requested: true)
+        expect(work_version.accessibility_remediation_requested).to be true
+      end
+    end
+
+    context 'when an error occurs within the curation task exporter' do
+      let(:work_version) { create :work_version, :dataset_able_to_be_published, accessibility_remediation_requested: nil }
+
+      before { allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, remediation_requested: true).and_raise(CurationTaskClient::CurationError) }
+
+      it 'saves changes to the work version and displays an error flash message' do
+        visit dashboard_form_publish_path(work_version)
+
+        fill_in 'work_version_title', with: ''
+        fill_in 'work_version_title', with: 'Changed Title'
+        check 'I have read and agree to the deposit agreement.'
+
+        click_on 'Request Accessibility Remediation'
+
+        within('.alert-danger') do
+          expect(page).to have_content('There was an error with your accessibility remediation request.')
+        end
+
+        work_version.reload
+        expect(work_version.title).to eq('Changed Title')
+        expect(work_version.accessibility_remediation_requested).not_to be true
+      end
+    end
+
+    context 'when there is a validation error' do
+      let(:work_version) { create :work_version, :dataset_able_to_be_published, accessibility_remediation_requested: nil }
+
+      before { allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, remediation_requested: true) }
+
+      it 'does not call the curation task exporter' do
+        visit dashboard_form_publish_path(work_version)
+
+        fill_in 'work_version_published_date', with: 'this is not a valid date'
+        check 'I have read and agree to the deposit agreement.'
+
+        click_on 'Request Accessibility Remediation'
+
+        expect(CurationTaskClient).not_to have_received(:send_curation).with(work_version.id, remediation_requested: true)
+
+        within '#error_explanation' do
+          expect(page).to have_content(I18n.t!('errors.messages.invalid_edtf'))
+        end
+
+        within '.footer--actions' do
+          expect(page).to have_button(I18n.t!('dashboard.form.actions.request_remediation'))
+        end
+
+        work_version.reload
+        expect(work_version).not_to be_published
+        expect(work_version.published_date).to eq 'this is not a valid date'
+        expect(work_version.accessibility_remediation_requested).to eq false
       end
     end
   end

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -1248,7 +1248,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
     let(:publish_description) { "Select 'Publish' if you would like to self-submit your deposit to Scholarsphere and make it immediately public. ScholarSphere curators will review your work after publication. Note, because curatorial review occurs after publication, any changes or updates may result in a versioned work." }
 
     context 'with a draft eligible for remediation request' do
-      let(:work_version) { create :work_version, :draft, accessibility_remediation_requested: nil }
+      let(:work_version) { create :work_version, :article, :draft, accessibility_remediation_requested: nil }
 
       it 'renders buttons for requesting remediation and publish and shows helper text explaing requesting curation' do
         visit dashboard_form_publish_path(work_version)
@@ -1261,7 +1261,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
       end
     end
 
-    context 'with a draft not eligible for remediation request' do
+    context 'with a draft that already has remediation request' do
       let(:work_version) { create :work_version, :draft, draft_curation_requested: true }
 
       it 'does not render a button for requesting remediation does not show helper text about requesting remediation' do
@@ -1272,8 +1272,19 @@ RSpec.describe 'Publishing a work', with_user: :user do
       end
     end
 
+    context 'with a draft work type that is not eligible for remediation request' do
+      let(:work_version) { create :work_version, :dataset_able_to_be_published }
+
+      it 'does not render a button for requesting remediation does not show helper text about requesting remediation' do
+        visit dashboard_form_publish_path(work_version)
+
+        expect(page).not_to have_button('Request Accessibility Remediation')
+        expect(page).not_to have_content(request_description)
+      end
+    end
+
     context 'with a draft that already has remediation requested' do
-      let(:work_version) { create :work_version, :dataset_able_to_be_published, accessibility_remediation_requested: true }
+      let(:work_version) { create :work_version, :article, :able_to_be_published, accessibility_remediation_requested: true }
       let(:remediation_requested) { 'Remediation has been requested. We will notify you when accessibility remediation is complete and your work is ready to be published. If you have any questions in the meantime, please contact ScholarSphere curators via our ' }
 
       context 'when user is an admin' do
@@ -1305,7 +1316,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
     end
 
     context 'when remediation is successfully requested' do
-      let(:work_version) { create :work_version, :dataset_able_to_be_published, accessibility_remediation_requested: nil }
+      let(:work_version) { create :work_version, :article, :able_to_be_published, accessibility_remediation_requested: nil }
 
       before do
         allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, remediation_requested: true, requested: false)
@@ -1326,7 +1337,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
     end
 
     context 'when an error occurs within the curation task exporter' do
-      let(:work_version) { create :work_version, :dataset_able_to_be_published, accessibility_remediation_requested: nil }
+      let(:work_version) { create :work_version, :article, :able_to_be_published, accessibility_remediation_requested: nil }
 
       before { allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, remediation_requested: true, requested: false).and_raise(CurationTaskClient::CurationError) }
 
@@ -1350,7 +1361,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
     end
 
     context 'when there is a validation error' do
-      let(:work_version) { create :work_version, :dataset_able_to_be_published, accessibility_remediation_requested: nil }
+      let(:work_version) { create :work_version, :article, :able_to_be_published, accessibility_remediation_requested: nil }
 
       before { allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, remediation_requested: true, requested: false) }
 

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -1171,7 +1171,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
       let(:work_version) { create :work_version, :dataset_able_to_be_published, draft_curation_requested: nil }
 
       before do
-        allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, requested: true)
+        allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, requested: true, remediation_requested: false)
       end
 
       it 'creates a Submission' do
@@ -1183,7 +1183,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         work_version.reload
 
-        expect(CurationTaskClient).to have_received(:send_curation).with(work_version.id, requested: true)
+        expect(CurationTaskClient).to have_received(:send_curation).with(work_version.id, requested: true, remediation_requested: false)
         expect(work_version.draft_curation_requested).to be true
       end
     end
@@ -1191,7 +1191,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
     context 'when an error occurs within the curation exporter' do
       let(:work_version) { create :work_version, :dataset_able_to_be_published, draft_curation_requested: nil }
 
-      before { allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, requested: true).and_raise(CurationTaskClient::CurationError) }
+      before { allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, requested: true, remediation_requested: false).and_raise(CurationTaskClient::CurationError) }
 
       it 'saves changes to the work version and displays an error flash message' do
         visit dashboard_form_publish_path(work_version)
@@ -1214,7 +1214,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
     context 'when there is a validation error' do
       let(:work_version) { create :work_version, :dataset_able_to_be_published, draft_curation_requested: nil }
 
-      before { allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, requested: true) }
+      before { allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, requested: true, remediation_requested: false) }
 
       it 'does not call the curation task exporter' do
         visit dashboard_form_publish_path(work_version)
@@ -1224,7 +1224,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         click_on 'Request Curation'
 
-        expect(CurationTaskClient).not_to have_received(:send_curation).with(work_version.id, requested: true)
+        expect(CurationTaskClient).not_to have_received(:send_curation).with(work_version.id, requested: true, remediation_requested: false)
 
         within '#error_explanation' do
           expect(page).to have_content(I18n.t!('errors.messages.invalid_edtf'))
@@ -1308,7 +1308,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
       let(:work_version) { create :work_version, :dataset_able_to_be_published, accessibility_remediation_requested: nil }
 
       before do
-        allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, remediation_requested: true)
+        allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, remediation_requested: true, requested: false)
       end
 
       it 'creates a Submission' do
@@ -1320,7 +1320,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         work_version.reload
 
-        expect(CurationTaskClient).to have_received(:send_curation).with(work_version.id, remediation_requested: true)
+        expect(CurationTaskClient).to have_received(:send_curation).with(work_version.id, remediation_requested: true, requested: false)
         expect(work_version.accessibility_remediation_requested).to be true
       end
     end
@@ -1328,7 +1328,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
     context 'when an error occurs within the curation task exporter' do
       let(:work_version) { create :work_version, :dataset_able_to_be_published, accessibility_remediation_requested: nil }
 
-      before { allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, remediation_requested: true).and_raise(CurationTaskClient::CurationError) }
+      before { allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, remediation_requested: true, requested: false).and_raise(CurationTaskClient::CurationError) }
 
       it 'saves changes to the work version and displays an error flash message' do
         visit dashboard_form_publish_path(work_version)
@@ -1352,7 +1352,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
     context 'when there is a validation error' do
       let(:work_version) { create :work_version, :dataset_able_to_be_published, accessibility_remediation_requested: nil }
 
-      before { allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, remediation_requested: true) }
+      before { allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, remediation_requested: true, requested: false) }
 
       it 'does not call the curation task exporter' do
         visit dashboard_form_publish_path(work_version)
@@ -1362,7 +1362,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         click_on 'Request Accessibility Remediation'
 
-        expect(CurationTaskClient).not_to have_received(:send_curation).with(work_version.id, remediation_requested: true)
+        expect(CurationTaskClient).not_to have_received(:send_curation).with(work_version.id, remediation_requested: true, requested: false)
 
         within '#error_explanation' do
           expect(page).to have_content(I18n.t!('errors.messages.invalid_edtf'))

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -1106,7 +1106,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
   describe 'Requesting curation', js: true do
     let(:user) { work_version.work.depositor.user }
-    let(:request_description) { "Select 'Request Curation' below if you would like ScholarSphere curators to review your work assessing its findability, accessibility, interoperability, and reusability prior to publication (recommended)." }
+    let(:request_description) { 'Recommended: Select ‘Request Curation’ below to have the ScholarSphere Curation Team review your work ensuring its findability, interoperability, accessibility, and reusability prior to publication. The curatorial review will focus on enhancing metadata quality, recommending improvements for deposit interoperability and reusability, and remediating files as necessary for accessibility. While under review, your work will remain saved as a draft. Once approved by the curator, the work will be published, and if applicable, a DOI will be minted.' }
     let(:publish_description) { "Select 'Publish' if you would like to self-submit your deposit to Scholarsphere and make it immediately public. ScholarSphere curators will review your work after publication. Note, because curatorial review occurs after publication, any changes or updates may result in a versioned work." }
 
     context 'with a draft eligible for curation request' do
@@ -1244,7 +1244,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
   describe 'Requesting accessibility remediation', js: true do
     let(:user) { work_version.work.depositor.user }
-    let(:request_description) { 'Test Description' }
+    let(:request_description) { 'Recommended: Select ‘Request Accessibility Remediation’ below to have the Adaptive Technologies Team review and improve the accessibility of your work before publication. While your work is being remediated it will remain saved as a draft and will be published upon completion of this work.' }
     let(:publish_description) { "Select 'Publish' if you would like to self-submit your deposit to Scholarsphere and make it immediately public. ScholarSphere curators will review your work after publication. Note, because curatorial review occurs after publication, any changes or updates may result in a versioned work." }
 
     context 'with a draft eligible for remediation request' do

--- a/spec/forms/work_deposit_pathway_spec.rb
+++ b/spec/forms/work_deposit_pathway_spec.rb
@@ -348,57 +348,69 @@ RSpec.describe WorkDepositPathway do
     end
   end
 
-  describe '#allows_accessibility_remediation_request? when a work type' do
-    %w[
-      article
-      book
-      capstone_project
-      conference_proceeding
-      dissertation
-      masters_culminating_experience
-      masters_thesis
-      part_of_book
-      report
-      research_paper
-      thesis
-      audio
-      image
-      journal
-      map_or_cartographic_material
-      other
-      poster
-      presentation
-      project
-      unspecified
-      video
-      dataset
-      software_or_program_code
-    ].each do |t|
-      let(:type) { t }
+  describe '#allows_accessibility_remediation_request?' do
+    context 'when in an allowable pathway' do
+      %w[
+        article
+        book
+        capstone_project
+        conference_proceeding
+        dissertation
+        masters_culminating_experience
+        masters_thesis
+        part_of_book
+        report
+        research_paper
+        thesis
+        audio
+        image
+        journal
+        map_or_cartographic_material
+        other
+        poster
+        presentation
+        project
+        unspecified
+        video
+      ].each do |t|
+        let(:type) { t }
 
-      context "when the given work version has a work type of #{t}" do
-        context 'when remediation has been requested for the given work version' do
-          let(:accessibility_remediation_requested) { true }
-
-          it 'returns false' do
-            expect(pathway.allows_accessibility_remediation_request?).to eq false
-          end
-        end
-
-        context 'when remediation has not been requested for the given work version' do
-          context 'when curation has been requested for the given work version' do
-            let(:draft_curation_requested) { true }
+        context "when the given work version has a work type of #{t}" do
+          context 'when remediation has been requested for the given work version' do
+            let(:accessibility_remediation_requested) { true }
 
             it 'returns false' do
               expect(pathway.allows_accessibility_remediation_request?).to eq false
             end
           end
 
-          context 'when curation has not been requested for the given work version' do
-            it 'returns true' do
-              expect(pathway.allows_accessibility_remediation_request?).to eq true
+          context 'when remediation has not been requested for the given work version' do
+            context 'when curation has been requested for the given work version' do
+              let(:draft_curation_requested) { true }
+
+              it 'returns false' do
+                expect(pathway.allows_accessibility_remediation_request?).to eq false
+              end
+            end
+
+            context 'when curation has not been requested for the given work version' do
+              it 'returns true' do
+                expect(pathway.allows_accessibility_remediation_request?).to eq true
+              end
             end
           end
+        end
+      end
+    end
+
+    context 'when in data and code pathway' do
+      %w[
+        dataset
+        software_or_program_code
+      ].each do |t|
+        let(:type) { t }
+        it 'returns false' do
+          expect(pathway.allows_accessibility_remediation_request?).to eq false
         end
       end
     end

--- a/spec/forms/work_deposit_pathway_spec.rb
+++ b/spec/forms/work_deposit_pathway_spec.rb
@@ -12,12 +12,14 @@ RSpec.describe WorkDepositPathway do
       attributes: {},
       id: 123,
       draft_curation_requested: draft_curation_requested,
+      accessibility_remediation_requested: accessibility_remediation_requested,
       doi_blank?: doi_blank,
       work: work
     )
   }
   let(:type) { nil }
   let(:draft_curation_requested) { false }
+  let(:accessibility_remediation_requested) { false }
   let(:doi_blank) { false }
   let(:work) { instance_double(Work) }
 
@@ -343,6 +345,70 @@ RSpec.describe WorkDepositPathway do
           expect(pathway.allows_mint_doi_request?).to eq false
         end
       end
+    end
+  end
+
+  describe '#allows_accessibility_remediation_request? when a work type' do
+    %w[
+      article
+      book
+      capstone_project
+      conference_proceeding
+      dissertation
+      masters_culminating_experience
+      masters_thesis
+      part_of_book
+      report
+      research_paper
+      thesis
+      audio
+      image
+      journal
+      map_or_cartographic_material
+      other
+      poster
+      presentation
+      project
+      unspecified
+      video
+      dataset
+      software_or_program_code
+    ].each do |t|
+      let(:type) { t }
+
+      context "when the given work version has a work type of #{t}" do
+        context 'when remediation has been requested for the given work version' do
+          let(:accessibility_remediation_requested) { true }
+
+          it 'returns false' do
+            expect(pathway.allows_accessibility_remediation_request?).to eq false
+          end
+        end
+
+        context 'when remediation has not been requested for the given work version' do
+          context 'when curation has been requested for the given work version' do
+            let(:draft_curation_requested) { true }
+
+            it 'returns false' do
+              expect(pathway.allows_accessibility_remediation_request?).to eq false
+            end
+          end
+
+          context 'when curation has not been requested for the given work version' do
+            it 'returns true' do
+              expect(pathway.allows_accessibility_remediation_request?).to eq true
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe '#allows_accessibility_remediation_request? when the given work version does not have a work type' do
+    let(:type) { 'collection' }
+
+    it 'returns false' do
+      expect(pathway.allows_accessibility_remediation_request?).to eq false
     end
   end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -497,6 +497,7 @@ RSpec.describe Work, type: :model do
           display_work_type_ssi
           doi_tesim
           draft_curation_requested_tesim
+          accessibility_remediation_requested_tesim
           edit_groups_ssim
           edit_users_ssim
           embargoed_until_dtsi

--- a/spec/services/curation_task_client_spec.rb
+++ b/spec/services/curation_task_client_spec.rb
@@ -56,6 +56,21 @@ RSpec.describe CurationTaskClient do
       end
     end
 
+    context 'when accessibility remediation is requested' do
+      let(:embargo) { nil }
+      let(:labels) { ['Accessibility Remediation Requested'] }
+
+      it 'creates a submission record in Airtable' do
+        expect(Submission).to receive(:create).with(expected_record)
+
+        described_class.send_curation(work_version.id, remediation_requested: true)
+
+        work_version.reload
+
+        expect(work_version.sent_for_curation_at).to be_within(1.minute).of(Time.zone.now)
+      end
+    end
+
     context 'when curation was not requested' do
       let(:embargo) { nil }
       let(:labels) { [] }

--- a/spec/services/depositor_request_service_spec.rb
+++ b/spec/services/depositor_request_service_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DepositorRequestService do
+  describe '#request_action' do
+    let(:work_version) { create :work_version, :able_to_be_published, published_date: pub_date }
+    let(:pub_date) { '2024' }
+    let(:curation_requested) { true }
+
+    context 'when curation is requested' do
+      before { allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, requested: true, remediation_requested: false) }
+
+      context 'when the work version is valid' do
+        it 'sends it for curation' do
+          described_class.new(work_version).request_action(curation_requested)
+          expect(CurationTaskClient).to have_received(:send_curation).with(work_version.id, requested: true, remediation_requested: false)
+
+          work_version.reload
+          expect(work_version.draft_curation_requested).to be true
+          expect(work_version.accessibility_remediation_requested).to be_nil
+        end
+      end
+
+      context 'when the work version is invalid' do
+        let(:pub_date) { 'not a date' }
+
+        it 'does not send it for curation and raises invalid resource error' do
+          expect { described_class.new(work_version).request_action(curation_requested) }.to raise_error(DepositorRequestService::InvalidResourceError)
+          expect(CurationTaskClient).not_to have_received(:send_curation).with(work_version.id, requested: true, remediation_requested: false)
+
+          work_version.reload
+          expect(work_version.draft_curation_requested).to be false
+          expect(work_version.accessibility_remediation_requested).to be_nil
+        end
+      end
+
+      context 'when there is a Curation Task error' do
+        before {
+ allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, requested: true,
+                                                                            remediation_requested: false).and_raise(CurationTaskClient::CurationError) }
+
+        it 'does not send it for remediation and raises request error' do
+          expect { described_class.new(work_version).request_action(curation_requested) }.to raise_error(DepositorRequestService::RequestError)
+
+          work_version.reload
+          expect(work_version.draft_curation_requested).to be false
+          expect(work_version.accessibility_remediation_requested).to be_nil
+        end
+      end
+    end
+
+    context 'when remediation is requested' do
+      before { allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, requested: false, remediation_requested: true) }
+
+      let(:curation_requested) { false }
+
+      context 'when the work version is valid' do
+        it 'sends it for remediation' do
+          described_class.new(work_version).request_action(curation_requested)
+          expect(CurationTaskClient).to have_received(:send_curation).with(work_version.id, requested: false, remediation_requested: true)
+
+          work_version.reload
+          expect(work_version.draft_curation_requested).to be_nil
+          expect(work_version.accessibility_remediation_requested).to be true
+        end
+      end
+
+      context 'when the work version is invalid' do
+        let(:pub_date) { 'not a date' }
+
+        it 'does not send it for remediation and raises invalid resource error' do
+          expect { described_class.new(work_version).request_action(curation_requested) }.to raise_error(DepositorRequestService::InvalidResourceError)
+          expect(CurationTaskClient).not_to have_received(:send_curation).with(work_version.id, requested: false, remediation_requested: true)
+
+          work_version.reload
+          expect(work_version.draft_curation_requested).to be_nil
+          expect(work_version.accessibility_remediation_requested).to be false
+        end
+      end
+
+      context 'when there is a Curation Task error' do
+        before {
+ allow(CurationTaskClient).to receive(:send_curation).with(work_version.id, requested: false,
+                                                                            remediation_requested: true).and_raise(CurationTaskClient::CurationError) }
+
+        it 'does not send it for remediation and raises request error' do
+          expect { described_class.new(work_version).request_action(curation_requested) }.to raise_error(DepositorRequestService::RequestError)
+
+          work_version.reload
+          expect(work_version.draft_curation_requested).to be_nil
+          expect(work_version.accessibility_remediation_requested).to be false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1603 

Currently, this pr allows accessibility remediation to be requested for any work type as long as it has not already been requested & draft curation has not been requested. Additional logic will need to be added so that the button does not show up if all files have passed the automatic checker, but that is on hold while the checker is being developed. Depending on timing, that addition will go in another ticket.

I updated the language for both request buttons to drop the '& Save as Draft' part. With the current number of buttons, it took up too much space & buttons were starting to overlap. Instead, I added that language to the help text so users still have an indicator that the work is being saved as a draft.