### PR TITLE
Block publication while accessibility checker is running

### DIFF
--- a/app/channels/publish_status_channel.rb
+++ b/app/channels/publish_status_channel.rb
@@ -1,5 +1,5 @@
 class PublishStatusChannel < ApplicationCable::Channel
     def subscribed
-      stream_for "publish_status"
+      stream_from "publish_status_channel"
     end
   end

--- a/app/channels/publish_status_channel.rb
+++ b/app/channels/publish_status_channel.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class PublishStatusChannel < ApplicationCable::Channel
-    def subscribed
-      stream_from "publish_status_channel"
-    end
+  def subscribed
+    stream_from 'publish_status_channel'
   end
+end

--- a/app/channels/publish_status_channel.rb
+++ b/app/channels/publish_status_channel.rb
@@ -1,0 +1,5 @@
+class PublishStatusChannel < ApplicationCable::Channel
+    def subscribed
+      stream_for "publish_status"
+    end
+  end

--- a/app/controllers/concerns/allow_publish.rb
+++ b/app/controllers/concerns/allow_publish.rb
@@ -9,7 +9,7 @@ module AllowPublish
 
   def allow_publish?(resource)
     deposit_pathway ||= WorkDepositPathway.new(resource)
-    if deposit_pathway.work? && resource.is_a?(WorkVersion)
+    if deposit_pathway.work?
       (!resource.draft_curation_requested &&
         !resource.accessibility_remediation_requested &&
         resource.file_version_memberships.none?(&:accessibility_score_pending?)) || current_user.admin?

--- a/app/controllers/concerns/allow_publish.rb
+++ b/app/controllers/concerns/allow_publish.rb
@@ -1,18 +1,20 @@
+# frozen_string_literal: true
+
 module AllowPublish
-    extend ActiveSupport::Concern
-  
-    included do
-      helper_method :allow_publish? if respond_to?(:helper_method)
-    end
-    
-    def allow_publish?(resource)
-      deposit_pathway ||= WorkDepositPathway.new(resource)
-      if deposit_pathway.work?
-        (!resource.draft_curation_requested &&
-          !resource.accessibility_remediation_requested &&
-          !resource.file_version_memberships.any?(&:accessibility_score_pending?)) || current_user.admin?
-      else
-        true
-      end
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :allow_publish? if respond_to?(:helper_method)
+  end
+
+  def allow_publish?(resource)
+    deposit_pathway ||= WorkDepositPathway.new(resource)
+    if deposit_pathway.work? && resource.is_a?(WorkVersion)
+      (!resource.draft_curation_requested &&
+        !resource.accessibility_remediation_requested &&
+        resource.file_version_memberships.none?(&:accessibility_score_pending?)) || current_user.admin?
+    else
+      true
     end
   end
+end

--- a/app/controllers/concerns/allow_publish.rb
+++ b/app/controllers/concerns/allow_publish.rb
@@ -1,0 +1,18 @@
+module AllowPublish
+    extend ActiveSupport::Concern
+  
+    included do
+      helper_method :allow_publish? if respond_to?(:helper_method)
+    end
+    
+    def allow_publish?(resource)
+      deposit_pathway ||= WorkDepositPathway.new(resource)
+      if deposit_pathway.work?
+        (!resource.draft_curation_requested &&
+          !resource.accessibility_remediation_requested &&
+          !resource.file_version_memberships.any?(&:accessibility_score_pending?)) || current_user.admin?
+      else
+        true
+      end
+    end
+  end

--- a/app/controllers/dashboard/form/base_controller.rb
+++ b/app/controllers/dashboard/form/base_controller.rb
@@ -3,6 +3,8 @@
 module Dashboard
   module Form
     class BaseController < ::Dashboard::BaseController
+      include AllowPublish
+
       private
 
         def resource_klass
@@ -101,13 +103,8 @@ module Dashboard
           deposit_pathway.allows_mint_doi_request?
         end
 
-        helper_method :allow_publish?
         def allow_publish?
-          if deposit_pathway.work?
-            (!@resource.draft_curation_requested && !@resource.accessibility_remediation_requested) || current_user.admin?
-          else
-            true
-          end
+          super(@resource)
         end
 
         helper_method :param_key

--- a/app/forms/work_deposit_pathway.rb
+++ b/app/forms/work_deposit_pathway.rb
@@ -136,6 +136,8 @@ class WorkDepositPathway
                :work_type,
                :draft_curation_requested,
                :accessibility_remediation_requested,
+               :file_resources,
+               :file_version_memberships,
                :mint_doi_requested,
                to: :work_version, prefix: false
 

