### PR TITLE
prevent work versions from re entering Airtable after removal

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -53,12 +53,14 @@ class Work < ApplicationRecord
 
   accepts_nested_attributes_for :versions
 
-  scope :recently_published, -> {
+  scope :send_for_curation_sync, -> {
     joins(:versions)
       .where(work_versions: { aasm_state: 'published' })
       .where(work_versions: { sent_for_curation_at: nil })
+      .where(work_versions: { created_at: 30.days.ago.. })
       .distinct
   }
+
   validate :embargoed_until_is_valid_date
   has_paper_trail versions: :paper_trail_versions
   module Types

--- a/app/services/curation_sync_service.rb
+++ b/app/services/curation_sync_service.rb
@@ -10,7 +10,7 @@ class CurationSyncService
     tasks = CurationTaskClient.find_all(@work.id)
     task_uuids = tasks.pluck('ID')
 
-    if task_uuids.exclude?(current_version_for_curation.uuid) && !admin_submitted?(current_version_for_curation)
+    if able_to_curate(task_uuids)
       CurationTaskClient.send_curation(current_version_for_curation.id, updated_version: updated_version(tasks))
     end
   rescue CurationTaskClient::CurationError => e
@@ -20,6 +20,13 @@ class CurationSyncService
   end
 
   private
+
+    def able_to_curate(task_uuids)
+      task_uuids.exclude?(current_version_for_curation.uuid) &&
+        !admin_submitted?(current_version_for_curation) &&
+        current_version_for_curation.sent_for_curation_at.nil? &&
+        !current_version_for_curation.remediated_version
+    end
 
     def current_version_for_curation
       if @work.latest_version.draft_curation_requested == true

--- a/lib/tasks/curation.rake
+++ b/lib/tasks/curation.rake
@@ -3,7 +3,7 @@
 namespace :curation do
   desc 'Sync curation tasks'
   task sync: :environment do
-    works = Work.recently_published
+    works = Work.send_for_curation_sync
     works.each do |work|
       CurationSyncService.new(work).sync
       sleep(0.5)

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -124,8 +124,8 @@ RSpec.describe Work do
     end
   end
 
-  describe '.recently_published' do
-    let(:wv1) { build(:work_version, :published, work: nil, sent_for_curation_at: nil) }
+  describe '.send_for_curation_sync' do
+    let(:wv1) { build(:work_version, :published, work: nil, sent_for_curation_at: nil, created_at: 1.week.ago) }
     let(:work1) { create(:work, versions: [wv1]) }
 
     let(:wv2) { build(:work_version, :published, work: nil, sent_for_curation_at: Time.now) }
@@ -136,8 +136,11 @@ RSpec.describe Work do
 
     let(:work4) { create(:work) }
 
+    let(:wv5) { build(:work_version, :published, work: nil, sent_for_curation_at: nil, created_at: 1.year.ago) }
+    let(:work5) { create(:work, versions: [wv5]) }
+
     it 'returns works with a published WorkVersion that has not been sent for curation' do
-      expect(described_class.recently_published).to contain_exactly(work1)
+      expect(described_class.send_for_curation_sync).to contain_exactly(work1)
     end
   end
 

--- a/spec/services/curation_sync_service_spec.rb
+++ b/spec/services/curation_sync_service_spec.rb
@@ -101,12 +101,34 @@ RSpec.describe CurationSyncService do
         allow(task1).to receive(:[]).and_return(work_version1.uuid)
       end
 
-      it 'sends current version for curation with Updated Version label' do
-        expect(CurationTaskClient).to receive(:send_curation).with(work_version2.id, updated_version: true)
-        expect(CurationTaskClient).not_to receive(:send_curation).with(work_version1.id)
-        expect(CurationTaskClient).not_to receive(:send_curation).with(work_version3.id)
+      context 'when current version for curation has previously been sent for curation' do
+        it 'does not send for curation' do
+          work_version2.update sent_for_curation_at: Time.now
+          expect(CurationTaskClient).not_to receive(:send_curation).with(work_version2.id)
 
-        described_class.new(work).sync
+          described_class.new(work).sync
+        end
+      end
+
+      context 'when current version for curation has not been sent for curation' do
+        context 'when current version for curation has been remediated' do
+          it 'does not send for curation' do
+            work_version2.update remediated_version: true
+            expect(CurationTaskClient).not_to receive(:send_curation).with(work_version2.id)
+
+            described_class.new(work).sync
+          end
+        end
+
+        context 'when current version for curation has not been remediated' do
+          it 'sends current version for curation with Updated Version label' do
+            expect(CurationTaskClient).to receive(:send_curation).with(work_version2.id, updated_version: true)
+            expect(CurationTaskClient).not_to receive(:send_curation).with(work_version1.id)
+            expect(CurationTaskClient).not_to receive(:send_curation).with(work_version3.id)
+
+            described_class.new(work).sync
+          end
+        end
       end
 
       context 'when the latest work version was created by an admin user' do


### PR DESCRIPTION
Fixes #1953 

I left the scope on Work because ultimately we want to be able to check Airtable for all versions/make new versions as updated version & having it on Work better facilitates that. Instead I added a condition to exclude versions older than 30 days as well as an additional check on the sync service to make sure the version about to be sent has not been curated already.

This also prevents remediated works from being sent to Airtable