### PR TITLE
Configure session timeout with devise after three days

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   # Connects this user object to Blacklights Bookmarks.
   include Blacklight::User
 
-  devise :omniauthable, omniauth_providers: %i[azure_oauth]
+  devise :timeoutable, :omniauthable, omniauth_providers: %i[azure_oauth]
 
   attr_writer :guest
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -190,7 +190,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 3.days
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -190,7 +190,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 3.days
+  config.timeout_in = 8.hours
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
This should force users to reauthenticate with azure after 8 hours so we don't have banned users running months-long sessions.

Note: this only ends the session if there is no activity from the user