### PR TITLE
Hotfix - reindex work versions after thumbnail generation

### DIFF
--- a/app/jobs/shrine/thumbnail_job.rb
+++ b/app/jobs/shrine/thumbnail_job.rb
@@ -9,9 +9,16 @@ class Shrine::ThumbnailJob < ApplicationJob
       attacher.create_derivatives :thumbnail
       record.save
     end
-    # If the created record is a thumbnail uploaded by a user,
-    # then the associated resource needs to be reindexed
-    record.thumbnail_upload.resource.update_index if record.thumbnail_upload.present?
+
+    if record.thumbnail_upload.present?
+      # If the created record is a thumbnail uploaded by a user,
+      # then the associated resource needs to be reindexed
+      record.thumbnail_upload.resource.update_index if record.thumbnail_upload.present?
+    else
+      # Update WorkVersions' solr docs with thumbnail url when
+      # thumbnail is auto-generated from a WorkVersion upload
+      record.work_versions.each(&:update_index)
+    end
   rescue Shrine::AttachmentChanged, ActiveRecord::RecordNotFound
     # attachment has changed or record has been deleted, nothing to do
   end

--- a/app/jobs/shrine/thumbnail_job.rb
+++ b/app/jobs/shrine/thumbnail_job.rb
@@ -13,7 +13,7 @@ class Shrine::ThumbnailJob < ApplicationJob
     if record.thumbnail_upload.present?
       # If the created record is a thumbnail uploaded by a user,
       # then the associated resource needs to be reindexed
-      record.thumbnail_upload.resource.update_index if record.thumbnail_upload.present?
+      record.thumbnail_upload.resource.update_index
     else
       # Update WorkVersions' solr docs with thumbnail url when
       # thumbnail is auto-generated from a WorkVersion upload

--- a/spec/jobs/shrine/thumbnail_job_spec.rb
+++ b/spec/jobs/shrine/thumbnail_job_spec.rb
@@ -22,5 +22,29 @@ RSpec.describe Shrine::ThumbnailJob, skip: !ci_build? do
       described_class.perform_now(image_record)
       expect(image_record.file_attacher.url(:thumbnail)).to include('thumbnails')
     end
+
+    it 'reindexes associated work versions when no thumbnail upload is present' do
+      work_version_one = instance_spy(WorkVersion)
+      work_version_two = instance_spy(WorkVersion)
+      allow(pdf_record).to receive(:work_versions).and_return([work_version_one, work_version_two])
+      allow(pdf_record).to receive(:thumbnail_upload).and_return(nil)
+
+      described_class.perform_now(pdf_record)
+
+      expect(work_version_one).to have_received(:update_index)
+      expect(work_version_two).to have_received(:update_index)
+    end
+
+    it 'reindexes associated thumbnail upload resource when present' do
+      thumbnail_upload = create(:thumbnail_upload)
+      resource = thumbnail_upload.resource
+      allow(resource).to receive(:update_index)
+      allow(pdf_record).to receive(:work_versions).and_return([])
+      allow(pdf_record).to receive(:thumbnail_upload).and_return(thumbnail_upload)
+
+      described_class.perform_now(pdf_record)
+
+      expect(resource).to have_received(:update_index)
+    end
   end
 end

--- a/spec/jobs/shrine/thumbnail_job_spec.rb
+++ b/spec/jobs/shrine/thumbnail_job_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe Shrine::ThumbnailJob, skip: !ci_build? do
     it 'reindexes associated work versions when no thumbnail upload is present' do
       work_version_one = instance_spy(WorkVersion)
       work_version_two = instance_spy(WorkVersion)
-      allow(pdf_record).to receive(:work_versions).and_return([work_version_one, work_version_two])
-      allow(pdf_record).to receive(:thumbnail_upload).and_return(nil)
+      allow(pdf_record).to receive_messages(work_versions: [work_version_one, work_version_two], thumbnail_upload: nil)
 
       described_class.perform_now(pdf_record)
 
@@ -39,8 +38,7 @@ RSpec.describe Shrine::ThumbnailJob, skip: !ci_build? do
       thumbnail_upload = create(:thumbnail_upload)
       resource = thumbnail_upload.resource
       allow(resource).to receive(:update_index)
-      allow(pdf_record).to receive(:work_versions).and_return([])
-      allow(pdf_record).to receive(:thumbnail_upload).and_return(thumbnail_upload)
+      allow(pdf_record).to receive_messages(work_versions: [], thumbnail_upload: thumbnail_upload)
 
       described_class.perform_now(pdf_record)
 


### PR DESCRIPTION
Since thumbnail generation happens at the same time the work version is created in the accessibility remediation pathway, the work versions were not being reindexed after thumbnail creation.  This was preventing thumbnails from showing in the catalog index/list pages.