### PR TITLE
Bump CI utils image tag to v4.5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ parameters:
     default: ""
   CI_UTILS_IMAGE_TAG:
     type: string
-    default: "v4.5.0"
+    default: "v4.5.1"
   CONFIG_REPO_NAME:
     type: string
     default: "scholarsphere-config"


### PR DESCRIPTION
- Updated the CI_UTILS_IMAGE_TAG parameter in CircleCI config
- new ci-utils correctly allows for unset to_yaml_tag_target