### PR TITLE
remediation triggered popup notification

### DIFF
--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -31,6 +31,7 @@ linters:
       - '*app/views/resources/_work_version.html.erb'
       - '*app/views/resources/_collection.html.erb'
       - '*app/views/shared/_work_version_files.html.erb'
+      - '*app/views/shared/_remediation_popup.html.erb'
       - '*test/*'
   RightTrim:
     enabled: true

--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -31,7 +31,6 @@ linters:
       - '*app/views/resources/_work_version.html.erb'
       - '*app/views/resources/_collection.html.erb'
       - '*app/views/shared/_work_version_files.html.erb'
-      - '*app/views/shared/_remediation_popup.html.erb'
       - '*test/*'
   RightTrim:
     enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -136,6 +136,7 @@ RSpec/VerifiedDoubles:
     - 'spec/components/work_histories/work_history_component_spec.rb'
     - 'spec/controllers/dashboard/work_search_controller_spec.rb'
     - 'spec/services/session_view_stats_cache_spec.rb'
+    - 'spec/components/file_download_link_component_spec.rb'
 
 Style/ClassVars:
   Exclude:

--- a/app/components/file_download_link_component.html.erb
+++ b/app/components/file_download_link_component.html.erb
@@ -13,7 +13,12 @@
   <%= link_to download_path(download: true),
               title: download_title,
               class: 'matomo_download',
-              'aria-label' => aria_label(download: true) do %>
+              'aria-label' => aria_label(download: true),
+              data: {
+                controller: "popup",
+                action: "click->popup#show",
+                popup_show_alert: remediation_alert?
+              } do %>
     <%= download_title %>
   <% end %>
 </h3>

--- a/app/components/file_download_link_component.html.erb
+++ b/app/components/file_download_link_component.html.erb
@@ -21,4 +21,5 @@
               } do %>
     <%= download_title %>
   <% end %>
+  <%= render "shared/remediation_popup" %>
 </h3>

--- a/app/components/file_download_link_component.html.erb
+++ b/app/components/file_download_link_component.html.erb
@@ -15,11 +15,11 @@
               class: 'matomo_download',
               'aria-label' => aria_label(download: true),
               data: {
-                controller: "popup",
-                action: "click->popup#show",
+                controller: 'popup',
+                action: 'click->popup#show',
                 popup_show_alert: remediation_alert?
               } do %>
     <%= download_title %>
   <% end %>
-  <%= render "shared/remediation_popup" %>
+  <%= render 'shared/remediation_popup' %>
 </h3>

--- a/app/components/file_download_link_component.rb
+++ b/app/components/file_download_link_component.rb
@@ -42,7 +42,6 @@ class FileDownloadLinkComponent < ViewComponent::Base
            name: @file_version_membership.title)
   end
 
-  #add method for whether popup should be triggered
   def remediation_alert?
     remediation_service = AutoRemediateService.new(work_version_id, helpers.current_user.admin?, pdf?)
     remediation_service.able_to_auto_remediate?
@@ -62,7 +61,7 @@ class FileDownloadLinkComponent < ViewComponent::Base
       @file_version_membership.work_version.uuid
     end
 
-    def work_version_id 
+    def work_version_id
       @file_version_membership.work_version.id
     end
 end

--- a/app/components/file_download_link_component.rb
+++ b/app/components/file_download_link_component.rb
@@ -42,13 +42,27 @@ class FileDownloadLinkComponent < ViewComponent::Base
            name: @file_version_membership.title)
   end
 
+  #add method for whether popup should be triggered
+  def remediation_alert?
+    remediation_service = AutoRemediateService.new(work_version_id, helpers.current_user.admin?, pdf?)
+    remediation_service.able_to_auto_remediate?
+  end
+
   private
 
     def image?
       @file_version_membership.file_resource.image?
     end
 
+    def pdf?
+      @file_version_membership.file_resource.pdf?
+    end
+
     def work_version_uuid
       @file_version_membership.work_version.uuid
+    end
+
+    def work_version_id 
+      @file_version_membership.work_version.id
     end
 end

