### PR TITLE
Bump CI utils image tag to v4.5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ parameters:
     default: ""
   CI_UTILS_IMAGE_TAG:
     type: string
-    default: "v4.5.1"
+    default: "v4.5.2"
   CONFIG_REPO_NAME:
     type: string
     default: "scholarsphere-config"


### PR DESCRIPTION
- Updated the default value of CI_UTILS_IMAGE_TAG in CircleCI config to v4.5.2.