### PR TITLE
Fix flaky test

### DIFF
--- a/spec/support/feature_helpers/dashboard_form.rb
+++ b/spec/support/feature_helpers/dashboard_form.rb
@@ -158,7 +158,8 @@ module FeatureHelpers
 
     def self.fill_in_publishing_details(metadata, visibility: Permissions::Visibility::OPEN)
       choose "work_version_work_attributes_visibility_#{visibility}"
-      find_by_id('work_version_rights', visible: true, wait: 3)
+      dropdown = find('#work_version_rights', visible: true)
+      dropdown.click
       select WorkVersion::Licenses.label(metadata[:rights]), from: 'work_version_rights'
     end
 

--- a/spec/support/feature_helpers/dashboard_form.rb
+++ b/spec/support/feature_helpers/dashboard_form.rb
@@ -158,7 +158,7 @@ module FeatureHelpers
 
     def self.fill_in_publishing_details(metadata, visibility: Permissions::Visibility::OPEN)
       choose "work_version_work_attributes_visibility_#{visibility}"
-      find("#work_version_rights", visible: true, wait: 3)
+      find_by_id('work_version_rights', visible: true, wait: 3)
       select WorkVersion::Licenses.label(metadata[:rights]), from: 'work_version_rights'
     end
 

--- a/spec/support/feature_helpers/dashboard_form.rb
+++ b/spec/support/feature_helpers/dashboard_form.rb
@@ -158,8 +158,7 @@ module FeatureHelpers
 
     def self.fill_in_publishing_details(metadata, visibility: Permissions::Visibility::OPEN)
       choose "work_version_work_attributes_visibility_#{visibility}"
-      dropdown = find('#work_version_rights', visible: true)
-      dropdown.click
+      find_by_id('work_version_rights', visible: true).click
       select WorkVersion::Licenses.label(metadata[:rights]), from: 'work_version_rights'
     end
 

--- a/spec/support/feature_helpers/dashboard_form.rb
+++ b/spec/support/feature_helpers/dashboard_form.rb
@@ -158,7 +158,7 @@ module FeatureHelpers
 
     def self.fill_in_publishing_details(metadata, visibility: Permissions::Visibility::OPEN)
       choose "work_version_work_attributes_visibility_#{visibility}"
-      sleep 3
+      find("#work_version_rights", visible: true, wait: 3)
       select WorkVersion::Licenses.label(metadata[:rights]), from: 'work_version_rights'
     end
 

--- a/spec/support/feature_helpers/dashboard_form.rb
+++ b/spec/support/feature_helpers/dashboard_form.rb
@@ -158,6 +158,7 @@ module FeatureHelpers
 
     def self.fill_in_publishing_details(metadata, visibility: Permissions::Visibility::OPEN)
       choose "work_version_work_attributes_visibility_#{visibility}"
+      sleep 3
       select WorkVersion::Licenses.label(metadata[:rights]), from: 'work_version_rights'
     end
 


### PR DESCRIPTION
This seems to have fixed the flaky test - or at least it passed 4 times in CI so I'm pretty confident.  Finding the dropdown and clicking it makes the following `select` statement more robust.  It seemed like the `select` statement was trying to select an option in the dropdown before the dropdown actually dropped.