### PR TITLE
add Airtable label when a work version needs accessibility review

### DIFF
--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -337,6 +337,10 @@ class WorkVersion < ApplicationRecord
     !!identifier.find { |id| Doi.new(id).valid? }
   end
 
+  def needs_accessibility_review
+    latest_published_version? && !accessibility_remediation_requested
+  end
+
   delegate :deposited_at,
            :depositor,
            :embargoed?,

--- a/app/services/curation_task_client.rb
+++ b/app/services/curation_task_client.rb
@@ -12,6 +12,7 @@ class CurationTaskClient
     labels << 'Embargoed' if submission.embargoed?
     labels << 'Updated Version' if updated_version
     labels << 'Accessibility Remediation Requested' if remediation_requested
+    labels << 'Needs Accessibility Review' if submission.needs_accessibility_review
 
     record =
       {

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -853,4 +853,38 @@ RSpec.describe WorkVersion, type: :model do
       end
     end
   end
+
+  describe '#needs_accessibility_review' do
+    context 'when version is not the latest published version' do
+      let(:wv) { create(:work_version, :published, accessibility_remediation_requested: requested) }
+      let(:requested) { false }
+      let(:wv2) { create(:work_version, :published) }
+      let(:work) { create(:work) }
+
+      it 'returns false' do
+        work.versions << [wv, wv2]
+        expect(wv.needs_accessibility_review).to be false
+      end
+    end
+
+    context 'when version is the latest published version' do
+      let(:wv) { create(:work_version, :published, accessibility_remediation_requested: requested) }
+      let(:work) { create(:work, versions: [wv]) }
+      let(:requested) { false }
+
+      context 'when remediation has not been requested' do
+        it 'returns true' do
+          expect(wv.needs_accessibility_review).to be true
+        end
+      end
+
+      context 'when remediation has been requested' do
+        let(:requested) { true }
+
+        it 'returns false' do
+          expect(wv.needs_accessibility_review).to be false
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1604 

Even if all files pass the auto checker, we want this label added so it gets eyes on it to be sure. The only time this label is not needed is if it isn't the latest published version (only applicable when draft curation is requested) or it has remediation requested meaning it has already undergone the manual accessibility check process.