### PR TITLE
ScholarSphere hotfixes

### DIFF
--- a/app/controllers/webhooks/pdf_accessibility_api_controller.rb
+++ b/app/controllers/webhooks/pdf_accessibility_api_controller.rb
@@ -5,8 +5,8 @@ class Webhooks::PdfAccessibilityApiController < ApplicationController
   before_action :authenticate_request
 
   def create
-    event_type = params[:event_type]
-    job_data   = params[:job] || {}
+    event_type = pdf_accessibility_params[:event_type]
+    job_data   = pdf_accessibility_params[:job] || {}
 
     case event_type
     when 'job.succeeded'

--- a/app/models/file_resource.rb
+++ b/app/models/file_resource.rb
@@ -114,8 +114,8 @@ class FileResource < ApplicationRecord
       .last
   end
 
-  def first_auto_remediated_work_version_after(version)
-    work_versions.where('work_versions.id > ? AND auto_remediated_version = ?', version.id, true)
+  def first_remediated_work_version_after(version)
+    work_versions.where('work_versions.id > ? AND remediated_version = ?', version.id, true)
       .order(:id)
       .first
   end

--- a/app/models/file_resource.rb
+++ b/app/models/file_resource.rb
@@ -33,7 +33,7 @@ class FileResource < ApplicationRecord
   }
 
   scope :can_remediate, -> {
-    is_pdf.where('remediated_version IS NULL OR remediated_version = ?', false)
+    is_pdf.where(remediated_version: [nil, false], auto_remediated_version: [nil, false])
   }
 
   scope :needs_accessibility_check, -> {
@@ -104,7 +104,7 @@ class FileResource < ApplicationRecord
   end
 
   def can_remediate?
-    file.mime_type == PDF_MIME_TYPE && !remediated_version
+    file.mime_type == PDF_MIME_TYPE && !remediated_version && !auto_remediated_version
   end
 
   def latest_remediation_work_version_candidate

--- a/app/models/file_resource.rb
+++ b/app/models/file_resource.rb
@@ -114,8 +114,8 @@ class FileResource < ApplicationRecord
       .last
   end
 
-  def first_remediated_work_version_after(version)
-    work_versions.where('work_versions.id > ? AND remediated_version = ?', version.id, true)
+  def first_auto_remediated_work_version_after(version)
+    work_versions.where('work_versions.id > ? AND auto_remediated_version = ?', version.id, true)
       .order(:id)
       .first
   end

--- a/app/services/pdf_remediation/build_auto_remediated_work_version.rb
+++ b/app/services/pdf_remediation/build_auto_remediated_work_version.rb
@@ -46,7 +46,8 @@ class PdfRemediation::BuildAutoRemediatedWorkVersion
   private_class_method def self.build_file_resource(work_version, replacement_tempfile, original_filename)
     new_resource = work_version.file_resources.create!(
       file: replacement_tempfile,
-      remediated_version: true
+      remediated_version: true,
+      auto_remediated_version: true
     )
 
     new_resource.file_data['metadata']['filename'] = "ACCESSIBLE_VERSION_#{original_filename}"

--- a/app/services/pdf_remediation/build_auto_remediated_work_version.rb
+++ b/app/services/pdf_remediation/build_auto_remediated_work_version.rb
@@ -8,6 +8,7 @@ class PdfRemediation::BuildAutoRemediatedWorkVersion
   def self.call(file_resource, remediated_file_url)
     wv_being_remediated = file_resource.latest_remediation_work_version_candidate
     original_filename = file_resource.file_data['metadata']['filename']
+
     # In the rare case a new work version is published after the remediation
     # job started, we stop the creation of a new remediated version here.
     unless wv_being_remediated.latest_published_version?
@@ -43,21 +44,25 @@ class PdfRemediation::BuildAutoRemediatedWorkVersion
     end
   end
 
-  private_class_method def self.build_file_resource(work_version, replacement_tempfile, original_filename)
-    new_resource = work_version.file_resources.create!(
-      file: replacement_tempfile,
-      remediated_version: true,
-      auto_remediated_version: true
-    )
+  class << self
+    private
 
-    new_resource.file_data['metadata']['filename'] = "ACCESSIBLE_VERSION_#{original_filename}"
-    new_resource.save!
-  end
+      def build_file_resource(work_version, replacement_tempfile, original_filename)
+        new_resource = work_version.file_resources.create!(
+          file: replacement_tempfile,
+          remediated_version: true,
+          auto_remediated_version: true
+        )
 
-  private_class_method def self.on_publish(built_work_version)
-    built_work_version.publish!
-    lib_answers = LibanswersApiService.new
-    lib_answers.admin_create_ticket(built_work_version.work.id, 'work_remediation')
-    PdfRemediation::AutoRemediationNotifications.new(built_work_version).send_notifications
+        new_resource.file_data['metadata']['filename'] = "ACCESSIBLE_VERSION_#{original_filename}"
+        new_resource.save!
+      end
+
+      def on_publish(built_work_version)
+        built_work_version.publish!
+        lib_answers = LibanswersApiService.new
+        lib_answers.admin_create_ticket(built_work_version.work.id, 'work_remediation')
+        PdfRemediation::AutoRemediationNotifications.new(built_work_version).send_notifications
+      end
   end
 end

--- a/db/migrate/20260319120000_add_auto_remediated_version_to_file_resources.rb
+++ b/db/migrate/20260319120000_add_auto_remediated_version_to_file_resources.rb
@@ -1,0 +1,5 @@
+class AddAutoRemediatedVersionToFileResources < ActiveRecord::Migration[7.2]
+  def change
+    add_column :file_resources, :auto_remediated_version, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_10_130000) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_19_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -155,6 +155,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_10_130000) do
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }
     t.string "remediation_job_uuid"
     t.boolean "remediated_version", default: false, null: false
