### PR TITLE
Skip validations for some of the values set at remediation start

### DIFF
--- a/app/jobs/pdf_remediation/auto_remediation_job.rb
+++ b/app/jobs/pdf_remediation/auto_remediation_job.rb
@@ -10,7 +10,7 @@ class PdfRemediation::AutoRemediationJob < ApplicationJob
 
     begin
       remediation_job_uuid = PdfRemediation::Client.new(file_resource.file_url).request_remediation
-      file_resource.update(remediation_job_uuid: remediation_job_uuid)
+      file_resource.update_column(:remediation_job_uuid, remediation_job_uuid) # rubocop:disable Rails/SkipsModelValidations
     rescue StandardError => e
       Rails.logger.error("Failed to auto remediate #{file_resource.id}: #{e.message}")
       raise e

--- a/app/services/pdf_remediation/auto_remediate_service.rb
+++ b/app/services/pdf_remediation/auto_remediate_service.rb
@@ -10,7 +10,8 @@ class PdfRemediation::AutoRemediateService
   end
 
   def call
-    work_version.update(auto_remediation_started_at: Time.current)
+    work_version.update_column(:auto_remediation_started_at, Time.current)
+
     pdfs = work_version.file_resources.can_remediate
     pdfs.each do |pdf|
       PdfRemediation::AutoRemediationJob.perform_later(pdf.id) if pdf.remediation_job_uuid.blank?

--- a/app/services/pdf_remediation/auto_remediate_service.rb
+++ b/app/services/pdf_remediation/auto_remediate_service.rb
@@ -10,7 +10,7 @@ class PdfRemediation::AutoRemediateService
   end
 
   def call
-    work_version.update_column(:auto_remediation_started_at, Time.current)
+    work_version.update_column(:auto_remediation_started_at, Time.current) # rubocop:disable Rails/SkipsModelValidations
 
     pdfs = work_version.file_resources.can_remediate
     pdfs.each do |pdf|

--- a/spec/services/pdf_remediation/auto_remediate_service_spec.rb
+++ b/spec/services/pdf_remediation/auto_remediate_service_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe PdfRemediation::AutoRemediateService do
       expect(PdfRemediation::AutoRemediationJob).not_to have_received(:perform_later).with(non_pdf.id)
       expect(PdfRemediation::AutoRemediationJob).not_to have_received(:perform_later).with(pdf3.id)
     end
+
+    it 'sets auto_remediation_started_at' do
+      expect {
+        described_class.new(work_version.id, user, true).call
+      }.to change { work_version.reload.auto_remediation_started_at }.from(nil)
+    end
   end
 
   describe '#able_to_auto_remediate?' do


### PR DESCRIPTION
`update` was being used in a few locations, which was validating old records and failing.  Model validations have changed so much that we have a lot of legacy "invalid" data.  Validations only really need to happen when editing and publishing works, so we can skip validations here with `update_column`.