--- a/app/javascript/controllers/publish_status_controller.js
+++ b/app/javascript/controllers/publish_status_controller.js
@@ -1,37 +1,37 @@
 import { Controller } from 'stimulus'
-import consumer from "../channels/consumer"
+import consumer from '../channels/consumer'
 
 export default class extends Controller {
   static targets = ['show_buttons', 'help_text'];
 
-  connect() {
+  connect () {
     consumer.subscriptions.create(
-      { channel: "PublishStatusChannel" },
+      { channel: 'PublishStatusChannel' },
       {
         connected: () => {
-            this.renderPublishStatus()
+          this.renderPublishStatus()
         },
         received: (data) => {
-            this.updatePublishStatus(data)
+          this.updatePublishStatus(data)
         }
       }
     )
-    console.log("TESTING: PublishStatusChannel subscription created");
+    console.log('TESTING: PublishStatusChannel subscription created')
   }
 
   updatePublishStatus (data) {
     this.data.set('allowPublish', data.allow_publish)
-    
+
     this.renderPublishStatus()
   }
 
   renderPublishStatus () {
     const primaryAction = this.data.get('primaryAction')
     const allowPublish = this.data.get('allowPublish') === 'true'
-    const show = allowPublish || primaryAction === "save_and_continue"
+    const show = allowPublish || primaryAction === 'save_and_continue'
 
-    console.log("TESTING: PublishStatusController show set as ", show);
-    this.show_buttonsTarget.classList.toggle('d-none', !show);
-    this.help_textTarget.classList.toggle('d-none', show);
+    console.log('TESTING: PublishStatusController show set as ', show)
+    this.show_buttonsTarget.classList.toggle('d-none', !show)
+    this.help_textTarget.classList.toggle('d-none', show)
   }
 }

--- a/app/javascript/controllers/publish_status_controller.js
+++ b/app/javascript/controllers/publish_status_controller.js
@@ -1,0 +1,55 @@
+import { Controller } from 'stimulus'
+import consumer from "../channels/consumer"
+
+export default class extends Controller {
+  static targets = ['show_buttons'];
+
+//   updatePublishStatus(data) {
+//     console.log("TESTING: PublishStatusController updatePublishStatus called");
+//     const allowPublish = data.allow_publish === "true";
+//     const primaryAction = data.primary_action;
+//     const show = allowPublish || primaryAction === "save_and_continue";
+//     // if (show) {
+//     //     this.show_buttonsTarget.classList.remove('d-none')
+//     //   } else {
+//     //     this.show_buttonsTarget.classList.add('d-none')
+//     //   }
+//     console.log("TESTING: PublishStatusController show set as ", show);
+//     this.show_buttonsTarget.classList.toggle('d-none', !show);
+//   }
+
+  connect() {
+    console.log("TESTING: PublishStatusController connected");
+    consumer.subscriptions.create(
+      { channel: "PublishStatusChannel" },
+      {
+        connected: () => {
+            this.renderPublishStatus()
+        },
+        received: (data) => {
+            this.updatePublishStatus(data)
+        }
+      }
+    )
+    console.log("TESTING: PublishStatusChannel subscription created");
+  }
+
+  updatePublishStatus (data) {
+    this.data.set('allowPublish', data.allow_publish)
+    
+    this.renderPublishStatus()
+  }
+
+  renderPublishStatus () {
+    const primaryAction = this.data.get('primaryAction')
+    const allowPublish = this.data.get('allowPublish') === 'true'
+    const show = allowPublish || primaryAction === "save_and_continue"
+
+    console.log("TESTING: PublishStatusController show set as ", show);
+    this.show_buttonsTarget.classList.toggle('d-none', !show);
+  }
+
+  disconnect() {
+    this.subscription.unsubscribe();
+  }
+}

--- a/app/javascript/controllers/publish_status_controller.js
+++ b/app/javascript/controllers/publish_status_controller.js
@@ -16,7 +16,6 @@ export default class extends Controller {
         }
       }
     )
