### PR TITLE
Allow contributors to be deleted when required fields are blank

### DIFF
--- a/app/forms/work_deposit_pathway.rb
+++ b/app/forms/work_deposit_pathway.rb
@@ -248,6 +248,8 @@ class WorkDepositPathway
 
         def validate_creator_names
           creators.each do |creator|
+            next if creator.respond_to?(:marked_for_destruction?) && creator.marked_for_destruction?
+
             if creator.given_name.blank? || creator.surname.blank?
               errors.add(:creators, I18n.t('dashboard.form.contributors.edit.incomplete_name'))
             end

--- a/app/javascript/controllers/associations_controller.js
+++ b/app/javascript/controllers/associations_controller.js
@@ -7,7 +7,7 @@ import axios from 'axios'
 import { csrfToken } from './stimulus_modules'
 
 export default class extends Controller {
-  connect () {
+  connect() {
     this.wrapperClass = this.data.get('wrapper-class')
     this.badgeClass = this.data.get('badge-class')
     this.positionClass = this.data.get('position-class')
@@ -15,12 +15,18 @@ export default class extends Controller {
     document.addEventListener('autocomplete:after-selected', () => this.post(this.data.get('post')))
     document.addEventListener('actor:created', () => this.appendResponse(event.detail.response))
 
+    $(this.element).on('cocoon:before-remove', (e, removedElement) => {
+      $(removedElement)
+        .find('[required]')
+        .removeAttr('required')
+    })
+
     $(this.element).on('cocoon:after-remove', () => this.$updateChildren())
 
     this.$updateChildren()
   }
 
-  post (url) {
+  post(url) {
     axios({
       method: 'POST',
       url: url,
@@ -33,7 +39,7 @@ export default class extends Controller {
       .catch(error => this.processError(error))
   }
 
-  appendResponse (response) {
+  appendResponse(response) {
     this.element.insertAdjacentHTML('beforeend', response.data)
     this.$updateChildren()
     const lastWrapper = $(this.element).find(`.${this.wrapperClass}:visible`).last()
@@ -41,11 +47,11 @@ export default class extends Controller {
   }
 
   // @todo Something nicer should go here.
-  processError (error) {
+  processError(error) {
     console.log(error)
   }
 
-  moveUp (event) {
+  moveUp(event) {
     event.preventDefault()
     const $target = $(event.target)
     const $parentWrapper = $target.closest(`.${this.wrapperClass}`)
@@ -57,7 +63,7 @@ export default class extends Controller {
     }
   }
 
-  moveDown (event) {
+  moveDown(event) {
     event.preventDefault()
     const $target = $(event.target)
     const $parentWrapper = $target.closest(`.${this.wrapperClass}`)
@@ -70,7 +76,7 @@ export default class extends Controller {
   }
 
   // Uses jQuery
-  $updateChildren () {
+  $updateChildren() {
     const children = $(this.element)
       .find(`.${this.wrapperClass}:visible`)
 
@@ -84,7 +90,7 @@ export default class extends Controller {
   }
 
   // Uses jQuery
-  _$swapElements ($el1, $el2) {
+  _$swapElements($el1, $el2) {
     // create temporary placeholder
     const $temp = $('<div>')
 

--- a/spec/forms/work_deposit_pathways/contributors_form_base_spec.rb
+++ b/spec/forms/work_deposit_pathways/contributors_form_base_spec.rb
@@ -94,5 +94,19 @@ RSpec.describe WorkDepositPathway::ContributorsFormBase, type: :model do
         expect(form).to be_valid
       end
     end
+
+    context 'when contributor is marked for destruction' do
+      before do
+        wv.creators << build(:authorship, { display_name: 'Creator 1',
+                                            given_name: nil,
+                                            surname: 'Doe',
+                                            email: 'abc123@email.com' })
+        wv.creators.last.mark_for_destruction
+      end
+
+      it 'skips validation and is valid' do
+        expect(form).to be_valid
+      end
+    end
   end
 end

--- a/spec/javascript/associations_controller.test.js
+++ b/spec/javascript/associations_controller.test.js
@@ -1,0 +1,30 @@
+import { Application } from 'stimulus'
+import AssociationsController from 'associations_controller'
+import $ from 'jquery'
+
+window.$ = $
+window.jQuery = $
+
+describe('AssociationsController', () => {
+  let element, input
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div data-controller="associations">
+        <div id="to-remove">
+          <input type="text" required="required" />
+        </div>
+      </div>
+    `
+    element = document.querySelector('[data-controller="associations"]')
+    input = document.querySelector('#to-remove input')
+    const app = Application.start()
+    app.register('associations', AssociationsController)
+  })
+
+  it('removes required attribute from fields in the removed element on cocoon:before-remove', () => {
+    // Simulate cocoon:before-remove event
+    $(element).trigger('cocoon:before-remove', [$('#to-remove')])
+    expect(input.hasAttribute('required')).toBe(false)
+  })
+})


### PR DESCRIPTION
Admins noticed an issue when deleting contributors that did not have givennames or surnames: they could not submit the form after deleting a contributor.  This was caused by `cocoon` (our frontend package that handles `has_many` associations forms) not removing the `required` attributes when marking records for destruction.

This PR adds a cocoon event to remove all required attributes from all fields in an "association" (ie contributors) form and turns off form validation for contributors if they are marked for deletion.