+    t.boolean "auto_remediated_version", default: false, null: false
     t.datetime "auto_remediation_failed_at"
   end
 

--- a/spec/models/file_resource_spec.rb
+++ b/spec/models/file_resource_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe FileResource do
     it { is_expected.to have_db_column(:file_data).of_type(:jsonb) }
     it { is_expected.to have_db_column(:remediation_job_uuid).of_type(:string) }
     it { is_expected.to have_db_column(:remediated_version).of_type(:boolean).with_options(default: false, null: false) }
+    it { is_expected.to have_db_column(:auto_remediated_version).of_type(:boolean).with_options(default: false, null: false) }
     it { is_expected.to have_db_column(:auto_remediation_failed_at).of_type(:datetime) }
   end
 
@@ -49,10 +50,11 @@ RSpec.describe FileResource do
   describe 'scopes' do
     describe '.can_remediate' do
       let(:remediable_pdf) { create(:file_resource, :pdf) }
-      let(:non_remediable_pdf) { create(:file_resource, :pdf, remediated_version: true) }
+      let(:auto_remediated_pdf) { create(:file_resource, :pdf, auto_remediated_version: true) }
+      let(:manual_remediated_pdf) { create(:file_resource, :pdf, remediated_version: true, auto_remediated_version: false) }
       let(:non_pdf_file_resource) { create(:file_resource, :with_processed_image) }
 
-      it 'returns only PDF files that are not auto-remediated' do
+      it 'returns only PDF files that are not remediated and not auto-remediated' do
         expect(described_class.can_remediate).to contain_exactly(remediable_pdf)
       end
     end
@@ -273,6 +275,7 @@ RSpec.describe FileResource do
         thumbnail_url_ssi
         remediation_job_uuid_tesim
         remediated_version_tesim
+        auto_remediated_version_tesim
         auto_remediation_failed_at_dtsi
       )
     end