-    console.log('TESTING: PublishStatusChannel subscription created')
   }
 
   updatePublishStatus (data) {
@@ -30,7 +29,6 @@ export default class extends Controller {
     const allowPublish = this.data.get('allowPublish') === 'true'
     const show = allowPublish || primaryAction === 'save_and_continue'
 
-    console.log('TESTING: PublishStatusController show set as ', show)
     this.show_buttonsTarget.classList.toggle('d-none', !show)
     this.help_textTarget.classList.toggle('d-none', show)
   }

--- a/app/javascript/controllers/publish_status_controller.js
+++ b/app/javascript/controllers/publish_status_controller.js
@@ -2,7 +2,7 @@ import { Controller } from 'stimulus'
 import consumer from "../channels/consumer"
 
 export default class extends Controller {
-  static targets = ['show_buttons'];
+  static targets = ['show_buttons', 'help_text'];
 
   connect() {
     consumer.subscriptions.create(
@@ -32,5 +32,6 @@ export default class extends Controller {
 
     console.log("TESTING: PublishStatusController show set as ", show);
     this.show_buttonsTarget.classList.toggle('d-none', !show);
+    this.help_textTarget.classList.toggle('d-none', show);
   }
 }

--- a/app/javascript/controllers/publish_status_controller.js
+++ b/app/javascript/controllers/publish_status_controller.js
@@ -4,22 +4,7 @@ import consumer from "../channels/consumer"
 export default class extends Controller {
   static targets = ['show_buttons'];
 
-//   updatePublishStatus(data) {
-//     console.log("TESTING: PublishStatusController updatePublishStatus called");
-//     const allowPublish = data.allow_publish === "true";
-//     const primaryAction = data.primary_action;
-//     const show = allowPublish || primaryAction === "save_and_continue";
-//     // if (show) {
-//     //     this.show_buttonsTarget.classList.remove('d-none')
-//     //   } else {
-//     //     this.show_buttonsTarget.classList.add('d-none')
-//     //   }
-//     console.log("TESTING: PublishStatusController show set as ", show);
-//     this.show_buttonsTarget.classList.toggle('d-none', !show);
-//   }
-
   connect() {
-    console.log("TESTING: PublishStatusController connected");
     consumer.subscriptions.create(
       { channel: "PublishStatusChannel" },
       {
@@ -47,9 +32,5 @@ export default class extends Controller {
 
     console.log("TESTING: PublishStatusController show set as ", show);
     this.show_buttonsTarget.classList.toggle('d-none', !show);
-  }
-
-  disconnect() {
-    this.subscription.unsubscribe();
   }
 }

--- a/app/models/accessibility_check_result.rb
+++ b/app/models/accessibility_check_result.rb
@@ -50,7 +50,7 @@ class AccessibilityCheckResult < ApplicationRecord
       resource = file_resource.work_versions.last
 
       ActionCable.server.broadcast(
-        "publish_status_channel",
+        'publish_status_channel',
         { allow_publish: AllowPublishService.check(resource) }
       )
     end

--- a/app/models/file_version_membership.rb
+++ b/app/models/file_version_membership.rb
@@ -49,7 +49,7 @@ class FileVersionMembership < ApplicationRecord
   end
 
   def accessibility_score_pending?
-    mime_type == 'application/pdf' && !accessibility_result.present?
+    mime_type == 'application/pdf' && accessibility_result.blank?
   end
 
   def accessibility_failures?

--- a/app/models/file_version_membership.rb
+++ b/app/models/file_version_membership.rb
@@ -49,7 +49,7 @@ class FileVersionMembership < ApplicationRecord
   end
 
   def accessibility_score_pending?
-    mime_type == 'application/pdf' && !accessibility_score_present?
+    mime_type == 'application/pdf' && !accessibility_result.present?
   end
 
   def accessibility_failures?

--- a/app/models/file_version_membership.rb
+++ b/app/models/file_version_membership.rb
@@ -48,6 +48,10 @@ class FileVersionMembership < ApplicationRecord
     accessibility_result&.score.present?
   end
 
+  def accessibility_score_pending?
+    mime_type == 'application/pdf' && !accessibility_score_present?
+  end
+
   def accessibility_failures?
     accessibility_result&.failures_present? || accessibility_result.blank?
   end

--- a/app/services/allow_publish_service.rb
+++ b/app/services/allow_publish_service.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 class AllowPublishService
-    include AllowPublish
-  
-    def self.check(resource)
-      new.allow_publish?(resource)
-    end
+  include AllowPublish
+
+  def self.check(resource)
+    new.allow_publish?(resource)
   end
+end

--- a/app/services/allow_publish_service.rb
+++ b/app/services/allow_publish_service.rb
@@ -1,0 +1,7 @@
+class AllowPublishService
+    include AllowPublish
+  
+    def self.check(resource)
+      new.allow_publish?(resource)
+    end
+  end

--- a/app/views/dashboard/form/shared/_action_footer.html.erb
+++ b/app/views/dashboard/form/shared/_action_footer.html.erb
@@ -3,9 +3,9 @@
 
 <footer class="footer footer--actions footer--fixed d-flex justify-content-center">
   <div>
-<span data-controller="publish-status" 
-      data-publish-status-allow-publish="<%= allow_publish? %>" 
-      data-publish-status-primary-action="<%= primary_action %>" >
+<span data-controller="publish-status"
+      data-publish-status-allow-publish="<%= allow_publish? %>"
+      data-publish-status-primary-action="<%= primary_action %>">
       <span data-target="publish-status.show_buttons">
       <% if primary_action == :publish %>
         <span data-controller="publishing-check">
@@ -23,7 +23,7 @@
       <% end %>
       </span>
       <span data-target="publish-status.help_text">
-        <%= t("dashboard.form.actions.publish.blocked") %>
+        <%= t('dashboard.form.actions.publish.blocked') %>
       </span>
   </span>
 

--- a/app/views/dashboard/form/shared/_action_footer.html.erb
+++ b/app/views/dashboard/form/shared/_action_footer.html.erb
@@ -3,7 +3,10 @@
 
 <footer class="footer footer--actions footer--fixed d-flex justify-content-center">
   <div>
-    <% if allow_publish? || primary_action == :save_and_continue %>
+<span data-controller="publish-status" 
+      data-publish-status-allow-publish="<%= allow_publish? %>" 
+      data-publish-status-primary-action="<%= primary_action %>" 
+      data-target="publish-status.show_buttons">
       <% if primary_action == :publish %>
         <span data-controller="publishing-check">
           <%= render 'dashboard/form/publish/publish_dialog', f: form %>
@@ -18,7 +21,7 @@
       <% else %>
         <%= form.submit t("dashboard.form.actions.#{primary_action}.button"), name: primary_action, data: { toggle: 'tooltip', placement: 'top', title: t("dashboard.form.actions.#{primary_action}.tooltip") }, class: 'btn btn-primary btn--rounded' %>
       <% end %>
-  <% end %>
+  </span>
 
     <%= link_to t('dashboard.form.actions.cancel.button'), cancel_path, data: { toggle: 'tooltip', placement: 'top', title: t('dashboard.form.actions.cancel.tooltip') }, class: 'btn btn-outline-dark btn--rounded ml-2' %>
   </div>

--- a/app/views/dashboard/form/shared/_action_footer.html.erb
+++ b/app/views/dashboard/form/shared/_action_footer.html.erb
@@ -5,8 +5,8 @@
   <div>
 <span data-controller="publish-status" 
       data-publish-status-allow-publish="<%= allow_publish? %>" 
-      data-publish-status-primary-action="<%= primary_action %>" 
-      data-target="publish-status.show_buttons">
+      data-publish-status-primary-action="<%= primary_action %>" >
+      <span data-target="publish-status.show_buttons">
       <% if primary_action == :publish %>
         <span data-controller="publishing-check">
           <%= render 'dashboard/form/publish/publish_dialog', f: form %>
@@ -21,6 +21,10 @@
       <% else %>
         <%= form.submit t("dashboard.form.actions.#{primary_action}.button"), name: primary_action, data: { toggle: 'tooltip', placement: 'top', title: t("dashboard.form.actions.#{primary_action}.tooltip") }, class: 'btn btn-primary btn--rounded' %>
       <% end %>
+      </span>
+      <span data-target="publish-status.help_text">
+        <%= t("dashboard.form.actions.publish.blocked") %>
+      </span>
   </span>
 
     <%= link_to t('dashboard.form.actions.cancel.button'), cancel_path, data: { toggle: 'tooltip', placement: 'top', title: t('dashboard.form.actions.cancel.tooltip') }, class: 'btn btn-outline-dark btn--rounded ml-2' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -429,6 +429,7 @@ en:
         publish: 
           button: Publish
           tooltip: Publish your work to make it publicly visible. Changes cannot be made to the published version, but you can create a new version if updates are needed.
+          blocked: Publishing blocked until Accessibility Results are finished processing
         confirm:
           publish: Confirm publish
           request_curation: Confirm Request Curation

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -57,6 +57,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_pdf_file do
+      after(:build, :stub) do |work_version|
+        work_version.file_resources << build(:file_resource, :pdf)
+      end
+    end
+
     # Bare minimum for a valid draft
     trait :draft do
       aasm_state { WorkVersion::STATE_DRAFT }
@@ -67,6 +73,17 @@ FactoryBot.define do
       article
       draft
       with_files
+      with_creators
+      description { Faker::Lorem.paragraph }
+      published_date { Faker::Date.between(from: 2.years.ago, to: Date.today).iso8601 }
+    end
+
+    # A draft article including a pdf that has everything needed to pass validations and be published
+    trait :able_to_be_published_with_pdf do
+      article
+      draft
+      with_files
+      with_pdf_file
       with_creators
       description { Faker::Lorem.paragraph }
       published_date { Faker::Date.between(from: 2.years.ago, to: Date.today).iso8601 }

--- a/spec/jobs/accessibility_check_job_spec.rb
+++ b/spec/jobs/accessibility_check_job_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe AccessibilityCheckJob do
-  let(:resource) { create(:file_resource) }
+  let(:resource) { create(:file_resource, :pdf, work_versions: [create(:work_version)]) }
   let(:service) { instance_double(AdobePdf::AccessibilityChecker, call: true) }
 
   before do

--- a/spec/models/accessibility_check_result_spec.rb
+++ b/spec/models/accessibility_check_result_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe AccessibilityCheckResult do
     before do
       allow(check_result).to receive(:persisted?).and_return(true)
       allow(check_result).to receive(:broadcast_to_file_version_memberships)
+      allow(check_result).to receive(:broadcast_publish_status)
       check_result.instance_variable_set(:@_new_record_before_last_commit, true)
       test_user = user
       AllowPublishService.class_eval do
@@ -36,6 +37,7 @@ RSpec.describe AccessibilityCheckResult do
     it 'calls subscribe when created' do
       check_result.run_callbacks(:commit)
       expect(check_result).to have_received(:broadcast_to_file_version_memberships)
+      expect(check_result).to have_received(:broadcast_publish_status)
     end
   end
 

--- a/spec/models/file_resource_spec.rb
+++ b/spec/models/file_resource_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe FileResource do
 
   describe 'scopes' do
     describe '.needs_accessibility_check' do
-      let(:file_resource_with_check) { create(:file_resource, :pdf) }
-      let(:file_resource_without_check) { create(:file_resource, :pdf) }
-      let(:non_pdf_file_resource) { create(:file_resource, :with_processed_image) }
+      let(:file_resource_with_check) { create(:file_resource, :pdf, work_versions: [create(:work_version)]) }
+      let(:file_resource_without_check) { create(:file_resource, :pdf, work_versions: [create(:work_version)]) }
+      let(:non_pdf_file_resource) { create(:file_resource, :with_processed_image, work_versions: [create(:work_version)]) }
 
       before do
         create(:accessibility_check_result, file_resource: file_resource_with_check)

--- a/spec/models/file_version_membership_spec.rb
+++ b/spec/models/file_version_membership_spec.rb
@@ -238,6 +238,39 @@ RSpec.describe FileVersionMembership do
     end
   end
 
+  describe '#accessibility_score_pending?' do
+    let(:file_version_membership) { create(:file_version_membership, file_resource: file) }
+    let(:file) { create(:file_resource) }
+
+    context 'when there is not a check result' do
+      context 'when the file is a pdf' do
+        let(:file) { create(:file_resource, :pdf) }
+
+        it 'returns true' do
+          expect(file_version_membership.accessibility_score_pending?).to eq true
+        end
+      end
+
+      context 'when the file is not a pdf' do
+        it 'returns false' do
+          expect(file_version_membership.accessibility_score_pending?).to eq false
+        end
+      end
+    end
+
+    context 'when there is a check result' do
+      let(:accessibility_check_result) do
+        create(:accessibility_check_result, file_resource_id: file_version_membership.file_resource.id)
+      end
+
+      before { accessibility_check_result.save! }
+
+      it 'returns false' do
+        expect(file_version_membership.accessibility_score_pending?).to eq false
+      end
+    end
+  end
+
   describe '#accessibility_failures?' do
     let(:file_version_membership) { create(:file_version_membership) }
 

--- a/spec/services/adobe_pdf/accessibility_checker_spec.rb
+++ b/spec/services/adobe_pdf/accessibility_checker_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AdobePdf::AccessibilityChecker, :vcr do
   end
 
   describe '#call' do
-    let(:resource) { create(:file_resource, :pdf) }
+    let(:resource) { create(:file_resource, :pdf, work_versions: [create(:work_version)]) }
 
     # Turn off vcr here for a full, live integration test
     describe 'happy path' do


### PR DESCRIPTION
Fixes #1625 

I moved `allow_publish?` into a concern so that it could be used in the broadcast method as well. From what I read, it's not good practice to call a concern directly which is why I added the service class, but as always, I'm open to suggestion if that's not actually the case.