### PR TITLE
Skip validations in build auto remediated work version

### DIFF
--- a/app/services/pdf_remediation/build_auto_remediated_work_version.rb
+++ b/app/services/pdf_remediation/build_auto_remediated_work_version.rb
@@ -21,8 +21,9 @@ class PdfRemediation::BuildAutoRemediatedWorkVersion
         built_work_version = file_resource.first_remediated_work_version_after(wv_being_remediated) ||
           begin
             v = BuildNewWorkVersion.call(wv_being_remediated)
-            v.update({ remediated_version: true,
-                       external_app: ExternalApp.pdf_accessibility_api })
+            v.assign_attributes({ remediated_version: true,
+                                  external_app: ExternalApp.pdf_accessibility_api })
+            v.save!(validate: false)
             v
           end
 
@@ -33,7 +34,7 @@ class PdfRemediation::BuildAutoRemediatedWorkVersion
         replacement_tempfile = Down.download(remediated_file_url)
         build_file_resource(built_work_version, replacement_tempfile, original_filename)
         if built_work_version.has_remaining_auto_remediation_jobs?
-          built_work_version.save!
+          built_work_version.save!(validate: false)
         else
           on_publish(built_work_version)
         end

--- a/spec/services/pdf_remediation/build_auto_remediated_work_version_spec.rb
+++ b/spec/services/pdf_remediation/build_auto_remediated_work_version_spec.rb
@@ -70,6 +70,18 @@ RSpec.describe PdfRemediation::BuildAutoRemediatedWorkVersion do
               .to have_received(:new).with(result)
           end
 
+          it 'remains draft when publish is attempted with legacy incomplete metadata' do
+            allow(Down).to receive(:download).with(remediated_url).and_return(Tempfile.new('remediated'))
+            legacy_metadata = wv_being_remediated.metadata.deep_dup
+            legacy_metadata['description'] = nil
+            wv_being_remediated.update_column(:metadata, legacy_metadata) # rubocop:disable Rails/SkipsModelValidations
+
+            result = described_class.call(file_resource, remediated_url)
+
+            expect(result).to be_draft
+            expect(result.description).to be_nil
+          end
+
           it 'calls the Libanswers service with an admin curation ticket' do
             allow(Down).to receive(:download).with(remediated_url).and_return(Tempfile.new('remediated'))
             result = described_class.call(file_resource, remediated_url)
@@ -103,6 +115,20 @@ RSpec.describe PdfRemediation::BuildAutoRemediatedWorkVersion do
             expect(result).to be_draft
             expect(PdfRemediation::AutoRemediationNotifications)
               .not_to have_received(:new).with(result)
+          end
+
+          it 'builds a remediated draft from a legacy source version with incomplete metadata' do
+            allow(Down).to receive(:download).with(remediated_url).and_return(Tempfile.new('remediated'))
+            legacy_metadata = wv_being_remediated.metadata.deep_dup
+            legacy_metadata['description'] = nil
+            wv_being_remediated.update_column(:metadata, legacy_metadata) # rubocop:disable Rails/SkipsModelValidations
+
+            result = described_class.call(file_resource, remediated_url)
+
+            expect(result).to be_persisted
+            expect(result).to be_draft
+            expect(result.description).to be_nil
+            expect(result.file_resources.where(remediated_version: true, auto_remediated_version: true).count).to eq(1)
           end
 
           it 'does not call the Libanswers service' do


### PR DESCRIPTION
 We have legacy data that is incomplete and fails validations, so we skip validations when creating an auto remediated work version.

Adds test for this.  Also, when publishing incomplete work versions, test that they remain as drafts after auto remediation.