### PR TITLE
Token verification on download links

### DIFF
--- a/app/components/file_download_link_component.rb
+++ b/app/components/file_download_link_component.rb
@@ -25,11 +25,13 @@ class FileDownloadLinkComponent < ViewComponent::Base
   end
 
   def download_path(download: true)
+    query_params = { resource_id: work_version_uuid }
+    query_params[:download_token] = download_token if download
+
     Rails.application
       .routes.url_helpers
       .resource_download_path(@file_version_membership.id,
-                              resource_id: work_version_uuid,
-                              download: download)
+                              **query_params)
   end
 
   def view_title
@@ -77,5 +79,18 @@ class FileDownloadLinkComponent < ViewComponent::Base
 
     def work
       @file_version_membership.work_version.work
+    end
+
+    def download_token
+      download_token_verifier.generate(
+        @file_version_membership.id,
+        # In seconds, default to 1 minute
+        expires_in: ENV.fetch('DOWNLOAD_TOKEN_TTL', 60).to_i,
+        purpose: :download_request
+      )
+    end
+
+    def download_token_verifier
+      Rails.application.message_verifier(:download_request_token)
     end
 end

--- a/app/components/file_download_link_component.rb
+++ b/app/components/file_download_link_component.rb
@@ -84,8 +84,8 @@ class FileDownloadLinkComponent < ViewComponent::Base
     def download_token
       download_token_verifier.generate(
         @file_version_membership.id,
-        # In seconds, default to 1 minute
-        expires_in: ENV.fetch('DOWNLOAD_TOKEN_TTL', 60).to_i,
+        # In seconds, default to 8 minutes
+        expires_in: ENV.fetch('DOWNLOAD_TOKEN_TTL', 480).to_i,
         purpose: :download_request
       )
     end

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -8,6 +8,8 @@ class DownloadsController < ApplicationController
   def content
     work_version = WorkVersion.find_by!(uuid: download_params[:resource_id])
     file_version = work_version.file_version_memberships.find(download_params[:id])
+    download_requested = valid_download_token?(download_params[:download_token], file_version.id)
+
     authorize(file_version)
     file_version.file_resource.count_view! if count_view?(file_version.file_resource)
 
@@ -16,9 +18,9 @@ class DownloadsController < ApplicationController
       current_user,
       file_version.file_resource.can_remediate?
     )
-    remediation_service.call if remediation_service.able_to_auto_remediate? && download_params[:download]
+    remediation_service.call if remediation_service.able_to_auto_remediate? && download_requested
 
-    redirect_to s3_presigned_url(file_version, download: download_params[:download]), allow_other_host: true
+    redirect_to s3_presigned_url(file_version, download: download_requested), allow_other_host: true
   end
 
   private
@@ -37,8 +39,20 @@ class DownloadsController < ApplicationController
       SessionViewStatsCache.call(session: session, resource: resource)
     end
 
+    def valid_download_token?(token, file_version_id)
+      return false if token.blank?
+
+      token_file_version_id = download_token_verifier.verify(token, purpose: :download_request)
+      token_file_version_id.to_i == file_version_id.to_i
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      false
+    end
+
+    def download_token_verifier
+      Rails.application.message_verifier(:download_request_token)
+    end
+
     def download_params
-      params[:download] = ActiveModel::Type::Boolean.new.cast(params[:download])
-      params.permit(:id, :resource_id, :download)
+      params.permit(:id, :resource_id, :download_token)
     end
 end

--- a/spec/components/file_download_link_component_spec.rb
+++ b/spec/components/file_download_link_component_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe FileDownloadLinkComponent, type: :component do
       render_inline(described_class.new(file_version_membership: file_version_membership))
       expect(page).to have_link(I18n.t!('resources.download',
                                         name: file_version_membership.title),
-                                href: "/resources/#{resource.uuid}/downloads/#{file_version_membership.id}?download=true")
+                                href: %r{/resources/#{resource.uuid}/downloads/#{file_version_membership.id}\?download_token=.+})
       expect(page).to have_link(I18n.t!('resources.view',
                                         name: file_version_membership.title),
-                                href: "/resources/#{resource.uuid}/downloads/#{file_version_membership.id}?download=false")
+                                href: "/resources/#{resource.uuid}/downloads/#{file_version_membership.id}")
       expect(page).to have_css("a[aria-label='Download file: #{file_version_membership.title}']")
       expect(page).to have_css("a[aria-label='View file: #{file_version_membership.title}']")
     end
