### PR TITLE
Prevent deletion of FileResource if there's an associated ThumbnailUpload

### DIFF
--- a/app/models/file_resource.rb
+++ b/app/models/file_resource.rb
@@ -25,6 +25,7 @@ class FileResource < ApplicationRecord
           required: false,
           dependent: :destroy
 
+  before_destroy :cannot_be_deleted_if_linked_to_thumbnail_upload
   after_commit :perform_update_index, on: [:create, :update]
 
   scope :needs_accessibility_check, -> {
@@ -104,5 +105,12 @@ class FileResource < ApplicationRecord
 
     def perform_update_index
       indexing_source.call(self)
+    end
+
+    def cannot_be_deleted_if_linked_to_thumbnail_upload
+      if thumbnail_upload.present?
+        errors.add(:base, 'FileResource cannot be deleted while associated with a ThumbnailUpload')
+        throw(:abort)
+      end
     end
 end

--- a/app/models/thumbnail_upload.rb
+++ b/app/models/thumbnail_upload.rb
@@ -4,8 +4,7 @@ class ThumbnailUpload < ApplicationRecord
   belongs_to :resource,
              polymorphic: true
 
-  belongs_to :file_resource,
-             dependent: :destroy
+  belongs_to :file_resource
 
   validates :resource_id,
             :resource_type,

--- a/spec/models/file_resource_spec.rb
+++ b/spec/models/file_resource_spec.rb
@@ -298,4 +298,25 @@ RSpec.describe FileResource do
       end
     end
   end
+
+  describe 'cannot_be_deleted_if_linked_to_thumbnail_upload' do
+    let!(:file_resource) { create(:file_resource) }
+
+    context 'when the file resource has a linked thumbnail upload' do
+      before do
+        create(:thumbnail_upload, file_resource: file_resource)
+      end
+
+      it 'does not allow the file resource to be deleted' do
+        expect { file_resource.destroy }.not_to change(described_class, :count)
+        expect(file_resource.errors[:base]).to include('FileResource cannot be deleted while associated with a ThumbnailUpload')
+      end
+    end
+
+    context 'when the file resource does not have a linked thumbnail upload' do
+      it 'allows the file resource to be deleted' do
+        expect { file_resource.destroy }.to change(described_class, :count).by(-1)
+      end
+    end
+  end
 end

--- a/spec/models/file_resource_spec.rb
+++ b/spec/models/file_resource_spec.rb
@@ -316,6 +316,7 @@ RSpec.describe FileResource do
     context 'when the file resource does not have a linked thumbnail upload' do
       it 'allows the file resource to be deleted' do
         expect { file_resource.destroy }.to change(described_class, :count).by(-1)
+        expect(file_resource.errors[:base]).to be_empty
       end
     end
   end


### PR DESCRIPTION
Since this set up for thumbnail uploads is not ideal, it's easier to just add a validation to the destroy callback to prevent a FileResource from being deleted if there's an associated ThumbnailUpload.

Ideally, ThumbnailUploads should just operate like a FileUploader and inherit all the Shrine functionality separate from FileResource.  Not sure why it was done this way, but I seem to remember there being a reason.  I just can't remember what.