--- a/app/javascript/controllers/popup_controller.js
+++ b/app/javascript/controllers/popup_controller.js
@@ -1,19 +1,25 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  connect() {
-    console.log("popup controller connected", this.element.dataset)
-  }
-
   show(event) {
     event.preventDefault()
 
     const showAlert = this.data.get("showAlert") === "true"
 
     if (showAlert) {
-      alert("Auto-remediation is starting — click OK to continue download")
-    }
+      const modalEl = document.getElementById('remediationPopup')
+      const modal = new window.bootstrap.Modal(modalEl)
 
-    window.location.href = this.element.href
+      modal.show()
+
+      modalEl.querySelector("#modalOkBtn").addEventListener("click", () => {
+        modal.hide()
+        window.location.href = this.element.href
+      }, { once: true })
+
+      modalEl.addEventListener("hidden.bs.modal", () => modalEl.remove())
+    } else {
+      window.location.href = this.element.href
+    }
   }
 }

--- a/app/javascript/controllers/popup_controller.js
+++ b/app/javascript/controllers/popup_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  connect() {
+    console.log("popup controller connected", this.element.dataset)
+  }
+
+  show(event) {
+    event.preventDefault()
+
+    const showAlert = this.data.get("showAlert") === "true"
+
+    if (showAlert) {
+      alert("Auto-remediation is starting — click OK to continue download")
+    }
+
+    window.location.href = this.element.href
+  }
+}

--- a/app/javascript/frontend/index.js
+++ b/app/javascript/frontend/index.js
@@ -10,7 +10,8 @@ import './scripts/thumbnail_selection_init'
 
 // Load dependencies
 require('jquery/src/jquery')
-require('bootstrap/dist/js/bootstrap')
+const bootstrap = require('bootstrap/dist/js/bootstrap')
+window.bootstrap = bootstrap
 require('select2/dist/js/select2')
 
 // Load Blacklight dependencies

