### PR TITLE
Fix up header link spacing, search text spacing, and upload workflow text size

### DIFF
--- a/app/components/form_tabs_component.html.erb
+++ b/app/components/form_tabs_component.html.erb
@@ -1,5 +1,5 @@
 <nav>
-  <div class="nav nav-tabs justify-content-between" role="tablist">
+  <div class="nav nav-tabs form-tabs justify-content-between" role="tablist">
     <% tabs.each do |tab| %>
       <%= link_to_unless (!links_enabled || tab.active), tab.label, tab.url, class: tab.classes, data: { action: 'unsaved-changes#prompt' }, role: 'tab' do %>
         <h2 role="tab" class="<%= tab.classes.join(' ') %>"><%= tab.label %></h2>

--- a/app/javascript/frontend/styles/_common.scss
+++ b/app/javascript/frontend/styles/_common.scss
@@ -1463,6 +1463,21 @@ h4,
   }
 }
 
+// Keep dashboard form tabs compact even if global/root sizing shifts.
+.form-tabs {
+  .nav-item {
+    padding: 0.875rem 2rem;
+    font-size: 1rem;
+  }
+
+  @include media-breakpoint-down(md) {
+    .nav-item {
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
+  }
+}
+
 .material-icons {
 
   &--thumbnail {
@@ -1548,6 +1563,35 @@ h4,
         border-width: 1px !important;
       }
     }
+  }
+}
+
+// Keep branding elements separated even if external theme CSS changes.
+.header--nav-branding {
+  .header-mark {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .header-mark--name-slogan {
+    padding-left: 0.5rem;
+  }
+}
+
+.action-bar--results-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.75rem;
+
+  #spell .suggest,
+  .page-links {
+    margin: 0;
+  }
+
+  .search-widgets {
+    margin-left: auto;
   }
 }
 

--- a/app/javascript/frontend/styles/_common.scss
+++ b/app/javascript/frontend/styles/_common.scss
@@ -1466,7 +1466,7 @@ h4,
 // Keep dashboard form tabs compact even if global/root sizing shifts.
 .form-tabs {
   .nav-item {
-    padding: 0.875rem 2rem;
+    padding: .875rem 2rem;
     font-size: 1rem;
   }
 
@@ -1571,11 +1571,11 @@ h4,
   .header-mark {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: .75rem;
   }
 
   .header-mark--name-slogan {
-    padding-left: 0.5rem;
+    padding-left: .5rem;
   }
 }
 
@@ -1583,9 +1583,9 @@ h4,
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 0.75rem;
+  gap: .75rem;
 
-  #spell .suggest,
+  [id='spell'] .suggest,
   .page-links {
     margin: 0;
   }

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -8,7 +8,7 @@
   <%= render 'constraints' %>
 </div>
 
-<div class="action-bar mb-3">
+<div class="action-bar action-bar--results-meta mb-3">
   <%= render 'did_you_mean' %>
   <%= render partial: 'paginate_compact', object: @response if show_pagination? %>
   <%= render_results_collection_tools wrapping_class: 'search-widgets' %>


### PR DESCRIPTION
Issues with text size:
<img width="1223" height="317" alt="Screenshot 2026-06-01 at 2 27 17 PM" src="https://github.com/user-attachments/assets/4c9120d7-7102-4f29-aad9-791bce3c5d5a" />

Header spacing:
<img width="591" height="145" alt="Screenshot 2026-06-01 at 2 14 49 PM" src="https://github.com/user-attachments/assets/dd98b581-603c-48a8-a723-e6c158dec418" />


And the spell check search response:
<img width="703" height="127" alt="Screenshot 2026-06-01 at 2 26 31 PM" src="https://github.com/user-attachments/assets/a7ad2743-70c4-4416-a8c0-b1fd85840b38" />


Fixes:
<img width="1273" height="184" alt="Screenshot 2026-06-01 at 2 29 48 PM" src="https://github.com/user-attachments/assets/6850f6cf-abfd-41bd-ac54-fb99d7382b5c" />
<img width="591" height="169" alt="Screenshot 2026-06-01 at 2 29 44 PM" src="https://github.com/user-attachments/assets/2df01f2a-b91e-40d3-ba7b-c85a0f24fd25" />
<img width="743" height="141" alt="Screenshot 2026-06-01 at 2 29 59 PM" src="https://github.com/user-attachments/assets/6aed6333-4e03-41f7-be09-fc3ff90e5d34" />


