### PR TITLE
add open access subpathway to the scholarly work pathway

### DIFF
--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -118,6 +118,8 @@ module Dashboard
               :subtitle,
               :rights,
               :version_name,
+              :open_access,
+              :open_access_version,
               :published_date,
               :depositor_agreement,
               :psu_community_agreement,

--- a/app/controllers/dashboard/form/work_version_type_controller.rb
+++ b/app/controllers/dashboard/form/work_version_type_controller.rb
@@ -35,6 +35,7 @@ module Dashboard
             .require(:work_version)
             .permit(
               :title,
+              :open_access,
               work_attributes: [
                 :id,
                 :work_type

--- a/app/forms/work_deposit_pathway.rb
+++ b/app/forms/work_deposit_pathway.rb
@@ -44,7 +44,7 @@ class WorkDepositPathway
   end
 
   def allows_visibility_change?
-    !data_and_code? && !grad_culminating_experiences?
+    !data_and_code? && !grad_culminating_experiences? && !@resource.open_access
   end
 
   def allows_curation_request?
@@ -191,6 +191,8 @@ class WorkDepositPathway
                :file_version_memberships,
                :mint_doi_requested,
                :has_image_file_resource?,
+               :open_access,
+               :open_access_version,
                to: :work_version, prefix: false
 
       private
@@ -211,6 +213,7 @@ class WorkDepositPathway
       }.freeze
 
       delegate :imported_metadata_from_rmd,
+               :open_access,
                to: :work_version, prefix: false
 
       def show_autocomplete_form?
@@ -303,6 +306,7 @@ class WorkDepositPathway
               subject
               publisher
               subtitle
+              open_access
             }
           ).freeze
         end
@@ -328,6 +332,8 @@ class WorkDepositPathway
               subject
               publisher
               subtitle
+              open_access_version
+              open_access
             }
           ).freeze
         end

