### PR TITLE
Use Sidekiq::Job instead of ActiveJob for MetdataListener::Job

### DIFF
--- a/app/jobs/metadata_listener/job.rb
+++ b/app/jobs/metadata_listener/job.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 module MetadataListener
-  class Job < ApplicationJob
+  class Job
+    # MetadataListener is not a Rails app, so do not use
+    # ActiveJob.  Instead, use Sidekiq::Job directly.
+    include Sidekiq::Job
+
     queue_as :metadata
 
     ## Job is performed by metadata-listener

--- a/app/services/update_extracted_text.rb
+++ b/app/services/update_extracted_text.rb
@@ -5,11 +5,11 @@ class UpdateExtractedText
   def self.call(resource:, force: false)
     return if resource.extracted_text.present? && (force != true)
 
-    MetadataListener::Job.perform_later(
-      path: [resource.file_data['storage'], resource.file_data['id']].join('/'),
-      endpoint: FileUploader.api_endpoint(resource),
-      api_token: ExternalApp.metadata_listener.token,
-      services: [:extracted_text]
+    MetadataListener::Job.perform_async(
+      'path' => [resource.file_data['storage'], resource.file_data['id']].join('/'),
+      'endpoint' => FileUploader.api_endpoint(resource),
+      'api_token' => ExternalApp.metadata_listener.token,
+      'services' => ['extracted_text']
     )
   end
 end

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -66,11 +66,11 @@ class FileUploader < Shrine
     # This is dependent on storage bucket policies keeping those cached files for a period of time after they've been
     # uploaded. Currently, this is 24 hours, which should be more than enough time unless the backlog of files becomes
     # large enough that they could wait longer than that.
-    MetadataListener::Job.perform_later(
-      path: [file_data['storage'], file_data['id']].join('/'),
-      endpoint: FileUploader.api_endpoint(record),
-      api_token: ExternalApp.metadata_listener.token,
-      services: [:virus, :extracted_text]
+    MetadataListener::Job.perform_async(
+      'path' => [file_data['storage'], file_data['id']].join('/').to_s,
+      'endpoint' => FileUploader.api_endpoint(record),
+      'api_token' => ExternalApp.metadata_listener.token,
+      'services' => ['virus', 'extracted_text']
     )
   end
 

--- a/spec/models/file_resource_spec.rb
+++ b/spec/models/file_resource_spec.rb
@@ -126,9 +126,9 @@ RSpec.describe FileResource do
     end
 
     it 'initiates a metadata listener job' do
-      allow(MetadataListener::Job).to receive(:perform_later)
+      allow(MetadataListener::Job).to receive(:perform_async)
       file_resource.save
-      expect(MetadataListener::Job).to have_received(:perform_later).with(
+      expect(MetadataListener::Job).to have_received(:perform_async).with(
         path: "#{file_data['storage']}/#{file_data['id']}",
         endpoint: "http://#{Rails.application.routes.default_url_options[:host]}/api/v1/files/#{file_resource.id}",
         api_token: ExternalApp.metadata_listener.token,

--- a/spec/models/file_resource_spec.rb
+++ b/spec/models/file_resource_spec.rb
@@ -129,10 +129,10 @@ RSpec.describe FileResource do
       allow(MetadataListener::Job).to receive(:perform_async)
       file_resource.save
       expect(MetadataListener::Job).to have_received(:perform_async).with(
-        path: "#{file_data['storage']}/#{file_data['id']}",
-        endpoint: "http://#{Rails.application.routes.default_url_options[:host]}/api/v1/files/#{file_resource.id}",
-        api_token: ExternalApp.metadata_listener.token,
-        services: [:virus, :extracted_text]
+        'path' => "#{file_data['storage']}/#{file_data['id']}",
+        'endpoint' => "http://#{Rails.application.routes.default_url_options[:host]}/api/v1/files/#{file_resource.id}",
+        'api_token' => ExternalApp.metadata_listener.token,
+        'services' => ['virus', 'extracted_text']
       )
     end
   end

--- a/spec/services/update_extracted_text_spec.rb
+++ b/spec/services/update_extracted_text_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe UpdateExtractedText do
       expect(resource.extracted_text).not_to be_present
       described_class.call(resource: resource)
       expect(MetadataListener::Job).to have_received(:perform_async).with(
-        path: [resource.file_data['storage'], resource.file_data['id']].join('/'),
-        endpoint: FileUploader.api_endpoint(resource),
-        api_token: ExternalApp.metadata_listener.token,
-        services: [:extracted_text]
+        'path' => [resource.file_data['storage'], resource.file_data['id']].join('/'),
+        'endpoint' => FileUploader.api_endpoint(resource),
+        'api_token' => ExternalApp.metadata_listener.token,
+        'services' => ['extracted_text']
       )
     end
   end
@@ -39,10 +39,10 @@ RSpec.describe UpdateExtractedText do
       expect(resource.extracted_text).to be_present
       described_class.call(resource: resource, force: true)
       expect(MetadataListener::Job).to have_received(:perform_async).with(
-        path: [resource.file_data['storage'], resource.file_data['id']].join('/'),
-        endpoint: FileUploader.api_endpoint(resource),
-        api_token: ExternalApp.metadata_listener.token,
-        services: [:extracted_text]
+        'path' => [resource.file_data['storage'], resource.file_data['id']].join('/'),
+        'endpoint' => FileUploader.api_endpoint(resource),
+        'api_token' => ExternalApp.metadata_listener.token,
+        'services' => ['extracted_text']
       )
     end
   end

--- a/spec/services/update_extracted_text_spec.rb
+++ b/spec/services/update_extracted_text_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe UpdateExtractedText do
   let(:resource) { FactoryBot.build(:file_resource, id: 1) }
 
   before do
-    allow(MetadataListener::Job).to receive(:perform_later)
+    allow(MetadataListener::Job).to receive(:perform_async)
   end
 
   context 'when the file has no extracted text' do
     it 'updates the resource' do
       expect(resource.extracted_text).not_to be_present
       described_class.call(resource: resource)
-      expect(MetadataListener::Job).to have_received(:perform_later).with(
+      expect(MetadataListener::Job).to have_received(:perform_async).with(
         path: [resource.file_data['storage'], resource.file_data['id']].join('/'),
         endpoint: FileUploader.api_endpoint(resource),
         api_token: ExternalApp.metadata_listener.token,
@@ -28,7 +28,7 @@ RSpec.describe UpdateExtractedText do
     it 'does NOT update the resource' do
       expect(resource.extracted_text).to be_present
       described_class.call(resource: resource)
-      expect(MetadataListener::Job).not_to have_received(:perform_later)
+      expect(MetadataListener::Job).not_to have_received(:perform_async)
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe UpdateExtractedText do
     it 'updates the resource' do
       expect(resource.extracted_text).to be_present
       described_class.call(resource: resource, force: true)
-      expect(MetadataListener::Job).to have_received(:perform_later).with(
+      expect(MetadataListener::Job).to have_received(:perform_async).with(
         path: [resource.file_data['storage'], resource.file_data['id']].join('/'),
         endpoint: FileUploader.api_endpoint(resource),
         api_token: ExternalApp.metadata_listener.token,


### PR DESCRIPTION
There appears to be a thing with Sidekiq 8 where it does not allow the `ActiveJob` adapter queue to work with non-Rails apps.  Since metadata-listener is not a Rails app, it was failing to process its Sidekiq jobs.  This PR changes the metadata-listener job to use the base Sidekiq module instead of `ActiveJob`.  This module uses the `perform_async` method instead of `perform_later`.  The changes needed for metadata-listener are here: https://github.com/psu-libraries/metadata-listener/pull/130