### PR TITLE
Depositors and creators cannot trigger auto remediation

### DIFF
--- a/app/components/file_download_link_component.rb
+++ b/app/components/file_download_link_component.rb
@@ -45,7 +45,7 @@ class FileDownloadLinkComponent < ViewComponent::Base
   def remediation_alert?
     remediation_service = PdfRemediation::AutoRemediateService.new(
       work_version_id,
-      helpers.current_user.admin?,
+      helpers.current_user,
       can_remediate?
     )
     remediation_service.able_to_auto_remediate?

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -9,7 +9,7 @@ class DownloadsController < ApplicationController
 
     remediation_service = PdfRemediation::AutoRemediateService.new(
       work_version.id,
-      current_user.admin?,
+      current_user,
       file_version.file_resource.can_remediate?
     )
     remediation_service.call if remediation_service.able_to_auto_remediate? && download_params[:download]

--- a/app/services/pdf_remediation/auto_remediate_service.rb
+++ b/app/services/pdf_remediation/auto_remediate_service.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class PdfRemediation::AutoRemediateService
-  attr_reader :work_version, :admin, :download_can_remediate
+  attr_reader :work_version, :current_user, :download_can_remediate
 
-  def initialize(work_version_id, is_admin, download_can_remediate)
+  def initialize(work_version_id, current_user, download_can_remediate)
     @work_version = WorkVersion.find(work_version_id)
-    @admin = is_admin
+    @current_user = current_user
     @download_can_remediate = download_can_remediate
   end
 
@@ -26,7 +26,29 @@ class PdfRemediation::AutoRemediateService
       work_version.auto_remediation_started_at.nil? &&
       !work_version.remediated_version &&
       download_can_remediate &&
-      !admin &&
+      !admin? &&
+      !creator? &&
+      !depositor? &&
       !work_version.work.under_manual_review
   end
+
+  private
+
+    def admin?
+      current_user.admin?
+    end
+
+    def depositor?
+      current_actor.present? && current_actor == work_version.depositor
+    end
+
+    def creator?
+      return false if current_actor.blank?
+
+      work_version.creators.exists?(actor_id: current_actor.id)
+    end
+
+    def current_actor
+      current_user.actor
+    end
 end

--- a/spec/services/pdf_remediation/auto_remediate_service_spec.rb
+++ b/spec/services/pdf_remediation/auto_remediate_service_spec.rb
@@ -9,11 +9,12 @@ RSpec.describe PdfRemediation::AutoRemediateService do
     let(:pdf2) { create(:file_resource, :pdf) }
     let(:non_pdf) { create(:file_resource) }
     let(:pdf3) { create(:file_resource, :pdf, remediation_job_uuid: 'existing_uuid') }
+    let(:user) { create(:user) }
 
     before { allow(PdfRemediation::AutoRemediationJob).to receive(:perform_later) }
 
     it 'enqueues an AutoRemediationJob for each PDF file resource without an existing remediation_job_uuid' do
-      described_class.new(work_version.id, false, true).call
+      described_class.new(work_version.id, user, true).call
       expect(PdfRemediation::AutoRemediationJob).to have_received(:perform_later).with(pdf1.id)
       expect(PdfRemediation::AutoRemediationJob).to have_received(:perform_later).with(pdf2.id)
       expect(PdfRemediation::AutoRemediationJob).not_to have_received(:perform_later).with(non_pdf.id)
@@ -22,6 +23,8 @@ RSpec.describe PdfRemediation::AutoRemediateService do
   end
 
   describe '#able_to_auto_remediate?' do
+    let(:user) { create(:user) }
+
     # TODO: Remove following context block when we are confident in the stability of the remediation service
     context 'when production environment' do
       before do
@@ -40,7 +43,7 @@ RSpec.describe PdfRemediation::AutoRemediateService do
 
         it 'returns true' do
           work_version = create(:work_version, :published)
-          expect(described_class.new(work_version.id, false, true).able_to_auto_remediate?).to be true
+          expect(described_class.new(work_version.id, user, true).able_to_auto_remediate?).to be true
         end
       end
 