--- a/app/javascript/controllers/work_type_controller.js
+++ b/app/javascript/controllers/work_type_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from 'stimulus'
 
 export default class extends Controller {
-  static targets = ['workTypeSelect', 'helpText']
+  static targets = ['workTypeSelect', 'helpText', 'openAccess']
 
   connect () {
     this.toggleHelpText()
@@ -9,10 +9,17 @@ export default class extends Controller {
   }
 
   toggleHelpText () {
-    if (this.workTypeSelectTarget.value === 'instrument') {
-      this.helpTextTarget.style.display = 'block'
+    const value = this.workTypeSelectTarget.value
+
+    if (value === "instrument") {
+      this.helpTextTarget.style.display = "block"
     } else {
-      this.helpTextTarget.style.display = 'none'
+      this.helpTextTarget.style.display = "none"
+    }
+    if (JSON.parse(this.data.get('oaTypesValue')).includes(value)) {
+      this.openAccessTarget.style.display = "block"
+    } else {
+      this.openAccessTarget.style.display = "none"
     }
   }
 }

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -12,7 +12,7 @@ class Work < ApplicationRecord
   fields_with_dois :doi, :latest_published_version_dois
 
   delegate :email, :display_name, to: :depositor
-  delegate :has_publisher_doi?, to: :latest_version
+  delegate :has_publisher_doi?, :open_access, to: :latest_version
 
   belongs_to :depositor,
              class_name: 'Actor',
@@ -103,6 +103,15 @@ class Work < ApplicationRecord
         report
         research_paper
         thesis
+      ].freeze
+    end
+
+    def self.oa_scholarly_works
+      %w[
+        article
+        book
+        conference_proceeding
+        part_of_book
       ].freeze
     end
 

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -7,6 +7,11 @@ class WorkVersion < ApplicationRecord
   include GeneratedUuids
   include UpdatingDois
 
+  OPEN_ACCESS_VERSIONS = %w[
+    accepted
+    published
+  ].freeze
+
   after_validation :remove_duplicate_errors
   before_save :reset_irrelevant_fields_if_work_type_changed
 
@@ -47,7 +52,8 @@ class WorkVersion < ApplicationRecord
                  funding_reference: :string,
                  sub_work_type: :string,
                  program: :string,
-                 degree: :string
+                 degree: :string,
+                 open_access_version: :string
 
   belongs_to :work,
              inverse_of: :versions
@@ -160,6 +166,13 @@ class WorkVersion < ApplicationRecord
             inclusion: {
               in: [Permissions::Visibility::OPEN, Permissions::Visibility::AUTHORIZED],
               message: 'cannot be private'
+            },
+            if: :published?
+
+  validates :open_access_version,
+            allow_nil: true,
+            inclusion: {
+              in: OPEN_ACCESS_VERSIONS
             },
             if: :published?
 

--- a/app/views/dashboard/form/details/_scholarly_works_work_version_fields.html.erb
+++ b/app/views/dashboard/form/details/_scholarly_works_work_version_fields.html.erb
@@ -3,7 +3,9 @@
 <div class="form-wrapper">
   <%= render 'form_fields/text', form: form, attribute: :subtitle %>
   <%= render 'form_fields/multi_text', form: form, attribute: :publisher %>
-  <%= render 'form_fields/text_area', form: form, attribute: :publisher_statement %>
+  <%= render 'form_fields/text_area', form: form,
+                                      attribute: :publisher_statement,
+                                      readonly: @resource.open_access && !current_user.admin? %>
   <%= render 'form_fields/multi_text', form: form,
                                        attribute: :identifier,
                                        readonly: @resource.imported_metadata_from_rmd? && !current_user.admin? %>

--- a/app/views/dashboard/form/publish/_fields.html.erb
+++ b/app/views/dashboard/form/publish/_fields.html.erb
@@ -4,6 +4,7 @@
              attribute: :rights,
              options_for_select: WorkVersion::Licenses.options_for_select_box,
              aria_required: true,
+             disabled: @resource.open_access && !current_user.admin?,
              include_blank: true %>
 </div>
 
@@ -22,7 +23,7 @@
 
         <p><%= t('dashboard.works.edit.embargo.explanation') %></p>
 
-        <%= render 'form_fields/date', form: work_form, attribute: :embargoed_until %>
+        <%= render 'form_fields/date', form: work_form, attribute: :embargoed_until, readonly: @resource.open_access && !current_user.admin? %>
       </div>
     <% end %>
 

--- a/app/views/dashboard/form/publish/_open_access_version.html.erb
+++ b/app/views/dashboard/form/publish/_open_access_version.html.erb
@@ -1,9 +1,9 @@
-<div class="form-group">
-  <div class="form-check ms-5">
+<div class="form-wrapper">
+  <div class="form-check mb-2">
     <%= form.radio_button :open_access_version, 'accepted', class: 'form-check-input' %>
     <%= form.label :open_access_version, 'Accepted Version', value: 'accepted', class: 'form-check-label' %>
   </div>
-  <div class="form-check ms-5">
+  <div class="form-check mb-2">
     <%= form.radio_button :open_access_version, 'published', class: 'form-check-input' %>
     <%= form.label :open_access_version, 'Published Version', value: 'published', class: 'form-check-label' %>
   </div>

--- a/app/views/dashboard/form/publish/_version.html.erb
+++ b/app/views/dashboard/form/publish/_version.html.erb
@@ -1,0 +1,10 @@
+<div class="form-group">
+  <div class="form-check ms-5">
+    <%= form.radio_button :open_access_version, 'accepted', class: 'form-check-input' %>
+    <%= form.label :open_access_version, 'Accepted Version', value: 'accepted', class: 'form-check-label' %>
+  </div>
+  <div class="form-check ms-5">
+    <%= form.radio_button :open_access_version, 'published', class: 'form-check-input' %>
+    <%= form.label :open_access_version, 'Published Version', value: 'published', class: 'form-check-label' %>
+  </div>
+</div>

--- a/app/views/dashboard/form/publish/edit.html.erb
+++ b/app/views/dashboard/form/publish/edit.html.erb
@@ -42,6 +42,15 @@
               <%= render 'dashboard/form/files/uploaded_file_list', work_version: form.object %>
             <% end %>
 
+            <% if @resource.open_access %>
+              <div class="form-wrapper form-wrapper--wide">
+                <div class="keyline keyline--left mb-3">
+                  <h4><%= t '.version' %></h4>
+                </div>
+              </div>
+              <%= render 'version', form: form %>
+            <% end %>
+
             <div class="form-wrapper form-wrapper--wide">
               <div class="keyline keyline--left mb-3">
                 <h4><%= t '.publishing_details' %></h4>

--- a/app/views/dashboard/form/publish/edit.html.erb
+++ b/app/views/dashboard/form/publish/edit.html.erb
@@ -48,7 +48,7 @@
                   <h4><%= t '.version' %></h4>
                 </div>
               </div>
-              <%= render 'version', form: form %>
+              <%= render 'open_access_version', form: form %>
             <% end %>
 
             <div class="form-wrapper form-wrapper--wide">

--- a/app/views/dashboard/form/type/_work_version_fields.html.erb
+++ b/app/views/dashboard/form/type/_work_version_fields.html.erb
@@ -4,17 +4,36 @@
   </div>
 </div>
 
-<div class="form-wrapper" data-controller="work-type">
+<div class="form-wrapper"
+  data-controller="work-type"
+  data-work-type-oa-types-value="<%= Work::Types.oa_scholarly_works.to_json %>">
+
   <%= render 'form_fields/text', form: form, attribute: :title, required: true %>
 
   <%= form.fields_for :work do |work_form| %>
     <%= render 'form_fields/select', form: work_form,
                                      attribute: :work_type,
                                      options_for_select: Work::Types.options_for_select_box,
-                                     data: { target: 'work-type.workTypeSelect' },
+                                     data: {
+                                       target: 'work-type.workTypeSelect'
+                                     },
                                      disabled: local_assigns[:work_type_disabled] %>
   <% end %>
 
+  <div class="form-check"
+       id="open-access-help-text"
+       data-target="work-type.openAccess"
+       style="display: none;">
+
+    <%= form.check_box :open_access,
+                       { class: 'form-check-input', id: 'open_access_checkbox', disabled: @resource.open_access && !current_user.admin? },
+                       true,
+                       false %>
+
+    <%= form.label :open_access,
+                   t('dashboard.form.details.open_access_prompt'),
+                   class: 'form-check-label' %>
+  </div>
   <div class="form-text text-muted" id="work-title-help-text" data-target="work-type.helpText" style="display: none;">
     <small><%= t 'dashboard.form.details.instrument_title' %></small>
   </div>

--- a/app/views/dashboard/form/type/_work_version_fields.html.erb
+++ b/app/views/dashboard/form/type/_work_version_fields.html.erb
@@ -20,7 +20,8 @@
                                      disabled: local_assigns[:work_type_disabled] %>
   <% end %>
 
-  <% if ENV['OPEN_ACCESS_FEATURE'] == 'true' %>
+  <!-- Feature Flag: remove once open access pathway is enabled -->
+  <% if ENV['ENABLE_OPEN_ACCESS_FEATURE'] == 'true' %>
     <div class="form-check"
         id="open-access-help-text"
         data-target="work-type.openAccess"

--- a/app/views/dashboard/form/type/_work_version_fields.html.erb
+++ b/app/views/dashboard/form/type/_work_version_fields.html.erb
@@ -20,20 +20,22 @@
                                      disabled: local_assigns[:work_type_disabled] %>
   <% end %>
 
-  <div class="form-check"
-       id="open-access-help-text"
-       data-target="work-type.openAccess"
-       style="display: none;">
+  <% if ENV['OPEN_ACCESS_FEATURE'] == 'true' %>
+    <div class="form-check"
+        id="open-access-help-text"
+        data-target="work-type.openAccess"
+        style="display: none;">
 
-    <%= form.check_box :open_access,
-                       { class: 'form-check-input', id: 'open_access_checkbox', disabled: @resource.open_access && !current_user.admin? },
-                       true,
-                       false %>
+      <%= form.check_box :open_access,
+                         { class: 'form-check-input', id: 'open_access_checkbox', disabled: @resource.open_access && !current_user.admin? },
+                         true,
+                         false %>
 
-    <%= form.label :open_access,
-                   t('dashboard.form.details.open_access_prompt'),
-                   class: 'form-check-label' %>
-  </div>
+      <%= form.label :open_access,
+                     t('dashboard.form.details.open_access_prompt'),
+                     class: 'form-check-label' %>
+    </div>
+  <% end %>
   <div class="form-text text-muted" id="work-title-help-text" data-target="work-type.helpText" style="display: none;">
     <small><%= t 'dashboard.form.details.instrument_title' %></small>
   </div>

--- a/app/views/form_fields/_text_area.html.erb
+++ b/app/views/form_fields/_text_area.html.erb
@@ -9,6 +9,7 @@
                      cols: 40,
                      placeholder: true,
                      required: local_assigns[:required].presence,
+                     readonly: local_assigns[:readonly].presence,
                      aria: { describedby: hint.dom_id, required: local_assigns[:aria_required].presence } %>
   <%= form.label attribute %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -527,6 +527,7 @@ en:
         required_to_publish_metadata: Needed to Publish
         additional_metadata: Optional Metadata
         instrument_title: Use the instrument name as the work title
+        open_access_prompt: Is this an Open Access submission?
         privacy_notice:
           header: Accessible Version Generation Privacy Notice
           description: When your PDF is downloaded for the first time, an accessible version will be created to meet ADA Title II requirements
@@ -578,6 +579,7 @@ en:
           contributors: Contributors
           files: Files
           publishing_details: Publishing Details
+          version: Open Access Version
         curation:
           header: Request Curation (Optional)
           request_description: "Recommended: Select ‘Request Curation’ below to have the ScholarSphere Curation Team review your work ensuring its findability, interoperability, accessibility, and reusability prior to publication. The curatorial review will focus on enhancing metadata quality, recommending improvements for deposit interoperability and reusability, and remediating files as necessary for accessibility. While under review, your work will remain saved as a draft. Once approved by the curator, the work will be published, and if applicable, a DOI will be minted."

--- a/db/migrate/20260428182459_add_open_accessto_work_version.rb
+++ b/db/migrate/20260428182459_add_open_accessto_work_version.rb
@@ -1,0 +1,6 @@
+class AddOpenAccesstoWorkVersion < ActiveRecord::Migration[7.2]
+  def change
+    add_column :work_versions, :open_access, :boolean
+    add_column :work_versions, :open_access_version, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_19_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_28_182459) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -279,6 +279,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_19_120000) do
     t.boolean "accessibility_remediation_requested"
     t.boolean "remediated_version", default: false, null: false
     t.datetime "auto_remediation_started_at"