@@ -389,20 +392,29 @@ RSpec.describe FileResource do
     context 'when the file is a pdf' do
       let(:file_resource) { build(:file_resource, :pdf) }
 
-      context 'when remediated_version is false' do
-        before { file_resource.remediated_version = false }
+      context 'when auto_remediated_version is false' do
+        before { file_resource.auto_remediated_version = false }
 
         it { is_expected.to be true }
       end
 
-      context 'when remediated_version is nil' do
-        before { file_resource.remediated_version = nil }
+      context 'when auto_remediated_version is nil' do
+        before { file_resource.auto_remediated_version = nil }
 
         it { is_expected.to be true }
       end
 
-      context 'when remediated_version is true' do
-        before { file_resource.remediated_version = true }
+      context 'when remediated_version is true but auto_remediated_version is false' do
+        before do
+          file_resource.remediated_version = true
+          file_resource.auto_remediated_version = false
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context 'when auto_remediated_version is true' do
+        before { file_resource.auto_remediated_version = true }
 
         it { is_expected.to be false }
       end
@@ -411,20 +423,20 @@ RSpec.describe FileResource do
     context 'when the file is not a PDF' do
       let(:file_resource) { build(:file_resource, :with_processed_image) }
 
-      context 'when remediated_version is false' do
-        before { file_resource.remediated_version = false }
+      context 'when auto_remediated_version is false' do
+        before { file_resource.auto_remediated_version = false }
 
         it { is_expected.to be false }
       end
 
-      context 'when remediated_version is nil' do
-        before { file_resource.remediated_version = nil }
+      context 'when auto_remediated_version is nil' do
+        before { file_resource.auto_remediated_version = nil }
 
         it { is_expected.to be false }
       end
 
-      context 'when remediated_version is true' do
-        before { file_resource.remediated_version = true }
+      context 'when auto_remediated_version is true' do
+        before { file_resource.auto_remediated_version = true }
 
         it { is_expected.to be false }
       end

--- a/spec/models/file_resource_spec.rb
+++ b/spec/models/file_resource_spec.rb
@@ -392,14 +392,11 @@ RSpec.describe FileResource do
     context 'when the file is a pdf' do
       let(:file_resource) { build(:file_resource, :pdf) }
 
-      context 'when auto_remediated_version is false' do
-        before { file_resource.auto_remediated_version = false }
-
-        it { is_expected.to be true }
-      end
-
-      context 'when auto_remediated_version is nil' do
-        before { file_resource.auto_remediated_version = nil }
+      context 'when auto_remediated_version is false and remediated_version is false' do
+        before do
+          file_resource.auto_remediated_version = false
+          file_resource.remediated_version = false
+        end
 
         it { is_expected.to be true }
       end
@@ -413,30 +410,60 @@ RSpec.describe FileResource do
         it { is_expected.to be false }
       end
 
-      context 'when auto_remediated_version is true' do
-        before { file_resource.auto_remediated_version = true }
+      context 'when remediated_version is true and auto_remediated_version is true' do
+        before do
+          file_resource.remediated_version = true
+          file_resource.auto_remediated_version = true
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context 'when remediated_version is false and auto_remediated_version is true' do
+        before do
+          file_resource.remediated_version = false
+          file_resource.auto_remediated_version = true
+        end
 
         it { is_expected.to be false }
       end
     end
 
-    context 'when the file is not a PDF' do
+    context 'when the file is not a pdf' do
       let(:file_resource) { build(:file_resource, :with_processed_image) }
 
-      context 'when auto_remediated_version is false' do
-        before { file_resource.auto_remediated_version = false }
+      context 'when auto_remediated_version is false and remediated_version is false' do
+        before do
+          file_resource.auto_remediated_version = false
+          file_resource.remediated_version = false
+        end
 
         it { is_expected.to be false }
       end
 
