### PR TITLE
add archive tag line to welcome header and footer

### DIFF
--- a/app/javascript/frontend/styles/_common.scss
+++ b/app/javascript/frontend/styles/_common.scss
@@ -249,23 +249,26 @@ h4,
 
 .navbar-brand {
   &--center {
-    top: 7px;
-    position: absolute;
+    position: relative;
+    right: 0;
+    width: 100vw;
+    text-align: center;
+    margin-left: -50vw;
     left: 50%;
-    transform: translateX(-50%);
 
-    a {
+    .home-heading {
+      font-size: $navbar-brand-font-size;
       color: $white;
-
-      &:hover {
-        text-decoration: none;
-      }
     }
 
-    @include media-breakpoint-down(xs) {
-      font-size: 16px;
-      top: 13px;
+    .home-subtitle {
+      font-size: 1rem;
+      color: $white;
+      margin-top: .25rem;
     }
+
+    background-color: $dark-blue;
+    padding: 1rem 2rem;
   }
 }
 
@@ -673,6 +676,7 @@ h4,
       p {
         color: $mid-blue;
         margin-bottom: 0;
+        font-size: $font-size-sm;
       }
     }
 

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -3,7 +3,10 @@
 <% end %>
 
 <% content_for :navbar_heading do %>
-  <h1 class="navbar-brand navbar-brand--center slab-font"><%= t('navbar.heading.home') %></h1>
+  <div class="navbar-brand navbar-brand--center slab-font">
+    <p class="home-heading"><%= t('navbar.heading.home') %></p>
+    <p class="home-subtitle"><%= t('navbar.heading.home_subtitle') %></p>
+  </div>
 <% end %>
 
 <div class="container-fluid">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,7 +206,7 @@ en:
         and will work to resolve it.
   footer:
     heading: 'ScholarSphere'
-    description: 'A service of the University Libraries.'
+    description: 'An institutional repository and archive sharing and preserving Penn State’s scholarly and research outputs'
     copyright_statement: 'Copyright © 2022 The Pennsylvania State University'
   helpers:
     # Note, for hints (and only hints) you can use Markdown
@@ -622,6 +622,7 @@ en:
       agreement_1_0: 'Deposit Agreement'
       dashboard: 'Your Dashboard'
       home: 'Welcome to ScholarSphere'
+      home_subtitle: 'An institutional repository and archive sharing and preserving Penn State’s scholarly and research outputs'
       not_found: 'Page Not Found'
       server_error: 'Server Error'
       graphql: 'GraphQL'

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Home page', type: :feature do
 
       within('footer') do
         expect(page).to have_selector('h3', text: 'ScholarSphere')
-        expect(page).to have_content('A service of the University Libraries.')
+        expect(page).to have_content(I18n.t!('footer.description'))
         expect(page).to have_content('Copyright')
         expect(page).to have_link('Penn State')
         expect(page).to have_link('University Libraries')


### PR DESCRIPTION
Fixes #1599 

Adds the archive tag line to a subtitle in the welcome header and to the footer

![image](https://github.com/user-attachments/assets/8c7aab6f-f9b5-4c05-92d2-5681c3e5272a)


![image](https://github.com/user-attachments/assets/d0ff3e41-f70e-4b4b-a5cf-fc908df49abb)