+    t.boolean "open_access"
+    t.string "open_access_version"
     t.index ["external_app_id"], name: "index_work_versions_on_external_app_id"
     t.index ["work_id", "version_number"], name: "index_work_versions_on_work_id_and_version_number", unique: true
     t.index ["work_id"], name: "index_work_versions_on_work_id"

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -242,6 +242,40 @@ RSpec.describe 'Publishing a work', with_user: :user do
           expect(page).to have_content metadata[:title]
         end
       end
+
+      context 'when the work type is an open access scholarly work', :js do
+        it 'shows the open access checkbox' do
+          visit dashboard_form_work_versions_path
+
+          FeatureHelpers::DashboardForm.fill_in_minimal_work_details_for_scholarly_works_draft(metadata)
+          expect(page).to have_field('open_access_checkbox', type: 'checkbox')
+          check 'open_access_checkbox'
+          FeatureHelpers::DashboardForm.save_and_continue
+          expect(Work.last.versions.last.open_access).to eq true
+        end
+      end
+
+      context 'when the work type is not an open access scholarly work', :js do
+        it 'does not show the open access checkbox' do
+          visit dashboard_form_work_versions_path
+
+          fill_in 'work_version_title', with: metadata[:title]
+          select Work::Types.display('research_paper'), from: 'work_version_work_attributes_work_type'
+          expect(page).to have_no_field('open_access_checkbox', type: 'checkbox')
+        end
+      end
+
+      context 'when the work is already open access', :js do
+        it 'displays the open access checkbox in readonly' do
+          visit dashboard_form_work_versions_path
+
+          FeatureHelpers::DashboardForm.fill_in_minimal_work_details_for_scholarly_works_draft(metadata)
+          check 'open_access_checkbox'
+          FeatureHelpers::DashboardForm.save_and_continue
+          click_on 'Work Type'
+          expect(page).to have_field('open_access_checkbox', type: 'checkbox', disabled: true)
+        end
+      end
     end
 
     context 'when selecting a work type that uses the data and code deposit pathway' do