--- a/app/javascript/frontend/styles/_remediation_popup.scss
+++ b/app/javascript/frontend/styles/_remediation_popup.scss
@@ -1,8 +1,8 @@
-#remediationPopup {
+.remediation-popup {
   .modal-dialog {
+    margin: 10% auto;
     max-width: 80%;
     width: 80%;
-    margin: 10% auto;
   }
 
   @media (min-width: 1200px) {

--- a/app/javascript/frontend/styles/_remediation_popup.scss
+++ b/app/javascript/frontend/styles/_remediation_popup.scss
@@ -1,0 +1,20 @@
+#remediationPopup {
+  .modal-dialog {
+    max-width: 80%;
+    width: 80%;
+    margin: 10% auto;
+  }
+
+  @media (min-width: 1200px) {
+    .modal-dialog {
+      max-width: 900px;
+    }
+  }
+
+  @media (max-width: 576px) {
+    .modal-dialog {
+      margin: 5% auto;
+      width: 95%;
+    }
+  }
+}

--- a/app/javascript/frontend/styles/index.scss
+++ b/app/javascript/frontend/styles/index.scss
@@ -49,3 +49,4 @@
 @import 'version_navigation';
 @import 'view-statistics-chart';
 @import 'alt_text_icons';
+@import 'remediation_popup';

--- a/app/views/shared/_remediation_popup.html.erb
+++ b/app/views/shared/_remediation_popup.html.erb
@@ -2,17 +2,16 @@
   <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-body">
-        <p><strong>Accessible Version in Progress</strong></p>
-        <p>We’re generating an accessible version of this file to meet ADA Title II requirements. This process may take up to one hour. Please return later to access the accessible copy once it’s ready.</p>
+        <p><strong><%= t('remediation_popup.title') %></strong></p>
+        <p><%= t('remediation_popup.description') %></p>
         <ul>
-          <li><strong>What’s happening:</strong> An accessible PDF is generated using Adobe with AI used to generate alternative text (alt text) for images in the PDF.</li>
-          <li><strong>Quality check:</strong> The Libraries’ Adaptive Technology and Services team will review and correct the accessible version manually, but that review may occur after the file becomes available.</li>
+          <li><strong><%= t('remediation_popup.whats_happening_label') %></strong> <%= t('remediation_popup.whats_happening_text') %></li>
+          <li><strong><%= t('remediation_popup.quality_check_label') %></strong> <%= t('remediation_popup.quality_check_text') %></li>
         </ul>
         <br>
-        <p>For questions or to request a different format, contact the Adaptive Technology and Services team at <a href="mailto:ul-adaptive-tech-svcs@lists.psu.edu">ul-adaptive-tech-svcs@lists.psu.edu</a>.</p>
-      </div>
+        <p><%= t('remediation_popup.contact_info').html_safe %></p>
       <div class="modal-footer justify-content-center">
-        <button type="button" class="btn btn-primary" id="modalOkBtn">OK</button>
+        <button type="button" class="btn btn-primary" id="modalOkBtn"><%= t('remediation_popup.ok_button') %></button>
       </div>
     </div>
   </div>

--- a/app/views/shared/_remediation_popup.html.erb
+++ b/app/views/shared/_remediation_popup.html.erb
@@ -1,0 +1,19 @@
+<div class="modal fade" id="remediationPopup" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-body">
+        <p><strong>Accessible Version in Progress</strong></p>
+        <p>We’re generating an accessible version of this file to meet ADA Title II requirements. This process may take up to one hour. Please return later to access the accessible copy once it’s ready.</p>
+        <ul>
+          <li><strong>What’s happening:</strong> An accessible PDF is generated using Adobe with AI used to generate alternative text (alt text) for images in the PDF.</li>
+          <li><strong>Quality check:</strong> The Libraries’ Adaptive Technology and Services team will review and correct the accessible version manually, but that review may occur after the file becomes available.</li>
+        </ul>
+        <br>
+        <p>For questions or to request a different format, contact the Adaptive Technology and Services team at <a href="mailto:ul-adaptive-tech-svcs@lists.psu.edu">ul-adaptive-tech-svcs@lists.psu.edu</a>.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" id="modalOkBtn">OK</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_remediation_popup.html.erb
+++ b/app/views/shared/_remediation_popup.html.erb
@@ -1,5 +1,5 @@
 <div class="modal fade" id="remediationPopup" tabindex="-1" role="dialog" aria-hidden="true">
-  <div class="modal-dialog" role="document">
+  <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-body">
         <p><strong>Accessible Version in Progress</strong></p>
@@ -11,7 +11,7 @@
         <br>
         <p>For questions or to request a different format, contact the Adaptive Technology and Services team at <a href="mailto:ul-adaptive-tech-svcs@lists.psu.edu">ul-adaptive-tech-svcs@lists.psu.edu</a>.</p>
       </div>
-      <div class="modal-footer">
+      <div class="modal-footer justify-content-center">
         <button type="button" class="btn btn-primary" id="modalOkBtn">OK</button>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,15 @@ en:
     tips: Tips for %{rule} Remediation
     intro: Below are the results of the accessibility check of the pdf you recently uploaded. <a href="https://www.ada.gov/resources/2024-03-08-web-rule" target="_blank">Title II of the ADA</a> requires that all digital content be made accessible. More information can be found in <a href=https://policy.psu.edu/policies/ad69>Penn State’s AD69 Accessibility Policy</a>.
     remediation_help: For remediation assistance or any questions, please contact <a href=mailto:digitalaccessibility@psu.libanswers.com>digitalaccessibility@psu.libanswers.com</a> or visit the <a href=https://smealonline.psu.edu/browse/accessibility-learning-path/courses/pdf-accessibility-overview-and-introduction>PDF Accessibility Training</a> on the <a href=https://accessibility.psu.edu/training/learningpath/>Penn State Accessibility Learning Path</a>.
+  remediation_popup:
+    title: Accessible Version in Progress
+    description: We're generating an accessible version of this file to meet ADA Title II requirements. This process may take up to one hour. Please return later to access the accessible copy once it's ready.
+    whats_happening_label: "What's happening:"
+    whats_happening_text: An accessible PDF is generated using Adobe with AI used to generate alternative text (alt text) for images in the PDF.
+    quality_check_label: "Quality check:"
+    quality_check_text: The Libraries' Adaptive Technology and Services team will review and correct the accessible version manually, but that review may occur after the file becomes available.
+    contact_info: For questions or to request a different format, contact the Adaptive Technology and Services team at <a href="mailto:ul-adaptive-tech-svcs@lists.psu.edu">ul-adaptive-tech-svcs@lists.psu.edu</a>.
+    ok_button: OK
   activerecord:
     attributes:
       actor:

--- a/spec/components/file_download_link_component_spec.rb
+++ b/spec/components/file_download_link_component_spec.rb
@@ -55,6 +55,8 @@ RSpec.describe FileDownloadLinkComponent, type: :component do
   end
 
   context 'when the file is able to auto remediate' do
+    let(:mime_type) { 'application/pdf' }
+
     it 'shows the remediation alert' do
       allow_any_instance_of(AutoRemediateService).to receive(:able_to_auto_remediate?).and_return(true)
       render_inline(described_class.new(file_version_membership: file_version_membership))
@@ -64,6 +66,8 @@ RSpec.describe FileDownloadLinkComponent, type: :component do
   end
 
   context 'when the file is not able to auto remediate' do
+    let(:mime_type) { 'application/pdf' }
+
     it 'does not show the remediation alert' do
       allow_any_instance_of(AutoRemediateService).to receive(:able_to_auto_remediate?).and_return(false)
       render_inline(described_class.new(file_version_membership: file_version_membership))

--- a/spec/components/file_download_link_component_spec.rb
+++ b/spec/components/file_download_link_component_spec.rb
@@ -53,4 +53,22 @@ RSpec.describe FileDownloadLinkComponent, type: :component do
       expect(page).to have_css("a[aria-label='View file: #{file_version_membership.title}, an image of Test text']")
     end
   end
+
+  context 'when the file is able to auto remediate' do
+    it 'shows the remediation alert' do
+      allow_any_instance_of(AutoRemediateService).to receive(:able_to_auto_remediate?).and_return(true)
+      render_inline(described_class.new(file_version_membership: file_version_membership))
+      expect(page).to have_css('[data-popup-show-alert="true"]')
+      expect(page).to have_css('#remediationPopup')
+    end
+  end
+
+  context 'when the file is not able to auto remediate' do
+    it 'does not show the remediation alert' do
+      allow_any_instance_of(AutoRemediateService).to receive(:able_to_auto_remediate?).and_return(false)
+      render_inline(described_class.new(file_version_membership: file_version_membership))
+      expect(page).to have_css('[data-popup-show-alert="false"]')
+      expect(page).to have_css('#remediationPopup')
+    end
+  end
 end

--- a/spec/components/file_download_link_component_spec.rb
+++ b/spec/components/file_download_link_component_spec.rb
@@ -10,9 +10,16 @@ RSpec.describe FileDownloadLinkComponent, type: :component do
   let!(:file_version_membership) { create(:file_version_membership,
                                           file_resource: file_resource,
                                           work_version: resource) }
+  let(:user) { build(:user) }
+  let(:mock_controller) do
+    instance_double('ApplicationController', current_user: user, controller_name: 'application')
+  end
+  let(:mock_helpers) { double('helpers', current_user: user) }
 
   before do
     allow(file_resource).to receive(:file).and_return(file_double)
+    allow_any_instance_of(described_class).to receive(:controller).and_return(mock_controller)
+    allow_any_instance_of(described_class).to receive(:helpers).and_return(mock_helpers)
   end
 
   describe 'when the file is not an image' do

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe 'Public Resources' do
 
             click_on 'OK'
 
-            sleep(1)
+            sleep(10)
           }.to change {
                  ViewStatistic.where(
                    resource_type: 'FileResource',
@@ -158,7 +158,7 @@ RSpec.describe 'Public Resources' do
             expect(page).to have_no_css('[data-popup-show-alert="true"]')
             expect(page).to have_no_css('#remediationPopup')
 
-            sleep(1)
+            sleep(10)
           }.to change {
             ViewStatistic.where(
               resource_type: 'FileResource',

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'Public Resources' do
                  ViewStatistic.where(
                    resource_type: 'FileResource',
                    resource_id: file.id
-                 ).sum(:count)
+                 ).count
                }.by(1)
         end
       end
@@ -163,7 +163,7 @@ RSpec.describe 'Public Resources' do
             ViewStatistic.where(
               resource_type: 'FileResource',
               resource_id: file.id
-            ).sum(:count)
+            ).count
           }.by(1)
         end
       end

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -124,30 +124,31 @@ RSpec.describe 'Public Resources' do
 
         it 'shows the remediation alert and then allows download' do
           visit resource_path(work.uuid)
