### PR TITLE
Bump resources in policy.xml

### DIFF
--- a/config/policy.xml
+++ b/config/policy.xml
@@ -81,13 +81,13 @@ root@scholarsphere-thumbnails-686f5cc8bc-hzd24:/app# cat /etc/ImageMagick-6/poli
   <!-- <policy domain="system" name="memory-map" value="anonymous"/> -->
   <!-- <policy domain="system" name="max-memory-request" value="256MiB"/> -->
   <!-- <policy domain="resource" name="temporary-path" value="/tmp"/> -->
-  <policy domain="resource" name="memory" value="256MiB"/>
-  <policy domain="resource" name="map" value="512MiB"/>
+  <policy domain="resource" name="memory" value="1GiB"/>
+  <policy domain="resource" name="map" value="1GiB"/>
   <policy domain="resource" name="width" value="16KP"/>
   <policy domain="resource" name="height" value="16KP"/>
   <!-- <policy domain="resource" name="list-length" value="128"/> -->
-  <policy domain="resource" name="area" value="128MB"/>
-  <policy domain="resource" name="disk" value="1GiB"/>
+  <policy domain="resource" name="area" value="512MB"/>
+  <policy domain="resource" name="disk" value="4GiB"/>
   <!-- <policy domain="resource" name="file" value="768"/> -->
   <!-- <policy domain="resource" name="thread" value="4"/> -->
   <!-- <policy domain="resource" name="throttle" value="0"/> -->

--- a/config/policy.xml
+++ b/config/policy.xml
@@ -81,12 +81,12 @@ root@scholarsphere-thumbnails-686f5cc8bc-hzd24:/app# cat /etc/ImageMagick-6/poli
   <!-- <policy domain="system" name="memory-map" value="anonymous"/> -->
   <!-- <policy domain="system" name="max-memory-request" value="256MiB"/> -->
   <!-- <policy domain="resource" name="temporary-path" value="/tmp"/> -->
-  <policy domain="resource" name="memory" value="1GiB"/>
-  <policy domain="resource" name="map" value="1GiB"/>
+  <policy domain="resource" name="memory" value="512MiB"/>
+  <policy domain="resource" name="map" value="800MiB"/>
   <policy domain="resource" name="width" value="16KP"/>
   <policy domain="resource" name="height" value="16KP"/>
   <!-- <policy domain="resource" name="list-length" value="128"/> -->
-  <policy domain="resource" name="area" value="512MB"/>
+  <policy domain="resource" name="area" value="256MB"/>
   <policy domain="resource" name="disk" value="4GiB"/>
   <!-- <policy domain="resource" name="file" value="768"/> -->
   <!-- <policy domain="resource" name="thread" value="4"/> -->

--- a/config/policy.xml
+++ b/config/policy.xml
@@ -87,7 +87,7 @@ root@scholarsphere-thumbnails-686f5cc8bc-hzd24:/app# cat /etc/ImageMagick-6/poli
   <policy domain="resource" name="height" value="16KP"/>
   <!-- <policy domain="resource" name="list-length" value="128"/> -->
   <policy domain="resource" name="area" value="256MB"/>
-  <policy domain="resource" name="disk" value="4GiB"/>
+  <policy domain="resource" name="disk" value="2GiB"/>
   <!-- <policy domain="resource" name="file" value="768"/> -->
   <!-- <policy domain="resource" name="thread" value="4"/> -->
   <!-- <policy domain="resource" name="throttle" value="0"/> -->


### PR DESCRIPTION
We had some thumbnail generation jobs fail due to resources limitations.  The limits set in the policy.xml were _very_ conservative, so I bumped these up a decent amount.