### PR TITLE
Handles Tempfile uploads in "page_count" shrine step

### DIFF
--- a/app/services/build_auto_remediated_work_version.rb
+++ b/app/services/build_auto_remediated_work_version.rb
@@ -37,6 +37,7 @@ class BuildAutoRemediatedWorkVersion
           on_publish(built_work_version)
         end
 
+        replacement_tempfile&.close!
         return built_work_version
       end
     end

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -42,11 +42,16 @@ class FileUploader < Shrine
     next unless mime_type == FileResource::PDF_MIME_TYPE
 
     begin
-      tempfile = io.download
-      reader = PDF::Reader.new(tempfile.path)
-      reader.page_count
+      tempfile =
+        if io.respond_to?(:download)
+          io.download
+        else
+          io
+        end
+
+      PDF::Reader.new(tempfile.path).page_count
     ensure
-      tempfile&.close!
+      tempfile.close! if tempfile.respond_to?(:close!) && tempfile != io
     end
   end
 

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -12,3 +12,4 @@ Shrine.plugin :activerecord
 Shrine.plugin :cached_attachment_data
 Shrine.plugin :restore_cached_data
 Shrine.plugin :uppy_s3_multipart
+Shrine.plugin :determine_mime_type, analyzer: :marcel

--- a/spec/models/file_resource_spec.rb
+++ b/spec/models/file_resource_spec.rb
@@ -136,25 +136,28 @@ RSpec.describe FileResource do
   end
 
   describe 'page count' do
-    let(:file_resource) { described_class.new }
-    let(:file) { File.open(path, binmode: true) }
-
-    before do
-      file_resource.file = Shrine.upload(file, :store, metadata: { 'mime_type' => 'application/pdf' })
-      file_resource.save
-    end
+    let(:file_resource) { described_class.create!(file: file) }
 
     context 'when the file is a pdf' do
-      let(:path) { Rails.root.join('spec', 'fixtures', 'ipsum.pdf') }
+      context 'when file responds to #download' do
+        let(:file) { FileHelpers.shrine_upload(file: Rails.root.join('spec', 'fixtures', 'ipsum.pdf')) }
 
-      it 'adds page count metadata' do
-        skip 'failing because of how Shrine is handling uploads in tests'
-        expect(file_resource.file_data.dig('metadata', 'page_count')).to eq 1
+        it 'adds page count metadata' do
+          expect(file_resource.file_data.dig('metadata', 'page_count')).to eq 1
+        end
+      end
+
+      context 'when file does not respond to #download' do
+        let(:file) { Rails.root.join('spec', 'fixtures', 'ipsum.pdf').open }
+
+        it 'adds page count metadata' do
+          expect(file_resource.file_data.dig('metadata', 'page_count')).to eq 1
+        end
       end
     end
 
     context 'when the file is not a pdf' do
-      let(:path) { Rails.root.join('spec', 'fixtures', 'image.png') }
+      let(:file) { FileHelpers.shrine_upload(file: Rails.root.join('spec', 'fixtures', 'image.png')) }
 
       it 'does not add page count metadata' do
         expect(file_resource.file_data['metadata']['page_count']).to be_nil


### PR DESCRIPTION
Grabbing the page counts was failing when storing the auto remediated files because we pass Shrine a Tempfile, not a cached S3 location (like the Uppy upload does).  I fixed this and added a shrine plugin for determining mime types (backup in case no content type is specified in downloaded files).  Adds tests for determining page counts.