### PR TITLE
Fix publish form bug for Grad Culminating Experiences

### DIFF
--- a/app/forms/work_deposit_pathway.rb
+++ b/app/forms/work_deposit_pathway.rb
@@ -188,6 +188,7 @@ class WorkDepositPathway
                :file_resources,
                :file_version_memberships,
                :mint_doi_requested,
+               :has_image_file_resource?,
                to: :work_version, prefix: false
 
       private
@@ -208,7 +209,6 @@ class WorkDepositPathway
       }.freeze
 
       delegate :imported_metadata_from_rmd,
-               :has_image_file_resource?,
                to: :work_version, prefix: false
 
       def show_autocomplete_form?

--- a/spec/forms/work_deposit_pathway_spec.rb
+++ b/spec/forms/work_deposit_pathway_spec.rb
@@ -944,4 +944,26 @@ RSpec.describe WorkDepositPathway do
       end
     end
   end
+
+  describe '#has_image_file_resource?' do
+    Work::Types.all.each do |t|
+      let(:type) { t }
+
+      context "when the given work version has a work type of #{t}" do
+        context 'when details form' do
+          it 'responds to has_image_file_resource?' do
+            form = pathway.details_form
+            expect(form).to respond_to(:has_image_file_resource?)
+          end
+        end
+
+        context 'when publish form' do
+          it 'responds to has_image_file_resource?' do
+            form = pathway.publish_form
+            expect(form).to respond_to(:has_image_file_resource?)
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Move has_file_image_resource? up the inheritance chain so it gets delegated for all work types in all forms.  Adds test for confirmation