### PR TITLE
Adds bot challenge to downloads controller

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,7 @@ Metrics/BlockLength:
     - 'config/routes.rb'
     - 'config/environments/production.rb'
     - 'config/environments/development.rb'
+    - 'config/initializers/bot_challenge_page.rb'
     - 'spec/**/*'
     - 'lib/tasks/**/*'
     - 'app/reports/**/*'

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class DownloadsController < ApplicationController
+  before_action only: :content do |controller|
+    BotChallengePage::BotChallengePageController.bot_challenge_enforce_filter(controller, immediate: true)
+  end
+
   def content
     work_version = WorkVersion.find_by!(uuid: download_params[:resource_id])
     file_version = work_version.file_version_memberships.find(download_params[:id])

--- a/config/initializers/bot_challenge_page.rb
+++ b/config/initializers/bot_challenge_page.rb
@@ -24,7 +24,8 @@ Rails.application.config.to_prepare do
     )
 
   BotChallengePage::BotChallengePageController.bot_challenge_config.rate_limited_locations = [
-    '/catalog'
+    '/catalog',
+    '/resources'
   ]
 
   BotChallengePage::BotChallengePageController.bot_challenge_config.challenge_renderer = -> {
@@ -34,6 +35,9 @@ Rails.application.config.to_prepare do
   # How long will a challenge success exempt a session from further challenges?
   BotChallengePage::BotChallengePageController.bot_challenge_config.session_passed_good_for = 24.hours
   BotChallengePage::BotChallengePageController.bot_challenge_config.allow_exempt = ->(controller, _config) {
+    # Skip challenge for authenticated users.
+    return true if controller.current_user.present? && !controller.current_user.guest?
+
     # Does not challenge "Good Bots" – we have another layer of filters so Header containing "Bot" should be legit
     !!(controller.request.headers['User-Agent'] =~ /bot|nagios-plugins/i)
   }

--- a/spec/initializers/bot_challenge_page_spec.rb
+++ b/spec/initializers/bot_challenge_page_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'BotChallengePage' do
+  subject(:allow_exempt) { BotChallengePage::BotChallengePageController.bot_challenge_config.allow_exempt }
+
+  let(:request) { instance_double(ActionDispatch::Request, headers: { 'User-Agent' => user_agent }) }
+  let(:controller) { instance_double(ApplicationController, current_user: current_user, request: request) }
+
+  context 'when user is authenticated' do
+    let(:current_user) { create(:user) }
+    let(:user_agent) { 'Mozilla/5.0' }
+
+    it 'exempts the request from challenge' do
+      expect(allow_exempt.call(controller, nil)).to be true
+    end
+  end
+
+  context 'when user is a guest' do
+    let(:current_user) { User.guest }
+
+    context 'when user agent is not a bot' do
+      let(:user_agent) { 'Mozilla/5.0' }
+
+      it 'does not exempt the request' do
+        expect(allow_exempt.call(controller, nil)).to be false
+      end
+    end
+
+    context 'when user agent is a bot' do
+      let(:user_agent) { 'Googlebot' }
+
+      it 'exempts the request' do
+        expect(allow_exempt.call(controller, nil)).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Also, adds logic to bot challenge page initializer to not challenge logged in users.

It appears we do have crawlers on our downloads endpoints.  This did not show in matomo analytics.  It may be because these are very simple bot crawlers, and do not trigger JS.  If that's the case, then this PR will dramatically reduce traffic, or it will do nothing because these bots may be "good" bots.