-      context 'when auto_remediated_version is nil' do
-        before { file_resource.auto_remediated_version = nil }
+      context 'when remediated_version is true but auto_remediated_version is false' do
+        before do
+          file_resource.remediated_version = true
+          file_resource.auto_remediated_version = false
+        end
 
         it { is_expected.to be false }
       end
 
-      context 'when auto_remediated_version is true' do
-        before { file_resource.auto_remediated_version = true }
+      context 'when remediated_version is true and auto_remediated_version is true' do
+        before do
+          file_resource.remediated_version = true
+          file_resource.auto_remediated_version = true
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context 'when remediated_version is false and auto_remediated_version is true' do
+        before do
+          file_resource.remediated_version = false
+          file_resource.auto_remediated_version = true
+        end
 
         it { is_expected.to be false }
       end
@@ -485,7 +512,7 @@ RSpec.describe FileResource do
     let(:file_resource) { create(:file_resource) }
     let!(:version_being_remediated) { create(:work_version) }
 
-    context 'when there are auto_remediated work_versions after the given version' do
+    context 'when there are remediated work_versions after the given version' do
       let!(:first_remediated) { create(:work_version,
                                        remediated_version: true) }
 
@@ -498,13 +525,13 @@ RSpec.describe FileResource do
                work_version: first_remediated)
       end
 
-      it 'returns the first remediated_version with id greater than the given version' do
+      it 'returns the first remediated_work_version with id greater than the given version' do
         expect(file_resource
         .first_remediated_work_version_after(version_being_remediated)).to eq(first_remediated)
       end
     end
 
-    context 'when multiple auto remediated versions exist after the given version' do
+    context 'when multiple remediated versions exist after the given version' do
       let!(:first_remediated) { create(:work_version,
                                        remediated_version: true) }
       let!(:later_remediated) { create(:work_version,
@@ -519,13 +546,13 @@ RSpec.describe FileResource do
                work_version: first_remediated)
       end
 
-      it 'returns the first auto remediated version after the given version' do
+      it 'returns the first remediated version after the given version' do
         expect(file_resource
         .first_remediated_work_version_after(version_being_remediated)).to eq(first_remediated)
       end
     end
 
-    context 'when no auto remediated versions exist after the given version' do
+    context 'when no remediated versions exist after the given version' do
       let!(:only_version) { create(:work_version) }
 
       before do

--- a/spec/services/pdf_remediation/build_auto_remediated_work_version_spec.rb
+++ b/spec/services/pdf_remediation/build_auto_remediated_work_version_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe PdfRemediation::BuildAutoRemediatedWorkVersion do
             expect(FileVersionMembership.find_by(work_version: result, file_resource: file_resource)).to be_nil
             remediated_file_resource = WorkVersion.find(result.id).file_resources.where(remediated_version: true)
             expect(remediated_file_resource.count).to eq(1)
+            expect(remediated_file_resource.first.auto_remediated_version).to be true
             expect(remediated_file_resource.first.file_data['metadata']['filename']).to eq(
               "ACCESSIBLE_VERSION_#{FileResource.find(file_resource.id).file_data['metadata']['filename']}"
             )


### PR DESCRIPTION
There's a couple things in this PR:

- app/controllers/webhooks/pdf_accessibility_api_controller.rb: the strong params were not being used here, so I changed the param call to use strong params
- I realized that an admin could upload a new work version _after_ a remediated version, and the `remediated_version` values for `FileResource`s could get reset if it's not flagged during upload that it's a remediated version.  So, I decided to add the `auto_remediated_version` field back to the `FileResource` data model.  That stays separate from `remediated_version`, so it's not affected by admins' manual remediation.
- I changed up how we define private methods here: app/services/pdf_remediation/build_auto_remediated_work_version.rb .  I think it's just a more idiomatic way of doing it when there are multiple private class methods.  Functionality is the same except that `auto_remediated_version` is set when the file is created (as a part of the above bullet point).