@@ -52,7 +55,7 @@ RSpec.describe PdfRemediation::AutoRemediateService do
 
         it 'returns false' do
           work_version = create(:work_version, :published)
-          expect(described_class.new(work_version.id, false, true).able_to_auto_remediate?).to be false
+          expect(described_class.new(work_version.id, user, true).able_to_auto_remediate?).to be false
         end
       end
     end
@@ -63,10 +66,10 @@ RSpec.describe PdfRemediation::AutoRemediateService do
           let(:work_version) { create(:work_version, :published) }
 
           context 'when the download can remediate' do
-            context 'when the user is not an admin' do
+            context 'when the user is not an admin, creator, or depositor' do
               context 'when the work is not under manual review' do
                 it 'returns true' do
-                  expect(described_class.new(work_version.id, false, true).able_to_auto_remediate?).to be true
+                  expect(described_class.new(work_version.id, user, true).able_to_auto_remediate?).to be true
                 end
               end
 
@@ -74,21 +77,39 @@ RSpec.describe PdfRemediation::AutoRemediateService do
                 before { work_version.work.update(under_manual_review: true) }
 
                 it 'returns false' do
-                  expect(described_class.new(work_version.id, false, true).able_to_auto_remediate?).to be false
+                  expect(described_class.new(work_version.id, user, true).able_to_auto_remediate?).to be false
                 end
               end
             end
 
             context 'when the user is an admin' do
               it 'returns false' do
-                expect(described_class.new(work_version.id, true, true).able_to_auto_remediate?).to be false
+                admin_user = create(:user, :admin)
+                expect(described_class.new(work_version.id, admin_user, true).able_to_auto_remediate?).to be false
+              end
+            end
+
+            context 'when the user is a creator' do
+              it 'returns false' do
+                work_version.creators << create(:authorship, actor: user.actor)
+                work_version.save!
+
+                expect(described_class.new(work_version.id, user, true).able_to_auto_remediate?).to be false
+              end
+            end
+
+            context 'when the user is the depositor' do
+              before { work_version.work.update!(depositor: user.actor) }
+
+              it 'returns false' do
+                expect(described_class.new(work_version.id, user, true).able_to_auto_remediate?).to be false
               end
             end
           end
 
           context 'when the download cannot remediate' do
             it 'returns false' do
-              expect(described_class.new(work_version.id, false, false).able_to_auto_remediate?).to be false
+              expect(described_class.new(work_version.id, user, false).able_to_auto_remediate?).to be false
             end
           end
         end
@@ -97,7 +118,7 @@ RSpec.describe PdfRemediation::AutoRemediateService do
           let(:work_version) { create(:work_version, :published, remediated_version: true) }
 
           it 'returns false' do
-            expect(described_class.new(work_version.id, false, true).able_to_auto_remediate?).to be false
+            expect(described_class.new(work_version.id, user, true).able_to_auto_remediate?).to be false
           end
         end
       end
@@ -106,7 +127,7 @@ RSpec.describe PdfRemediation::AutoRemediateService do
         let(:work_version) { create(:work_version, :published, auto_remediation_started_at: 1.hour.ago) }
 
         it 'returns false' do
-          expect(described_class.new(work_version.id, false, true).able_to_auto_remediate?).to be false
+          expect(described_class.new(work_version.id, user, true).able_to_auto_remediate?).to be false
         end
       end
     end
@@ -115,7 +136,7 @@ RSpec.describe PdfRemediation::AutoRemediateService do
       let(:work_version) { create(:work_version, :draft) }
 
       it 'returns false' do
-        expect(described_class.new(work_version.id, false, true).able_to_auto_remediate?).to be false
+        expect(described_class.new(work_version.id, user, true).able_to_auto_remediate?).to be false
       end
     end
   end


### PR DESCRIPTION
Adds logic to `able_to_auto_remediate?` to return false if current user is the depositor or a creator.  Adds tests for this.

Part of #1800 