### PR TITLE
Flag non PDF files as remediated

### DIFF
--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -402,7 +402,7 @@ class WorkVersion < ApplicationRecord
   end
 
   def mirror_remediated_version_to_files!
-    file_resources.is_pdf.find_each do |file_resource|
+    file_resources.find_each do |file_resource|
       file_resource.update!(remediated_version: remediated_version)
     end
   end

--- a/lib/tasks/flag_existing_remediated_files_and_work_versions.rake
+++ b/lib/tasks/flag_existing_remediated_files_and_work_versions.rake
@@ -3,7 +3,7 @@
 namespace :pdf_remediation do
   desc 'Flag existing remediated WorkVersions that have AccessibleCopy_ filename prefix'
   task flag_existing_remediated_files_and_work_versions: :environment do
-    scope = FileResource.is_pdf.where("file_data->'metadata'->>'filename' LIKE ?", 'AccessibleCopy_%')
+    scope = FileResource.where("file_data->'metadata'->>'filename' LIKE ?", 'AccessibleCopy_%')
 
     puts "Found #{scope.count} FileResource records with AccessibleCopy_ filename prefix"
 

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -1664,7 +1664,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
       check I18n.t('dashboard.form.publish.remediated_version.label')
 
       FeatureHelpers::DashboardForm.finish
-      expect(SolrIndexingJob).to have_received(:perform_later).once
+      expect(SolrIndexingJob).to have_received(:perform_later).with(work_version).once
 
       work_version.reload
       expect(work_version.rights).to eq(incorrect_rights)

--- a/spec/lib/tasks/pdf_remediation_spec.rb
+++ b/spec/lib/tasks/pdf_remediation_spec.rb
@@ -28,25 +28,34 @@ describe 'pdf_remediation', type: :task do
         )
       end
 
-      let!(:work_version) do
+      let!(:work_version_w_pdf) do
         create(:work_version).tap do |version|
           create(:file_version_membership, work_version: version, file_resource: pdf_accessiblecopy_file_resource)
         end
       end
 
-      it 'only flags PDF FileResources with AccessibleCopy_ filenames and their latest WorkVersions' do
+      let!(:work_version_w_non_pdf) do
+        create(:work_version).tap do |version|
+          create(:file_version_membership, work_version: version, file_resource: non_pdf_accessiblecopy_file_resource)
+        end
+      end
+
+      it 'only flags FileResources with AccessibleCopy_ filenames and their latest WorkVersions' do
         expect(pdf_accessiblecopy_file_resource.remediated_version).to be(false)
         expect(pdf_non_accessiblecopy_file_resource.remediated_version).to be(false)
         expect(non_pdf_accessiblecopy_file_resource.remediated_version).to be(false)
-        expect(work_version.remediated_version).to be(false)
+        expect(work_version_w_pdf.remediated_version).to be(false)
+        expect(work_version_w_non_pdf.remediated_version).to be(false)
 
-        expect {
-          Rake::Task['pdf_remediation:flag_existing_remediated_files_and_work_versions'].invoke
-        }.to change { pdf_accessiblecopy_file_resource.reload.remediated_version }.from(false).to(true)
-          .and change { work_version.reload.remediated_version }.from(false).to(true)
+        Rake::Task['pdf_remediation:flag_existing_remediated_files_and_work_versions'].invoke
+
+        expect(pdf_accessiblecopy_file_resource.reload.remediated_version).to be(true)
+        expect(work_version_w_pdf.reload.remediated_version).to be(true)
+
+        expect(non_pdf_accessiblecopy_file_resource.reload.remediated_version).to be(true)
+        expect(work_version_w_non_pdf.reload.remediated_version).to be(true)
 
         expect(pdf_non_accessiblecopy_file_resource.reload.remediated_version).to be(false)
-        expect(non_pdf_accessiblecopy_file_resource.reload.remediated_version).to be(false)
       end
     end
 

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -1089,11 +1089,11 @@ RSpec.describe WorkVersion do
       create(:file_version_membership, work_version: work_version, file_resource: non_pdf_file)
     end
 
-    it 'updates only PDF file resources to match the work version' do
+    it 'updates all file resources to match the work version' do
       work_version.mirror_remediated_version_to_files!
 
       expect(pdf_file.reload.remediated_version).to be true
-      expect(non_pdf_file.reload.remediated_version).to be false
+      expect(non_pdf_file.reload.remediated_version).to be true
     end
   end
 end

--- a/spec/request/dashboard/form/publish_controller_spec.rb
+++ b/spec/request/dashboard/form/publish_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Dashboard::Form::PublishController, type: :request do
 
       before { sign_in admin }
 
-      it 'saves work_version.remediated_version and mirrors remediated_version to associated PDF files' do
+      it 'saves work_version.remediated_version and mirrors remediated_version to associated files' do
         expect(pdf_file.remediated_version).to be false
         expect(non_pdf_file.remediated_version).to be false
 
@@ -35,7 +35,7 @@ RSpec.describe Dashboard::Form::PublishController, type: :request do
         expect(response).to have_http_status(:redirect)
         expect(work_version.reload.remediated_version).to be true
         expect(pdf_file.reload.remediated_version).to be true
-        expect(non_pdf_file.reload.remediated_version).to be false
+        expect(non_pdf_file.reload.remediated_version).to be true
       end
     end
 


### PR DESCRIPTION
I spoke with the ScholarSphere admins and discovered that when they are doing manual accessibility remediation, they are uploading accessible copies for more than just PDFs.  So, this PR changes the existing script that backfills "remediated_version" records to update _any_ file with an "AccessibleCopy_" prefix.  I also changed the code that sets the "remediated_version" for files when an admin checks the checkbox on the publish page to set that field for _all_ files (not just PDFs).