### PR TITLE
add admin under accessibility review checkbox

### DIFF
--- a/app/components/file_download_link_component.html.erb
+++ b/app/components/file_download_link_component.html.erb
@@ -1,3 +1,7 @@
+<div>
+<p><%= under_review_notice %></p>
+</div>
+
 <h3 class="d-inline-block mb-1 me-2">
   <%= link_to download_path(download: false),
               title: view_title,

--- a/app/components/file_download_link_component.rb
+++ b/app/components/file_download_link_component.rb
@@ -47,6 +47,12 @@ class FileDownloadLinkComponent < ViewComponent::Base
     remediation_service.able_to_auto_remediate?
   end
 
+  def under_review_notice
+    if work.under_manual_review
+      I18n.t('dashboard.works.show.under_review_notice')
+    end
+  end
+
   private
 
     def image?
@@ -63,5 +69,9 @@ class FileDownloadLinkComponent < ViewComponent::Base
 
     def work_version_id
       @file_version_membership.work_version.id
+    end
+
+    def work
+      @file_version_membership.work_version.work
     end
 end

--- a/app/controllers/dashboard/works_controller.rb
+++ b/app/controllers/dashboard/works_controller.rb
@@ -44,6 +44,7 @@ module Dashboard
         @editors_form = EditorsForm.new(resource: @undecorated_work, user: current_user, params: editors_params)
         @depositor_form = DepositorForm.new(resource: @undecorated_work, params: depositor_params) if current_user.admin?
         @curator_form = CuratorForm.new(resource: @undecorated_work, params: curator_params) if current_user.admin?
+        @manual_review_form = ManualReviewForm.new(resource: @undecorated_work, params: manual_review_params) if current_user.admin?
         @withdraw_versions_form = WithdrawVersionsForm.new(work: @undecorated_work, params: withdraw_versions_params)
         @thumbnail_form = ThumbnailForm.new(resource: @undecorated_work, params: thumbnail_params)
       end
@@ -57,6 +58,8 @@ module Dashboard
           @depositor_form
         elsif params[:curator_form].present?
           @curator_form
+        elsif params[:manual_review_form].present?
+          @manual_review_form
         elsif params[:withdraw_versions_form].present?
           @withdraw_versions_form
         elsif params[:thumbnail_form].present?
@@ -111,6 +114,14 @@ module Dashboard
           .fetch(:curator_form, {})
           .permit(
             :access_id
+          )
+      end
+
+      def manual_review_params
+        params
+          .fetch(:manual_review_form, {})
+          .permit(
+            :under_manual_review
           )
       end
 

--- a/app/forms/manual_review_form.rb
+++ b/app/forms/manual_review_form.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class ManualReviewForm
+  include ActiveModel::Model
+
+  attr_reader :resource, :user
+  attr_writer :under_manual_review
+
+  def initialize(resource:, params:)
+    @resource = resource
+    super(params)
+  end
+
+  def under_manual_review
+    @under_manual_review || resource.under_manual_review
+  end
+
+  def save
+    resource.under_manual_review = under_manual_review
+    resource.save!
+  end
+end

--- a/app/services/auto_remediate_service.rb
+++ b/app/services/auto_remediate_service.rb
@@ -22,6 +22,7 @@ class AutoRemediateService
       work_version.auto_remediation_started_at.nil? &&
       !work_version.auto_remediated_version &&
       download_is_pdf &&
-      !admin
+      !admin &&
+      !work_version.work.under_manual_review
   end
 end

--- a/app/views/dashboard/shared/_manual_review_form.html.erb
+++ b/app/views/dashboard/shared/_manual_review_form.html.erb
@@ -1,0 +1,23 @@
+<p><%= t('.explanation') %></p>
+
+<%- manual_review_form_id = "edit_manual_review_#{dom_id manual_review_form.resource}" %>
+<%= form_for manual_review_form,
+             url: url,
+             method: :patch,
+             remote: false,
+             html: { id: manual_review_form_id, class: 'edit-resource-manual-review' } do |form| %>
+
+  <%= hidden_field_tag 'form_id', manual_review_form_id %>
+  <%= render FormErrorMessageComponent.new(form: form) %>
+
+  <div class="mb-3">
+    <div class="form-check">
+      <%= form.check_box :under_manual_review, { class: 'form-check-input' } %>
+      <%= form.label :under_manual_review, t('.under_manual_review'), class: 'form-check-label' %>
+    </div>
+  </div>
+
+  <div class="actions mt-1 mb-3">
+    <%= form.submit t('.submit_button'), class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/app/views/dashboard/works/edit.html.erb
+++ b/app/views/dashboard/works/edit.html.erb
@@ -37,6 +37,12 @@
                           class: 'nav-link' %>
             </li>
 
