### PR TITLE
Use host env variable for publication url in delete webhook to RMD

### DIFF
--- a/app/services/work_removed_webhook.rb
+++ b/app/services/work_removed_webhook.rb
@@ -11,7 +11,7 @@ class WorkRemovedWebhook
       headers: { 'X-API-KEY' => ENV['RMD_WEBHOOK_SECRET'] }
     )
 
-    conn.post('/webhooks/scholarsphere_events', publication_url: "https://scholarsphere.psu.edu/resources/#{work_uuid}")
+    conn.post('/webhooks/scholarsphere_events', publication_url: "#{Rails.application.routes.default_url_options[:host]}/resources/#{work_uuid}")
   end
 
   private

--- a/app/services/work_removed_webhook.rb
+++ b/app/services/work_removed_webhook.rb
@@ -11,7 +11,7 @@ class WorkRemovedWebhook
       headers: { 'X-API-KEY' => ENV['RMD_WEBHOOK_SECRET'] }
     )
 
-    conn.post('/webhooks/scholarsphere_events', publication_url: "#{Rails.application.routes.default_url_options[:host]}/resources/#{work_uuid}")
+    conn.post('/webhooks/scholarsphere_events', publication_url: "https://#{Rails.application.routes.default_url_options[:host]}/resources/#{work_uuid}")
   end
 
   private

--- a/spec/services/work_removed_webhook_spec.rb
+++ b/spec/services/work_removed_webhook_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe WorkRemovedWebhook do
 
       expect(faraday_connection).to have_received(:post).with(
         '/webhooks/scholarsphere_events',
-        publication_url: 'https://scholarsphere.psu.edu/resources/abc123'
+        publication_url: "https://#{Rails.application.routes.default_url_options[:host]}/resources/abc123"
       )
     end
   end


### PR DESCRIPTION
So it uses the right host url for different environments