### PR TITLE
Delete orphaned FileResources

### DIFF
--- a/app/models/accessibility_check_result.rb
+++ b/app/models/accessibility_check_result.rb
@@ -3,8 +3,8 @@
 class AccessibilityCheckResult < ApplicationRecord
   belongs_to :file_resource
 
-  after_commit :broadcast_to_file_version_memberships
-  after_commit :broadcast_publish_status
+  after_commit :broadcast_to_file_version_memberships, on: [:create, :update]
+  after_commit :broadcast_publish_status, on: [:create, :update]
 
   validates :detailed_report, presence: true
 

--- a/app/models/file_version_membership.rb
+++ b/app/models/file_version_membership.rb
@@ -4,11 +4,10 @@ class FileVersionMembership < ApplicationRecord
   belongs_to :work_version
   belongs_to :file_resource
 
+  before_validation :initialize_title, on: :create
   after_destroy :destroy_file_if_orphaned
 
   default_scope { order(title: :asc) }
-
-  before_validation :initialize_title, on: :create
 
   validates :title,
             presence: true,

--- a/app/models/file_version_membership.rb
+++ b/app/models/file_version_membership.rb
@@ -4,6 +4,8 @@ class FileVersionMembership < ApplicationRecord
   belongs_to :work_version
   belongs_to :file_resource
 
+  after_destroy :destroy_file_if_orphaned
+
   default_scope { order(title: :asc) }
 
   before_validation :initialize_title, on: :create
@@ -78,5 +80,9 @@ class FileVersionMembership < ApplicationRecord
       return if title.blank? || File.extname(title) == File.extname(original_filename)
 
       errors.add(:title, :different_extension, original: original_filename)
+    end
+
+    def destroy_file_if_orphaned
+      file_resource.destroy if file_resource.file_version_memberships.reload.empty?
     end
 end

--- a/lib/tasks/destroy_orphaned_file_resources.rake
+++ b/lib/tasks/destroy_orphaned_file_resources.rake
@@ -1,0 +1,11 @@
+namespace :cleanup do
+  desc "Destroy orphaned file resources"
+  task destroy_orphaned_file_resources: :environment do
+    orphaned_file_resources = FileResource.left_joins(:file_version_memberships)
+                                          .where(file_version_memberships: { id: nil })
+
+    orphaned_file_resources.each do |file_resource|
+      file_resource.destroy
+    end
+  end
+end

--- a/lib/tasks/destroy_orphaned_file_resources.rake
+++ b/lib/tasks/destroy_orphaned_file_resources.rake
@@ -1,11 +1,10 @@
-namespace :cleanup do
-  desc "Destroy orphaned file resources"
-  task destroy_orphaned_file_resources: :environment do
-    orphaned_file_resources = FileResource.left_joins(:file_version_memberships)
-                                          .where(file_version_memberships: { id: nil })
+# frozen_string_literal: true
 
-    orphaned_file_resources.each do |file_resource|
-      file_resource.destroy
-    end
+namespace :cleanup do
+  desc 'Destroy orphaned file resources'
+  task destroy_orphaned_file_resources: :environment do
+    orphaned_file_resources = FileResource.where.missing(:file_version_memberships)
+
+    orphaned_file_resources.each(&:destroy)
   end
 end

--- a/spec/models/accessibility_check_result_spec.rb
+++ b/spec/models/accessibility_check_result_spec.rb
@@ -41,6 +41,42 @@ RSpec.describe AccessibilityCheckResult do
     end
   end
 
+  describe 'after_commit callbacks' do
+    let(:detailed_report) {
+      { 'Detailed Report' => { 'Status' => 'Something' } }
+    }
+
+    before do
+      accessibility_check_result.save!
+      allow(accessibility_check_result).to receive(:broadcast_to_file_version_memberships)
+      allow(accessibility_check_result).to receive(:broadcast_publish_status)
+    end
+
+    context 'when create' do
+      it 'calls broadcast_to_file_version_memberships and broadcast_publish_status' do
+        accessibility_check_result.save!
+        expect(accessibility_check_result).to have_received(:broadcast_to_file_version_memberships)
+        expect(accessibility_check_result).to have_received(:broadcast_publish_status)
+      end
+    end
+
+    context 'when update' do
+      it 'calls broadcast_to_file_version_memberships and broadcast_publish_status' do
+        accessibility_check_result.update!(detailed_report: { 'Detailed Report' => {} })
+        expect(accessibility_check_result).to have_received(:broadcast_to_file_version_memberships)
+        expect(accessibility_check_result).to have_received(:broadcast_publish_status)
+      end
+    end
+
+    context 'when destroy' do
+      it 'does not call broadcast_to_file_version_memberships or broadcast_publish_status' do
+        accessibility_check_result.destroy!
+        expect(accessibility_check_result).not_to have_received(:broadcast_to_file_version_memberships)
+        expect(accessibility_check_result).not_to have_received(:broadcast_publish_status)
+      end
+    end
+  end
+
   describe '#score' do
     let(:detailed_report) {
         { 'Detailed Report' => {

--- a/spec/models/file_version_membership_spec.rb
+++ b/spec/models/file_version_membership_spec.rb
@@ -34,6 +34,31 @@ RSpec.describe FileVersionMembership do
     end
   end
 
+  describe 'after_destroy callback' do
+    let(:file_resource) { create(:file_resource) }
+
+    context 'when the file_resource becomes orphaned' do
+      it 'destroys the file_resource' do
+        file_version_membership = create(:file_version_membership, file_resource: file_resource)
+        expect(FileResource.exists?(file_resource.id)).to be true
+
+        file_version_membership.destroy
+        expect(FileResource.exists?(file_resource.id)).to be false
+      end
+    end
+
+    context 'when the file_resource is not orphaned' do
+      it 'does not destroy the file_resource' do
+        file_version_membership1 = create(:file_version_membership, file_resource: file_resource)
+        file_version_membership2 = create(:file_version_membership, file_resource: file_resource)
+        expect(FileResource.exists?(file_resource.id)).to be true
+
+        file_version_membership1.destroy
+        expect(FileResource.exists?(file_resource.id)).to be true
+      end
+    end
+  end
+
   describe 'delegate methods' do
     subject(:membership) { build(:file_version_membership) }
 

--- a/spec/models/file_version_membership_spec.rb
+++ b/spec/models/file_version_membership_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe FileVersionMembership do
     context 'when the file_resource is not orphaned' do
       it 'does not destroy the file_resource' do
         file_version_membership1 = create(:file_version_membership, file_resource: file_resource)
-        file_version_membership2 = create(:file_version_membership, file_resource: file_resource)
+        create(:file_version_membership, file_resource: file_resource)
         expect(FileResource.exists?(file_resource.id)).to be true
 
         file_version_membership1.destroy


### PR DESCRIPTION
closes #792 

Shrine is already set up to delete files in S3 (the file and it's derivatives) when a FileResource is destroyed.  However, since FileResources could have multiple associations with WorkVersions, there was no function to delete the FileResource once orphaned.  This PR fixes that and adds a rake task to cleanup existing orphaned FileResources.