+            <li class="nav-item">
+              <%= link_to t('dashboard.shared.manual_review_form.heading'),
+                          "##{t('dashboard.shared.manual_review_form.heading').parameterize}",
+                          class: 'nav-link' %>
+            </li>
+
             <% if policy(@work.latest_version).destroy? %>
               <li class="nav-item">
                 <%= link_to t('dashboard.shared.depositor_form.heading'),
@@ -191,6 +197,14 @@
             </p>
           </div>
         <% end %>
+
+        <div class="keyline keyline--left">
+          <h2 id="<%= t('dashboard.shared.manual_review_form.heading').parameterize %>" class="h4"><%= t('dashboard.shared.manual_review_form.heading') %></h2>
+        </div>
+
+        <div class="actions mb-3">
+          <%= render 'dashboard/shared/manual_review_form', manual_review_form: @manual_review_form, url: dashboard_work_path(@work) %>
+        </div>
 
         <% if policy(@work.latest_version).destroy? %>
           <div class="keyline keyline--left">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -384,6 +384,11 @@ en:
         audit_heading: "Previous Curators:"
         explanation: "Changes the curator of the work. Currently, only existing Penn State users are allowed."
         submit_button: Update Curator
+      manual_review_form:
+        heading: Manual Accessibility Review
+        explanation: If checked, sets the work under manual review for accessibility. If a work is under manual review, it will be blocked from the automated remediation process.
+        under_manual_review: Work is under manual accessibility review
+        submit_button: Update Manual Accessibility Review Status
       files:
         heading: Accessibility Review
     works:
@@ -442,6 +447,7 @@ en:
         aria_download_image: ", an image of %{alt_text}"
         aria_download_file: "Download file: %{file_name}"
         aria_view_file: "View file: %{file_name}"
+        under_review_notice: This work is currently under manual accessibility review and may not be fully accessible at this time. An accessible version is being generated and will be available soon.
     form:
       unsaved_changes_prompt: You have unsaved changes on this page. Are you sure you want to leave and discard these changes? 
       heading:

--- a/db/migrate/20251007200037_add_under_manual_review_to_works.rb
+++ b/db/migrate/20251007200037_add_under_manual_review_to_works.rb
@@ -1,0 +1,5 @@
+class AddUnderManualReviewToWorks < ActiveRecord::Migration[7.2]
+  def change
+    add_column :works, :under_manual_review, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_16_154921) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_07_200037) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -295,6 +295,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_16_154921) do
     t.datetime "deposit_agreed_at", precision: nil
     t.boolean "notify_editors", default: false
     t.string "thumbnail_selection", default: "default_icon"
+    t.boolean "under_manual_review"
     t.index ["depositor_id"], name: "index_works_on_depositor_id"
     t.index ["proxy_id"], name: "index_works_on_proxy_id"
   end

--- a/spec/components/file_download_link_component_spec.rb
+++ b/spec/components/file_download_link_component_spec.rb
@@ -75,4 +75,32 @@ RSpec.describe FileDownloadLinkComponent, type: :component do
       expect(page).to have_css('#remediationPopup')
     end
   end
+
+  context 'when the work is under manual review' do
+    let(:mime_type) { 'application/pdf' }
+    let(:work) { resource.work }
+
+    before do
+      work.update(under_manual_review: true)
+    end
+
+    it 'shows the under review notice' do
+      render_inline(described_class.new(file_version_membership: file_version_membership))
+      expect(page).to have_text(I18n.t('dashboard.works.show.under_review_notice'))
+    end
+  end
+
+  context 'when the work is not under manual review' do
+    let(:mime_type) { 'application/pdf' }
+    let(:work) { resource.work }
+
+    before do
+      work.update(under_manual_review: false)
+    end
+
+    it 'does not show the under review notice' do
+      render_inline(described_class.new(file_version_membership: file_version_membership))
+      expect(page).to have_no_text(I18n.t('dashboard.works.show.under_review_notice'))
+    end
+  end
 end