@@ -45,10 +45,10 @@ RSpec.describe FileDownloadLinkComponent, type: :component do
       render_inline(described_class.new(file_version_membership: file_version_membership))
       expect(page).to have_link(I18n.t!('resources.download',
                                         name: file_version_membership.title),
-                                href: "/resources/#{resource.uuid}/downloads/#{file_version_membership.id}?download=true")
+                                href: %r{/resources/#{resource.uuid}/downloads/#{file_version_membership.id}\?download_token=.+})
       expect(page).to have_link(I18n.t!('resources.view',
                                         name: file_version_membership.title),
-                                href: "/resources/#{resource.uuid}/downloads/#{file_version_membership.id}?download=false")
+                                href: "/resources/#{resource.uuid}/downloads/#{file_version_membership.id}")
       expect(page).to have_css("a[aria-label='Download file: #{file_version_membership.title}, an image of Test text']")
       expect(page).to have_css("a[aria-label='View file: #{file_version_membership.title}, an image of Test text']")
     end

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe DownloadsController do
   let(:user) { create(:user) }
   let(:admin_user) { create(:user, :admin) }
   let(:viewer_user) { create(:user, :viewer) }
+  let(:download_token_verifier) { Rails.application.message_verifier(:download_request_token) }
 
   describe 'GET #content' do
     context 'when not signed in' do
@@ -179,11 +180,15 @@ RSpec.describe DownloadsController do
     end
   end
 
-  context 'when "download" param is true' do
+  context 'when "download_token" param is valid' do
     let(:work_version) { create(:work_version, :published, :with_files, file_count: 2) }
+    let(:file_version_membership) { work_version.file_version_memberships[0] }
+    let(:download_token) do
+      download_token_verifier.generate(file_version_membership.id, expires_in: 60, purpose: :download_request)
+    end
 
     it 'uses "attachment" for the response content disposition' do
-      get :content, params: { resource_id: work_version.uuid, id: work_version.file_version_memberships[0].id, download: true }
+      get :content, params: { resource_id: work_version.uuid, id: file_version_membership.id, download_token: download_token }
       expect(response.location).to include('response-content-disposition=attachment')
     end
 
@@ -195,7 +200,15 @@ RSpec.describe DownloadsController do
       before { allow(PdfRemediation::AutoRemediateService).to receive(:new).and_return(service) }
 
       it 'calls AutoRemediationService' do
-        get :content, params: { resource_id: work_version.uuid, id: work_version.file_version_memberships[0].id, download: true }
+        get :content, params: {
+          resource_id: work_version.uuid,
+          id: work_version.file_version_memberships[0].id,
+          download_token: download_token_verifier.generate(
+            work_version.file_version_memberships[0].id,
+            expires_in: 60,
+            purpose: :download_request
+          )
+        }
         expect(service).to have_received(:call)
       end
     end
@@ -208,7 +221,15 @@ RSpec.describe DownloadsController do
       before { allow(PdfRemediation::AutoRemediateService).to receive(:new).and_return(service) }
 
       it 'does not enqueue an AutoRemediationJob' do
-        get :content, params: { resource_id: work_version.uuid, id: work_version.file_version_memberships[0].id, download: true }
+        get :content, params: {
+          resource_id: work_version.uuid,
+          id: work_version.file_version_memberships[0].id,
+          download_token: download_token_verifier.generate(
+            work_version.file_version_memberships[0].id,
+            expires_in: 60,
+            purpose: :download_request
+          )
+        }
         expect(service).not_to have_received(:call)
       end
     end
@@ -222,6 +243,24 @@ RSpec.describe DownloadsController do
 
     it 'uses "inline" for the response content disposition' do
       get :content, params: { resource_id: work_version.uuid, id: work_version.file_version_memberships[0].id }
+      expect(response.location).to include('response-content-disposition=inline')
+      expect(service).not_to have_received(:call)
+    end
+  end
+
+  context 'when "download_token" param is invalid' do
+    let(:work_version) { create(:work_version, :published, :with_files, file_count: 2) }
+    let(:service) { instance_double(PdfRemediation::AutoRemediateService, able_to_auto_remediate?: true, call: nil) }
+
+    before { allow(PdfRemediation::AutoRemediateService).to receive(:new).and_return(service) }
+
+    it 'uses "inline" disposition and does not call auto-remediation' do
+      get :content, params: {
+        resource_id: work_version.uuid,
+        id: work_version.file_version_memberships[0].id,
+        download_token: 'not-a-valid-token'
+      }
+
       expect(response.location).to include('response-content-disposition=inline')
       expect(service).not_to have_received(:call)
     end


### PR DESCRIPTION
Replace `download=true` process on file download links/controller with a signed token verification process.  I set the token to expire after 8 minutes, this may need adjusted but I think that's long enough for most real users.  If the token expires, the user will still be directed to the "View", where they can still download.  

This will confirm that users are downloading and triggering remediation only when the show page has been rendered in a browser.

closes #1928 