### PR TITLE
Prevent auto remediation in production

### DIFF
--- a/app/services/auto_remediate_service.rb
+++ b/app/services/auto_remediate_service.rb
@@ -18,6 +18,10 @@ class AutoRemediateService
   end
 
   def able_to_auto_remediate?
+    # The following line can be removed when
+    # auto-remediation is enabled in production
+    return false if Rails.env.production?
+
     work_version.latest_published_version? &&
       work_version.auto_remediation_started_at.nil? &&
       !work_version.auto_remediated_version &&

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ x-web_env: &web_env
       REDIS_PASSWORD: redispassword
       OAUTH_APP_ID: ${OAUTH_APP_ID}
       OAUTH_APP_SECRET: ${OAUTH_APP_SECRET}
-      DEFAULT_URL_HOST: web
+      DEFAULT_URL_HOST: ${DEFAULT_URL_HOST:-web}
       SELENIUM_URL: http://selenium:4444/wd/hub
       APP_HOST: web
       OAUTH_APP_URL: ${OAUTH_APP_URL}

--- a/spec/services/auto_remediate_service_spec.rb
+++ b/spec/services/auto_remediate_service_spec.rb
@@ -22,6 +22,19 @@ RSpec.describe AutoRemediateService do
   end
 
   describe '#able_to_auto_remediate?' do
+    # The following context block can be removed when
+    # auto-remediation is enabled in production
+    context 'when production environment' do
+      before do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+      end
+
+      it 'returns false' do
+        work_version = create(:work_version, :published)
+        expect(described_class.new(work_version.id, false, true).able_to_auto_remediate?).to be false
+      end
+    end
+
     context 'when the work version is the latest published version' do
       context 'when remediation has not been started' do
         context 'when there is no remediated version' do


### PR DESCRIPTION
Check rails environment in #able_to_auto_remediate?.  If `production` -> return false.  This turns off the remediation features (both the trigger and popup) in production.

closes #1841 