### PR TITLE
Send RMD uploads to airtable for curation

### DIFF
--- a/app/services/curation_sync_service.rb
+++ b/app/services/curation_sync_service.rb
@@ -41,7 +41,7 @@ class CurationSyncService
       publishing_changes = work_version.versions.select { |v| v.object_changes['published_at'].present? }
       whodunnit = publishing_changes.last['whodunnit']
       user = GlobalID::Locator.locate(whodunnit)
-      user.is_a?(User) && user&.admin?
+      user.is_a?(User) && user.admin?
     rescue StandardError
       false
     end

--- a/app/services/curation_sync_service.rb
+++ b/app/services/curation_sync_service.rb
@@ -10,6 +10,7 @@ class CurationSyncService
     tasks = CurationTaskClient.find_all(@work.id)
     task_uuids = tasks.pluck('ID')
 
+    byebug
     if task_uuids.exclude?(current_version_for_curation.uuid) && !admin_submitted?(current_version_for_curation)
       CurationTaskClient.send_curation(current_version_for_curation.id, updated_version: updated_version(tasks))
     end

--- a/app/services/curation_sync_service.rb
+++ b/app/services/curation_sync_service.rb
@@ -41,7 +41,7 @@ class CurationSyncService
       publishing_changes = work_version.versions.select { |v| v.object_changes['published_at'].present? }
       whodunnit = publishing_changes.last['whodunnit']
       user = GlobalID::Locator.locate(whodunnit)
-      user&.admin? && !user.class.is_a?(ExternalApp)
+      user.is_a?(User) && user&.admin?
     rescue StandardError
       false
     end

--- a/app/services/curation_sync_service.rb
+++ b/app/services/curation_sync_service.rb
@@ -10,7 +10,6 @@ class CurationSyncService
     tasks = CurationTaskClient.find_all(@work.id)
     task_uuids = tasks.pluck('ID')
 
-    byebug
     if task_uuids.exclude?(current_version_for_curation.uuid) && !admin_submitted?(current_version_for_curation)
       CurationTaskClient.send_curation(current_version_for_curation.id, updated_version: updated_version(tasks))
     end

--- a/app/services/curation_sync_service.rb
+++ b/app/services/curation_sync_service.rb
@@ -41,7 +41,7 @@ class CurationSyncService
       publishing_changes = work_version.versions.select { |v| v.object_changes['published_at'].present? }
       whodunnit = publishing_changes.last['whodunnit']
       user = GlobalID::Locator.locate(whodunnit)
-      user&.admin?
+      user&.admin? && !user.class.is_a?(ExternalApp)
     rescue StandardError
       false
     end

--- a/spec/services/curation_sync_service_spec.rb
+++ b/spec/services/curation_sync_service_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe CurationSyncService do
         end
       end
 
-      context 'when the latest work version was created by an external app' do
+      context 'when the latest work version was created by something other than a user' do
         # The latest published work_version must be saved, so that PaperTrail can track the changes
         let(:work_version2) { create(:work_version, :published, title: 'Title with-dash') }
         let(:external_app)  { create(:external_app) }
@@ -130,7 +130,7 @@ RSpec.describe CurationSyncService do
         it 'sends current version for curation' do
           PaperTrail.request.whodunnit = external_app.id
           work_version2.update(published_at: Time.new(2024, 5, 10, 10, 30, 0))
-          expect(CurationTaskClient).not_to receive(:send_curation).with(work_version2.id, updated_version: true)
+          expect(CurationTaskClient).to receive(:send_curation).with(work_version2.id, updated_version: true)
           described_class.new(work).sync
         end
       end

--- a/spec/services/curation_sync_service_spec.rb
+++ b/spec/services/curation_sync_service_spec.rb
@@ -110,26 +110,20 @@ RSpec.describe CurationSyncService do
       end
 
       context 'when the latest work version was created by an admin user' do
-        # The latest published work_version must be saved, so that PaperTrail can track the changes
-        let(:work_version2) { create(:work_version, :published, title: 'Title with-dash') }
         let(:admin)  { create(:user, :admin) }
 
         it 'does not send current version for curation' do
-          PaperTrail.request.whodunnit = admin.to_gid.to_s
-          work_version2.update(published_at: Time.new(2024, 5, 10, 10, 30, 0))
+          work_version2.versions.last.update whodunnit: admin.to_gid.to_s
           expect(CurationTaskClient).not_to receive(:send_curation).with(work_version2.id, updated_version: true)
           described_class.new(work).sync
         end
       end
 
       context 'when the latest work version was created by something other than a user' do
-        # The latest published work_version must be saved, so that PaperTrail can track the changes
-        let(:work_version2) { create(:work_version, :published, title: 'Title with-dash') }
         let(:external_app)  { create(:external_app) }
 
         it 'sends current version for curation' do
-          PaperTrail.request.whodunnit = external_app.to_gid.to_s
-          work_version2.update(published_at: Time.new(2024, 5, 10, 10, 30, 0))
+          work_version2.versions.last.update whodunnit: external_app.to_gid.to_s
           expect(CurationTaskClient).to receive(:send_curation).with(work_version2.id, updated_version: true)
           described_class.new(work).sync
         end

--- a/spec/services/curation_sync_service_spec.rb
+++ b/spec/services/curation_sync_service_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe CurationSyncService do
       end
 
       context 'when the latest work version was created by something other than a user' do
-        let(:external_app)  { create(:external_app) }
+        let(:external_app) { create(:external_app) }
 
         it 'sends current version for curation' do
           work_version2.versions.last.update whodunnit: external_app.to_gid.to_s

--- a/spec/services/curation_sync_service_spec.rb
+++ b/spec/services/curation_sync_service_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe CurationSyncService do
         let(:admin)  { create(:user, :admin) }
 
         it 'does not send current version for curation' do
-          PaperTrail.request.whodunnit = admin.id
+          PaperTrail.request.whodunnit = admin.to_gid.to_s
           work_version2.update(published_at: Time.new(2024, 5, 10, 10, 30, 0))
           expect(CurationTaskClient).not_to receive(:send_curation).with(work_version2.id, updated_version: true)
           described_class.new(work).sync
@@ -128,7 +128,7 @@ RSpec.describe CurationSyncService do
         let(:external_app)  { create(:external_app) }
 
         it 'sends current version for curation' do
-          PaperTrail.request.whodunnit = external_app.id
+          PaperTrail.request.whodunnit = external_app.to_gid.to_s
           work_version2.update(published_at: Time.new(2024, 5, 10, 10, 30, 0))
           expect(CurationTaskClient).to receive(:send_curation).with(work_version2.id, updated_version: true)
           described_class.new(work).sync


### PR DESCRIPTION
Was debating removing this:

https://github.com/psu-libraries/scholarsphere/blob/main/app/models/external_app.rb#L44-L48

But decided not to because:

1.  It broke a bunch of tests _and_
2. The statement `For all intensive purposes, external applications have admin rights` is still true.  External apps still have admin rights, they just aren't included in the "Don't send to airtable if published by us" logic