### PR TITLE
Fetches params in mailer so an error will raise if a param is missing

### DIFF
--- a/app/mailers/auto_remediation_mailer.rb
+++ b/app/mailers/auto_remediation_mailer.rb
@@ -2,10 +2,10 @@
 
 class AutoRemediationMailer < ApplicationMailer
   def remediated_version_created
-    contributor_email = params[:contributor_email]
+    contributor_email = params.fetch(:contributor_email)
 
-    @work_title = params[:work_title]
-    @work_version_uuid = params[:work_version_uuid]
+    @work_title = params.fetch(:work_title)
+    @work_version_uuid = params.fetch(:work_version_uuid)
 
     mail(
       to: contributor_email,

--- a/app/services/auto_remediation_notifications.rb
+++ b/app/services/auto_remediation_notifications.rb
@@ -10,7 +10,7 @@ class AutoRemediationNotifications
       AutoRemediationMailer
         .with(work_version_title: @remediated_work_version.title,
               work_version_uuid: @remediated_work_version.uuid,
-              user_email: email)
+              contributor_email: email)
         .remediated_version_created
         .deliver_later
     end

--- a/spec/mailers/auto_remediation_mailer_spec.rb
+++ b/spec/mailers/auto_remediation_mailer_spec.rb
@@ -3,22 +3,42 @@
 require 'rails_helper'
 
 RSpec.describe AutoRemediationMailer do
-  subject(:mailer) { described_class.with(contributor_email: 'contributor@example.com',
-                                          work_title: 'Title of Work',
-                                          work_version_uuid: '123e4567-e89b-12d3-a456-426614174000') }
+  subject(:mailer) { described_class.with(params) }
+
+  let(:params) { { contributor_email: 'contributor@example.com',
+                   work_title: 'Title of Work',
+                   work_version_uuid: '123e4567-e89b-12d3-a456-426614174000' } }
+  let(:mail) { mailer.remediated_version_created }
 
   describe '#remediated_version_created' do
-    it 'renders the remediated_version_created template' do
-      mail = mailer.remediated_version_created
+    context 'when all required params are provided' do
+      it 'renders the remediated_version_created template' do
+        expect(mail.subject).to eq('Accessible Version of Your Work Now Available on ScholarSphere')
+        expect(mail.to).to contain_exactly('contributor@example.com')
+        expect(mail.body.encoded).to include(
+          "<a href=\"#{Rails.application.routes.url_helpers.root_url}resources/123e4567-e89b-12d3-a456-426614174000\">Title of Work</a>"
+        )
+        expect(mail.body.encoded).to include(
+          'The Libraries’ Adaptive Technology and Services team will manually '
+        )
+      end
+    end
 
-      expect(mail.subject).to eq('Accessible Version of Your Work Now Available on ScholarSphere')
-      expect(mail.to).to contain_exactly('contributor@example.com')
-      expect(mail.body.encoded).to include(
-        "<a href=\"#{Rails.application.routes.url_helpers.root_url}resources/123e4567-e89b-12d3-a456-426614174000\">Title of Work</a>"
-      )
-      expect(mail.body.encoded).to include(
-        'The Libraries’ Adaptive Technology and Services team will manually '
-      )
+    context 'when delivering the email' do
+      context 'when a required param is missing' do
+        let(:params) { { work_title: 'Title of Work',
+                         work_version_uuid: '123e4567-e89b-12d3-a456-426614174000' } }
+
+        it 'raises an error' do
+          expect { mail.deliver_now }.to raise_error(KeyError)
+        end
+      end
+
+      context 'when all required params are provided' do
+        it 'sends the email successfully' do
+          expect { mail.deliver_now }.not_to raise_error
+        end
+      end
     end
   end
 end

--- a/spec/services/auto_remediation_notifications_spec.rb
+++ b/spec/services/auto_remediation_notifications_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe AutoRemediationNotifications do
         .to receive(:with)
         .with(work_version_title: work_title,
               work_version_uuid: work_uuid,
-              user_email: email)
+              contributor_email: email)
         .and_return(mailer_proxy)
     end
 
@@ -59,7 +59,7 @@ RSpec.describe AutoRemediationNotifications do
         .to have_received(:with)
         .with(work_version_title: work_title,
               work_version_uuid: work_uuid,
-              user_email: email)
+              contributor_email: email)
     end
   end
 


### PR DESCRIPTION
I noticed while testing in QA that the auto remediation email notification was not getting any "to" emails.  Digging through the code I realized I was passing the wrong param key to set up the "to" emails.  I added `.fetch`es to grab the params in the mailer class so an error raises if params are missing.