-          
+
           click_on 'Download'
           expect(page).to have_css('[data-popup-show-alert="true"]')
           expect(page).to have_css('#remediationPopup')
-          
+
           initial_count = ViewStatistic.where(
             resource_type: 'FileResource',
             resource_id: file.file_resource.id
           ).count
-          
+
           click_on 'OK'
-          
+
           Timeout.timeout(10) do
             loop do
               current_count = ViewStatistic.where(
                 resource_type: 'FileResource',
                 resource_id: file.file_resource.id
               ).count
-              
+
               break if current_count == initial_count + 1
+
               sleep(0.1)
             end
           end
-          
+
           expect(ViewStatistic.where(
             resource_type: 'FileResource',
             resource_id: file.file_resource.id
@@ -164,29 +165,30 @@ RSpec.describe 'Public Resources' do
 
         it 'does not show the remediation alert and allows direct download' do
           visit resource_path(work.uuid)
-          
+
           initial_count = ViewStatistic.where(
             resource_type: 'FileResource',
             resource_id: file.file_resource.id
           ).count
-          
+
           click_on 'Download'
-          
+
           expect(page).to have_no_css('[data-popup-show-alert="true"]')
           expect(page).to have_no_css('#remediationPopup')
-          
+
           Timeout.timeout(10) do
             loop do
               current_count = ViewStatistic.where(
                 resource_type: 'FileResource',
                 resource_id: file.file_resource.id
               ).count
-              
+
               break if current_count == initial_count + 1
+
               sleep(0.1)
             end
           end
-          
+
           expect(ViewStatistic.where(
             resource_type: 'FileResource',
             resource_id: file.file_resource.id

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -124,22 +124,34 @@ RSpec.describe 'Public Resources' do
 
         it 'shows the remediation alert and then allows download' do
           visit resource_path(work.uuid)
-
-          expect {
-            click_on 'Download'
-
-            expect(page).to have_css('[data-popup-show-alert="true"]')
-            expect(page).to have_css('#remediationPopup')
-
-            click_on 'OK'
-
-            sleep(10)
-          }.to change {
-                 ViewStatistic.where(
-                   resource_type: 'FileResource',
-                   resource_id: file.id
-                 ).count
-               }.by(1)
+          
+          click_on 'Download'
+          expect(page).to have_css('[data-popup-show-alert="true"]')
+          expect(page).to have_css('#remediationPopup')
+          
+          initial_count = ViewStatistic.where(
+            resource_type: 'FileResource',
+            resource_id: file.file_resource.id
+          ).count
+          
+          click_on 'OK'
+          
+          Timeout.timeout(10) do
+            loop do
+              current_count = ViewStatistic.where(
+                resource_type: 'FileResource',
+                resource_id: file.file_resource.id
+              ).count
+              
+              break if current_count == initial_count + 1
+              sleep(0.1)
+            end
+          end
+          
+          expect(ViewStatistic.where(
+            resource_type: 'FileResource',
+            resource_id: file.file_resource.id
+          ).count).to eq(initial_count + 1)
         end
       end
 
@@ -152,19 +164,33 @@ RSpec.describe 'Public Resources' do
 
         it 'does not show the remediation alert and allows direct download' do
           visit resource_path(work.uuid)
-          expect {
-            click_on 'Download'
-
-            expect(page).to have_no_css('[data-popup-show-alert="true"]')
-            expect(page).to have_no_css('#remediationPopup')
-
-            sleep(10)
-          }.to change {
-            ViewStatistic.where(
-              resource_type: 'FileResource',
-              resource_id: file.id
-            ).count
-          }.by(1)
+          
+          initial_count = ViewStatistic.where(
+            resource_type: 'FileResource',
+            resource_id: file.file_resource.id
+          ).count
+          
+          click_on 'Download'
+          
+          expect(page).to have_no_css('[data-popup-show-alert="true"]')
+          expect(page).to have_no_css('#remediationPopup')
+          
+          Timeout.timeout(10) do
+            loop do
+              current_count = ViewStatistic.where(
+                resource_type: 'FileResource',
+                resource_id: file.file_resource.id
+              ).count
+              
+              break if current_count == initial_count + 1
+              sleep(0.1)
+            end
+          end
+          
+          expect(ViewStatistic.where(
+            resource_type: 'FileResource',
+            resource_id: file.file_resource.id
+          ).count).to eq(initial_count + 1)
         end
       end
     end


### PR DESCRIPTION
Fixes #1808 

side note- looks like the trouble I had with handling `helpers.current_user` in the test isn't new (similar examples [here](https://github.com/psu-libraries/scholarsphere/blob/d160a038ef586a62c0eb740d01f1b8975b134cd9/spec/components/collection_metadata_component_spec.rb#L9) and [here](https://github.com/psu-libraries/scholarsphere/blob/d160a038ef586a62c0eb740d01f1b8975b134cd9/spec/components/files_visibility_detail_component_spec.rb#L15)). What's there now is obviously working, but might be something to create a ticket for if we ever spend some time on a refactor/interns are looking for something to do