@@ -2170,6 +2204,58 @@ RSpec.describe 'Publishing a work', with_user: :user do
         click_on 'Confirm'
 
         expect(MintDoiAsync).not_to have_received(:call).with(work_version.work)
+      end
+    end
+  end
+
+  describe 'open access scholarly works', :js do
+    let(:work) { create(:work, work_type: 'article', versions_count: 1, has_draft: true) }
+    let(:work_version) { work.versions.first }
+    let(:user) { work_version.work.depositor.user }
+
+    before { work_version.update(open_access: true) }
+
+    context 'when work type is open access scholarly work' do
+      it 'disables autopopulated fields' do
+        visit dashboard_form_publish_path(work_version)
+        expect(page).to have_field('open_access_checkbox', type: 'checkbox', disabled: true)
+        expect(page).to have_field('work_version_publisher_statement', readonly: true)
+        expect(page).to have_field('work_version_rights', disabled: true)
+        expect(page).to have_field('work_version_work_attributes_embargoed_until', readonly: true)
+        expect(page).to have_field('work_version_open_access_version_accepted')
+        expect(page).to have_field('work_version_open_access_version_published')
+
+        choose 'Accepted Version'
+        click_on 'Save Draft & Exit'
+        expect(work_version.reload.open_access_version).to eq 'accepted'
+      end
+    end
+
+    context 'when user is an admin' do
+      let(:user) { create(:user, :admin) }
+
+      it 'enables autopopulated fields' do
+        visit dashboard_form_publish_path(work_version)
+        expect(page).to have_field('open_access_checkbox', type: 'checkbox')
+        expect(page).to have_field('work_version_publisher_statement')
+        expect(page).to have_field('work_version_rights')
+        expect(page).to have_field('work_version_work_attributes_embargoed_until')
+        expect(page).to have_field('work_version_open_access_version_accepted')
+        expect(page).to have_field('work_version_open_access_version_published')
+      end
+    end
+
+    context 'when the work is not open access' do
+      before { work_version.update(open_access: nil) }
+
+      it 'enables autopopulated fields and does not display open access version' do
+        visit dashboard_form_publish_path(work_version)
+        expect(page).to have_field('open_access_checkbox', type: 'checkbox')
+        expect(page).to have_field('work_version_publisher_statement')
+        expect(page).to have_field('work_version_rights')
+        expect(page).to have_field('work_version_work_attributes_embargoed_until')
+        expect(page).to have_no_field('work_version_open_access_version_accepted')
+        expect(page).to have_no_field('work_version_open_access_version_published')
       end
     end
   end

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -244,6 +244,15 @@ RSpec.describe 'Publishing a work', with_user: :user do
       end
 
       context 'when the work type is an open access scholarly work', :js do
