### PR TITLE
Adds old file download route and directs to legacy urls controller

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,6 +183,7 @@ Rails.application.routes.draw do
   # lead to an extraordinarily unlikely false positive, but it would never lead to a false negative.
   get '/concern/generic_works/:id', to: 'legacy_urls#v3'
   get '/collections/:id', to: 'legacy_urls#v3'
+  get '/downloads/:id', to: 'legacy_urls#v3'
 
   # Bot challenge page
   post '/challenge', to: 'bot_challenge_page/bot_challenge_page#verify_challenge', as: :bot_detect_challenge

--- a/spec/request/legacy_urls_spec.rb
+++ b/spec/request/legacy_urls_spec.rb
@@ -38,6 +38,20 @@ RSpec.describe LegacyUrlsController, type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context 'when directed from a v3 file download path' do
+      before do
+        create(:legacy_identifier,
+               version: 3,
+               old_id: 'old1234id',
+               resource: resource)
+      end
+
+      it do
+        get '/downloads/old1234id'
+        expect(response).to redirect_to resource_path(resource.uuid)
+      end
+    end
   end
 
   describe 'Scholarsphere v3 legacy URLs to a Collection' do


### PR DESCRIPTION
This was all I needed to get the SchoalrSphere 3 file download paths to map up to ScholarSphere 4 work paths. 