### PR TITLE
Use more idiomatic way of checking for test env

### DIFF
--- a/config/initializers/bot_challenge_page.rb
+++ b/config/initializers/bot_challenge_page.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.config.to_prepare do
-  BotChallengePage::BotChallengePageController.bot_challenge_config.enabled = ENV.fetch('RAILS_ENV') != 'test'
+  BotChallengePage::BotChallengePageController.bot_challenge_config.enabled = !Rails.env.test?
 
   # Get from CloudFlare Turnstile: https://www.cloudflare.com/application-services/products/turnstile/
   # Some testing keys are also available: https://developers.cloudflare.com/turnstile/troubleshooting/testing/


### PR DESCRIPTION
This was causing some issues locally.