+        before do
+          @original_secret = ENV['ENABLE_OPEN_ACCESS_FEATURE']
+          ENV['ENABLE_OPEN_ACCESS_FEATURE'] = 'true'
+        end
+
+        after do
+          ENV['ENABLE_OPEN_ACCESS_FEATURE'] = @original_secret
+        end
+
         it 'shows the open access checkbox' do
           visit dashboard_form_work_versions_path
 
@@ -256,6 +265,15 @@ RSpec.describe 'Publishing a work', with_user: :user do
       end
 
       context 'when the work type is not an open access scholarly work', :js do
+        before do
+          @original_secret = ENV['ENABLE_OPEN_ACCESS_FEATURE']
+          ENV['ENABLE_OPEN_ACCESS_FEATURE'] = 'true'
+        end
+
+        after do
+          ENV['ENABLE_OPEN_ACCESS_FEATURE'] = @original_secret
+        end
+
         it 'does not show the open access checkbox' do
           visit dashboard_form_work_versions_path
 
@@ -266,6 +284,15 @@ RSpec.describe 'Publishing a work', with_user: :user do
       end
 
       context 'when the work is already open access', :js do
+        before do
+          @original_secret = ENV['ENABLE_OPEN_ACCESS_FEATURE']
+          ENV['ENABLE_OPEN_ACCESS_FEATURE'] = 'true'
+        end
+
+        after do
+          ENV['ENABLE_OPEN_ACCESS_FEATURE'] = @original_secret
+        end
+
         it 'displays the open access checkbox in readonly' do
           visit dashboard_form_work_versions_path
 
@@ -2213,7 +2240,15 @@ RSpec.describe 'Publishing a work', with_user: :user do
     let(:work_version) { work.versions.first }
     let(:user) { work_version.work.depositor.user }
 
