### PR TITLE
Make bot_challenge configurable

### DIFF
--- a/config/initializers/bot_challenge_page.rb
+++ b/config/initializers/bot_challenge_page.rb
@@ -2,7 +2,7 @@
 
 Rails.application.config.to_prepare do
   BotChallengePage::BotChallengePageController.bot_challenge_config.enabled = !Rails.env.test? && ActiveModel::Type::Boolean.new.cast(
-    ENV.fetch('BOT_CHALLENGE_PAGE_ENABLED', 'true')
+    ENV.fetch('CLOUDFLARE_CHALLENGE_ENABLED', 'true')
   )
 
   # Get from CloudFlare Turnstile: https://www.cloudflare.com/application-services/products/turnstile/

--- a/config/initializers/bot_challenge_page.rb
+++ b/config/initializers/bot_challenge_page.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.config.to_prepare do
-  BotChallengePage::BotChallengePageController.bot_challenge_config.enabled = false # !Rails.env.test?
+  BotChallengePage::BotChallengePageController.bot_challenge_config.enabled = !Rails.env.test? && ActiveModel::Type::Boolean.new.cast(
+    ENV.fetch('BOT_CHALLENGE_PAGE_ENABLED', 'true')
+  )
 
   # Get from CloudFlare Turnstile: https://www.cloudflare.com/application-services/products/turnstile/
   # Some testing keys are also available: https://developers.cloudflare.com/turnstile/troubleshooting/testing/

--- a/config/initializers/bot_challenge_page.rb
+++ b/config/initializers/bot_challenge_page.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.config.to_prepare do
-  BotChallengePage::BotChallengePageController.bot_challenge_config.enabled = !Rails.env.test?
+  BotChallengePage::BotChallengePageController.bot_challenge_config.enabled = false # !Rails.env.test?
 
   # Get from CloudFlare Turnstile: https://www.cloudflare.com/application-services/products/turnstile/
   # Some testing keys are also available: https://developers.cloudflare.com/turnstile/troubleshooting/testing/

--- a/config/initializers/bot_challenge_page.rb
+++ b/config/initializers/bot_challenge_page.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 Rails.application.config.to_prepare do
-  BotChallengePage::BotChallengePageController.bot_challenge_config.enabled = !Rails.env.test? && ActiveModel::Type::Boolean.new.cast(
-    ENV.fetch('CLOUDFLARE_CHALLENGE_ENABLED', 'true')
-  )
+  enabled =
+    !Rails.env.test? &&
+    ActiveModel::Type::Boolean.new.cast(ENV.fetch('CLOUDFLARE_CHALLENGE_ENABLED', 'true'))
+
+  BotChallengePage::BotChallengePageController.bot_challenge_config.enabled = enabled
 
   # Get from CloudFlare Turnstile: https://www.cloudflare.com/application-services/products/turnstile/
   # Some testing keys are also available: https://developers.cloudflare.com/turnstile/troubleshooting/testing/


### PR DESCRIPTION
In case of cloudflare outages we need a simple way to toggle off the bot challenge.  This makes the bot challenge configurable by environment variable.