--- a/spec/features/dashboard/work_settings_spec.rb
+++ b/spec/features/dashboard/work_settings_spec.rb
@@ -430,6 +430,37 @@ RSpec.describe 'Work Settings Page', with_user: :user do
     end
   end
 
+  describe 'Changing the manual review status' do
+    context 'with a standard user' do
+      it 'does not allow the change' do
+        visit edit_dashboard_work_path(work)
+        expect(page).to have_no_content(I18n.t!('dashboard.shared.manual_review_form.heading'))
+        expect(page).to have_no_link(I18n.t!('dashboard.shared.manual_review_form.submit_button'))
+      end
+    end
+
+    context 'with an admin user' do
+      let(:user) { create(:user, :admin) }
+      let(:checkbox_label) { I18n.t!('dashboard.shared.manual_review_form.under_manual_review') }
+      let(:explanation_text) { I18n.t!('dashboard.shared.manual_review_form.explanation') }
+      let(:submit_button) { I18n.t!('dashboard.shared.manual_review_form.submit_button') }
+      let(:heading_text) { I18n.t!('dashboard.shared.manual_review_form.heading') }
+
+      it 'allows the change and updates the work under_manual_review value' do
+        visit edit_dashboard_work_path(work)
+        expect(page).to have_content(heading_text)
+        expect(page).to have_content(explanation_text)
+        expect(page).to have_unchecked_field(checkbox_label)
+        check checkbox_label
+        click_on(submit_button)
+        expect(page).to have_content(I18n.t!('dashboard.works.update.success'))
+        expect(page).to have_checked_field(checkbox_label)
+        work.reload
+        expect(work.under_manual_review).to be true
+      end
+    end
+  end
+
   describe 'Withdrawing a version' do
     context 'with a standard user' do
       it 'does not allow the change' do

--- a/spec/forms/manual_review_form_spec.rb
+++ b/spec/forms/manual_review_form_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ManualReviewForm, type: :model do
+  subject(:form) { described_class.new(resource: resource, params: params) }
+
+  let(:resource) { build(:work) }
+
+  describe 'initialization' do
+    context 'with no params' do
+      let(:params) { {} }
+
+      its(:under_manual_review) { is_expected.to be_nil }
+    end
+
+    context 'with under_manual_review value' do
+      let(:params) { { under_manual_review: true } }
+
+      its(:under_manual_review) { is_expected.to eq(true) }
+    end
+  end
+
+  describe '#save' do
+    let(:params) { { under_manual_review: true } }
+
+    it 'sets resource.under_manual_review to the form value and saves the resource' do
+      form.save
+      resource.reload
+      expect(resource.under_manual_review).to eq(true)
+    end
+  end
+end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -524,6 +524,7 @@ RSpec.describe Work do
           thumbnail_url_ssi
           thumbnail_selection_tesim
           notify_editors_tesim
+          under_manual_review_tesim
         )
       end
 
@@ -593,6 +594,7 @@ RSpec.describe Work do
           thumbnail_url_ssi
           thumbnail_selection_tesim
           notify_editors_tesim
+          under_manual_review_tesim
           external_app_id_isi
           published_at_dtsi
           removed_at_dtsi

--- a/spec/services/auto_remediate_service_spec.rb
+++ b/spec/services/auto_remediate_service_spec.rb
@@ -29,8 +29,18 @@ RSpec.describe AutoRemediateService do
 
           context 'when the download is a PDF' do
             context 'when the user is not an admin' do
-              it 'returns true' do
-                expect(described_class.new(work_version.id, false, true).able_to_auto_remediate?).to be true
+              context 'when the work is not under manual review' do
+                it 'returns true' do
+                  expect(described_class.new(work_version.id, false, true).able_to_auto_remediate?).to be true
+                end
+              end
+
+              context 'when the work is under manual review' do
+                before { work_version.work.update(under_manual_review: true) }
+
+                it 'returns false' do
+                  expect(described_class.new(work_version.id, false, true).able_to_auto_remediate?).to be false
+                end
               end
             end
 


### PR DESCRIPTION
Fixes #1817 

@bdezray I put the following placeholder text for what we want to display on the work page while under manual review. Please edit as needed:
This work is currently under manual accessibility review and may not be fully accessible at this time. An accessible version is being generated and will be available soon.