-    before { work_version.update(open_access: true) }
+    before do
+      work_version.update(open_access: true)
+      @original_secret = ENV['ENABLE_OPEN_ACCESS_FEATURE']
+      ENV['ENABLE_OPEN_ACCESS_FEATURE'] = 'true'
+    end
+
+    after do
+      ENV['ENABLE_OPEN_ACCESS_FEATURE'] = @original_secret
+    end
 
     context 'when work type is open access scholarly work' do
       it 'disables autopopulated fields' do

--- a/spec/forms/work_deposit_pathway_spec.rb
+++ b/spec/forms/work_deposit_pathway_spec.rb
@@ -15,13 +15,15 @@ RSpec.describe WorkDepositPathway do
       accessibility_remediation_requested: accessibility_remediation_requested,
       doi_blank?: doi_blank,
       work: work,
-      file_version_memberships: [file_version_membership1, file_version_membership2]
+      file_version_memberships: [file_version_membership1, file_version_membership2],
+      open_access: open_access
     )
   }
   let(:type) { nil }
   let(:draft_curation_requested) { false }
   let(:accessibility_remediation_requested) { false }
   let(:doi_blank) { false }
+  let(:open_access) { false }
   let(:file_version_membership1) { instance_double(FileVersionMembership, accessibility_failures?: true) }
   let(:file_version_membership2) { instance_double(FileVersionMembership, accessibility_failures?: false) }
   let(:work) { instance_double(Work) }
@@ -830,7 +832,7 @@ RSpec.describe WorkDepositPathway do
 
       context 'when original type was scholarly work' do
         it 'returns the fields in scholarly work that are not in data and code' do
-          expect(pathway.fields_to_reset(scholarly_work)).to contain_exactly('publisher_statement', 'identifier')
+          expect(pathway.fields_to_reset(scholarly_work)).to contain_exactly('publisher_statement', 'identifier', 'open_access', 'open_access_version')
         end
       end
 
@@ -868,7 +870,8 @@ RSpec.describe WorkDepositPathway do
 
       context 'when original type was scholarly work' do
         it 'returns the fields in scholarly work that are not in grad culminating experience' do
-          expect(pathway.fields_to_reset(scholarly_work)).to contain_exactly('publisher_statement', 'identifier', 'subject', 'publisher', 'subtitle')
+          expect(pathway.fields_to_reset(scholarly_work)).to contain_exactly('publisher_statement', 'identifier', 'subject', 'publisher', 'subtitle',
+                                                                             'open_access', 'open_access_version')
         end
       end
 
@@ -897,7 +900,7 @@ RSpec.describe WorkDepositPathway do
 
       context 'when original type was scholarly work' do
         it 'returns the fields in scholarly work that are not in instrument' do
-          expect(pathway.fields_to_reset(scholarly_work)).to contain_exactly('identifier', 'publisher_statement')
+          expect(pathway.fields_to_reset(scholarly_work)).to contain_exactly('identifier', 'publisher_statement', 'open_access', 'open_access_version')
         end
       end
 
@@ -927,7 +930,7 @@ RSpec.describe WorkDepositPathway do
 
       context 'when original type was scholarly work' do
         it 'returns the fields in scholarly work that are not in general' do
-          expect(pathway.fields_to_reset(scholarly_work)).to eq([])
+          expect(pathway.fields_to_reset(scholarly_work)).to eq(['open_access', 'open_access_version'])
         end
       end
 

--- a/spec/forms/work_deposit_pathways/scholarly_works/details_form_spec.rb
+++ b/spec/forms/work_deposit_pathways/scholarly_works/details_form_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe WorkDepositPathway::ScholarlyWorks::DetailsForm, type: :model do
         related_url
         subject
         language
+        open_access
       }
 
       expect(described_class.form_fields).to be_frozen

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -613,6 +613,8 @@ RSpec.describe Work do
           degree_tesim
           program_tesim
           sub_work_type_tesim
+          open_access_tesim
+          open_access_version_tesim
         )
       end
 


### PR DESCRIPTION
Fixes #1945 

Rather than create a new pathway, I kept it within the scholarly work pathway & just added open access as a boolean to work version to control field visibility. Briana also requested that once something is set to open access, only admins can change that.