### PR TITLE
Require DOI for open access sub pathway

### DIFF
--- a/app/components/form_error_message_component.rb
+++ b/app/components/form_error_message_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class FormErrorMessageComponent < ApplicationComponent
   attr_reader :resource,
               :heading
@@ -18,7 +19,7 @@ class FormErrorMessageComponent < ApplicationComponent
   end
 
   def errors
-    resource.errors || form.object.errors
+    resource&.errors || @form&.object&.errors
   end
 
   def default_heading

--- a/app/components/form_error_message_component.rb
+++ b/app/components/form_error_message_component.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
-
 class FormErrorMessageComponent < ApplicationComponent
-  attr_reader :form,
+  attr_reader :resource,
               :heading
 
-  def initialize(form:, heading: nil)
+  def initialize(form: nil, resource: nil, heading: nil)
+    @resource = resource
     @form = form
     @heading = heading || default_heading
   end
@@ -18,7 +18,7 @@ class FormErrorMessageComponent < ApplicationComponent
   end
 
   def errors
-    form.object.errors
+    resource.errors || form.object.errors
   end
 
   def default_heading

--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -88,6 +88,7 @@ module Api::V1
             :publisher_statement,
             :doi,
             :open_access,
+            :open_access_version,
             :imported_metadata_from_rmd,
             keyword: [],
             resource_type: [],

--- a/app/controllers/dashboard/form/base_controller.rb
+++ b/app/controllers/dashboard/form/base_controller.rb
@@ -125,9 +125,12 @@ module Dashboard
 
         helper_method :lock_open_access_fields?
         def lock_open_access_fields?
+          param_permissions = JSON.parse(params.dig(:oaw_permissions, :versions_found) || '[]')
+          permissions_found = @permissions&.all_permissions.present? || param_permissions.present?
+
           @resource.open_access &&
             !current_user.admin? &&
-            (@permissions&.all_permissions.present? || params.dig(:oaw_permissions, :versions_found).present?)
+            permissions_found
         end
 
         def save_resource(validation_context: nil)

--- a/app/controllers/dashboard/form/base_controller.rb
+++ b/app/controllers/dashboard/form/base_controller.rb
@@ -123,6 +123,13 @@ module Dashboard
           @deposit_pathway ||= WorkDepositPathway.new(@work_version || @resource)
         end
 
+        helper_method :lock_open_access_fields?
+        def lock_open_access_fields?
+          @resource.open_access &&
+            !current_user.admin? &&
+            (@permissions&.all_permissions.present? || params.dig(:oaw_permissions, :versions_found).present?)
+        end
+
         def save_resource(validation_context: nil)
           @resource.indexing_source = nil # uses the default source
           @resource.update_doi = (publish? || finish? || save_and_exit?)

--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -70,7 +70,7 @@ module Dashboard
 
         # @note Validate the work like we're going to publish it, so we can inform the user ahead of time before they
         # actually attempt it. However, we want to be nice and not yell at them for something they _haven't_ seen yet
-        # like rights.
+        # like rights and open access version.
         def prevalidate
           temporarily_publish @resource do
             @resource.validate
@@ -79,6 +79,7 @@ module Dashboard
               @resource.errors.delete(attribute) if attribute.to_s.include?('work.versions')
             end
             @resource.errors.delete(:rights)
+            @resource.errors.delete(:open_access_version)
           end
         end
 

--- a/app/controllers/dashboard/form/work_version_details_controller.rb
+++ b/app/controllers/dashboard/form/work_version_details_controller.rb
@@ -35,7 +35,7 @@ module Dashboard
           render :edit
         end
       rescue RmdPublication::PublicationNotFound
-        work_version.update imported_metadata_from_rmd: false
+        work_version.update imported_metadata_from_rmd: false, identifier: [autocomplete_work_form_params[:doi]]
         flash[:error] = I18n.t('dashboard.form.notices.autocomplete_unsuccessful')
         render :edit
       end

--- a/app/forms/work_deposit_pathway.rb
+++ b/app/forms/work_deposit_pathway.rb
@@ -321,7 +321,17 @@ class WorkDepositPathway
         end
 
         def show_autocomplete_form?
-          imported_metadata_from_rmd == nil
+          open_access == true && imported_metadata_from_rmd.nil?
+        end
+
+        validate :autocomplete_must_be_completed
+
+        def autocomplete_must_be_completed
+          return unless show_autocomplete_form?
+
+          if imported_metadata_from_rmd.nil?
+            errors.add(:base, I18n.t('dashboard.form.details.autocomplete_required'))
+          end
         end
       end
 

--- a/app/javascript/controllers/open_access_version_controller.js
+++ b/app/javascript/controllers/open_access_version_controller.js
@@ -128,7 +128,7 @@ export default class extends Controller {
     }
 
     // block publish when there is a version mismatch
-    const versionAllowed = version == null || version === '' || currentVersionFound
+    const versionAllowed = version == null || version === '' || currentVersionFound || versionsFound.length === 0
     setTimeout(() => {
       document.dispatchEvent(new CustomEvent('open-access:version-updated', {
         detail: { versionAllowed }

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -170,6 +170,8 @@ class WorkVersion < ApplicationRecord
               in: OpenAccessVersion::VersionValues::ALL
             }
 
+  validate :open_access_version_required, if: :published?
+
   validates :rights,
             presence: true,
             inclusion: {
@@ -467,6 +469,12 @@ class WorkVersion < ApplicationRecord
           open_access_version: open_access_version
         }
       )
+    end
+
+    def open_access_version_required
+      if open_access && OpenAccessVersion::VersionValues::KNOWN.exclude?(open_access_version)
+        errors.add(:open_access_version, :blank)
+      end
     end
 
     def strip_blanks_from_array(arr)

--- a/app/services/open_access_version/version_values.rb
+++ b/app/services/open_access_version/version_values.rb
@@ -7,5 +7,6 @@ module OpenAccessVersion
     UNKNOWN = 'unknownVersion'
 
     ALL = [ACCEPTED, PUBLISHED, UNKNOWN].freeze
+    KNOWN = [ACCEPTED, PUBLISHED].freeze
   end
 end

--- a/app/views/dashboard/form/details/_autocomplete_form.html.erb
+++ b/app/views/dashboard/form/details/_autocomplete_form.html.erb
@@ -1,6 +1,6 @@
 <div class="form-wrapper form-wrapper--wide">
   <div class="keyline keyline--left mb-2">
-    <h4><%= 'Autocomplete for Scholarly Works' %></h4>
+    <h4><%= 'Autocomplete for Open Access Scholarly Works' %></h4>
   </div>
   <div class="form-wrapper mb-3">
     <div>

--- a/app/views/dashboard/form/details/_form.html.erb
+++ b/app/views/dashboard/form/details/_form.html.erb
@@ -1,10 +1,10 @@
+<%= render FormErrorMessageComponent.new(resource: @resource) %>
+
 <% if @resource.show_autocomplete_form? %>
   <%= render 'autocomplete_form' %>
 <% end %>
 
 <%= form_with(model: @resource, url: url, local: true, data: { target: 'unsaved-changes.form' }) do |form| %>
-
-  <%= render FormErrorMessageComponent.new(form: form) %>
 
   <%= render "#{@resource.form_partial}_fields", form: form %>
 

--- a/app/views/dashboard/form/details/_scholarly_works_work_version_fields.html.erb
+++ b/app/views/dashboard/form/details/_scholarly_works_work_version_fields.html.erb
@@ -10,7 +10,7 @@
            form: form,
            attribute: :publisher_statement,
            data: { target: 'open-access-version.publisherStatement' },
-           readonly: @resource.open_access && !current_user.admin? %>
+           readonly: lock_open_access_fields? %>
   <%= render 'form_fields/multi_text', form: form,
                                        attribute: :identifier,
                                        readonly: @resource.imported_metadata_from_rmd? && !current_user.admin? %>

--- a/app/views/dashboard/form/publish/_fields.html.erb
+++ b/app/views/dashboard/form/publish/_fields.html.erb
@@ -1,10 +1,8 @@
 <% open_access = @resource.open_access %>
-<% lock_open_access_fields = open_access && !current_user.admin? %>
 <% selected_rights = open_access ? @permissions&.licence(@resource.open_access_version) : form.object.rights %>
 <% open_access_embargo_end_date = @permissions&.embargo_end_date(@resource.open_access_version) %>
-
 <div class="form-wrapper">
-  <% if lock_open_access_fields %>
+  <% if lock_open_access_fields? %>
     <%= hidden_field_tag 'work_version[rights]', selected_rights, id: 'work_version_rights_hidden' %>
   <% end %>
 
@@ -16,7 +14,7 @@
                selected_rights
              ),
              aria_required: true,
-             disabled: lock_open_access_fields,
+             disabled: lock_open_access_fields?,
              include_blank: true,
              data: { target: 'open-access-version.rights' } %>
 </div>
@@ -43,7 +41,7 @@
                    form: work_form,
                    attribute: :embargoed_until,
                    value: (open_access ? open_access_embargo_end_date : work_form.object.embargoed_until),
-                   readonly: lock_open_access_fields,
+                   readonly: lock_open_access_fields?,
                    data: { target: 'open-access-version.embargo' } %>
       </div>
     <% end %>

--- a/app/views/dashboard/form/publish/_open_access_version.html.erb
+++ b/app/views/dashboard/form/publish/_open_access_version.html.erb
@@ -1,4 +1,6 @@
 <div class="form-wrapper">
+<%= render FieldHintComponent.new(form: form, attribute: :open_access_version) %>
+<br><br>
   <div class="form-check mb-2">
     <%= form.radio_button :open_access_version,
                           OpenAccessVersion::VersionValues::ACCEPTED,

--- a/app/views/dashboard/form/publish/edit.html.erb
+++ b/app/views/dashboard/form/publish/edit.html.erb
@@ -52,7 +52,7 @@
               <%= hidden_field_tag 'oaw_permissions[accepted_version_embargo]', @permissions&.embargo_end_date(accepted_version) %>
               <%= hidden_field_tag 'oaw_permissions[published_version_embargo]', @permissions&.embargo_end_date(published_version) %>
 
-              <%= hidden_field_tag 'oaw_permissions[versions_found]', @permissions&.versions_found? %>
+              <%= hidden_field_tag 'oaw_permissions[versions_found]', @permissions&.versions_found?.to_json %>
 
             <%= render FormErrorMessageComponent.new(
                   form: form,

--- a/app/views/dashboard/form/type/_work_version_fields.html.erb
+++ b/app/views/dashboard/form/type/_work_version_fields.html.erb
@@ -33,8 +33,11 @@
                          false %>
 
       <%= form.label :open_access,
-                     t('dashboard.form.details.open_access_prompt'),
+                     t('dashboard.form.details.open_access_prompt').html_safe,
                      class: 'form-check-label' %>
+        <div class="form-text text-muted">
+          <br><small><%= t('dashboard.form.details.open_access_help_text_html').html_safe %></small>
+        </div>
     </div>
   <% end %>
   <div class="form-text text-muted" id="work-title-help-text" data-target="work-type.helpText" style="display: none;">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,7 +441,7 @@ en:
             heading: Withdraw A Version
         open_access_version:
           permissions_not_found: >
-             We could not find sharing rules for your work. Please contact us for assistance.
+             We could not find sharing rules for your work. Please fill out any missing information.
           other_version_preferred: >
              We could not find sharing rules for the %{this_version} of this work, only the %{other_version}. To upload the %{other_version}, please return to the file upload page and upload your %{other_version} there. If you are sure you want to upload the %{this_version}, please contact us for assistance.
       update:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -524,6 +524,7 @@ en:
                                        You cannot modify the DOI once you have completed a search. If you discover that the DOI is incorrect, please delete the draft and start a new search.
                                        <br/><br/>Please note that if you are working to make your work open per <a href="https://policy.psu.edu/policies/ac02">AC02</a>, we recommend using 
                                        the process available directly within the <a href="https://openaccess.psu.edu/deposit/rmd/">Researcher Metadata Database</a> for deposit when possible.
+        autocomplete_required: You must complete the DOI autocomplete form before continuing.
         about_collections: 
           label: About Collections
           message: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -278,6 +278,9 @@ en:
         manufacturer: Organization or individual that built the instrument.
         rights: The license you select determines how your work can be used by others. [Read more about choosing a license](https://docs.scholarsphere.psu.edu/guides/licenses/)
         contributor: If applicable, please include a brief acknowledgment of any funding sources that supported your research. This helps ensure proper attribution and increases the visibility of your funder’s contribution.
+        open_access_version: >
+          The system has attempted to identify which version of the article you have uploaded. If a version could not be detected, no option will be pre-selected and you will be asked to choose manually. If you believe the detected version is incorrect, you may override it by selecting the appropriate option below. More information about the version options can be found in the <a href="https://psu.libanswers.com/faq/279953">AC02 FAQ</a>.
+          <br/><br/><strong>Please note:</strong> The version you select will be used to look up the publisher’s default sharing policy and complete the publishing details section including license and embargo. Selecting the correct version helps ensure accurate implementation of policy requirements.
       autocomplete_work_form:
         doi: Please enter a valid DOI (e.g. https://doi.org/10.xxxx/xxxxxx or 10.xxxx/xxxxxx)
       actor:
@@ -518,12 +521,7 @@ en:
         autocomplete_unsuccessful: 'We were not able to find and autocomplete the metadata for your work.  Please manually enter your metadata in the following forms to complete your submission.'
       details:
         autocomplete_form:
-          autocomplete_help_text_html: By adding the Digital Object Identifier (DOI) for the article, issued by the Publisher, to this field, we can search the Penn State Researcher Metadata 
-                                       Database and potentially enrich the following metadata fields for your deposit. If the Researcher Metadata Database contains pertinent information about 
-                                       your scholarly work, it will automatically be imported into the fields below. You can choose to retain or modify this imported information. 
-                                       You cannot modify the DOI once you have completed a search. If you discover that the DOI is incorrect, please delete the draft and start a new search.
-                                       <br/><br/>Please note that if you are working to make your work open per <a href="https://policy.psu.edu/policies/ac02">AC02</a>, we recommend using 
-                                       the process available directly within the <a href="https://openaccess.psu.edu/deposit/rmd/">Researcher Metadata Database</a> for deposit when possible.
+          autocomplete_help_text_html: You've indicated this is an open access submission with a publisher-provided DOI. Please submit that DOI here.                        
         autocomplete_required: You must complete the DOI autocomplete form before continuing.
         about_collections: 
           label: About Collections
@@ -534,7 +532,15 @@ en:
         required_to_publish_metadata: Needed to Publish
         additional_metadata: Optional Metadata
         instrument_title: Use the instrument name as the work title
-        open_access_prompt: Is this an Open Access submission?
+        open_access_prompt: I am depositing this work to comply with <a href="https://policy.psu.edu/policies/ac02">Penn State’s Open Access Policy (AC02)</a>, and this work has a publisher-provided DOI.
+        open_access_help_text_html: >
+          Selecting this check box and entering the publisher-provided DOI will initiate the following automated tools on your behalf: 
+          <ol>
+          <li> <strong>Version Check</strong> – The system will attempt to identify which version of the article you have uploaded to determine publisher sharing information.</li>
+          <li> <strong>Publisher Sharing Information</strong> – Using the identified version, the system will attempt to retrieve the publisher’s default sharing policy. It will then notify you regarding your permission to share the uploaded version as well as assign the appropriate license, embargo (if applicable), and publisher statement (if applicable).</li>
+          <li> <strong>Metadata Import</strong> – If information about this scholarly work is available in the <a href="https://researcher.psu.edu/metadata">Penn State Researcher Metadata Database</a>, it will be automatically imported into the appropriate fields. You may retain or edit imported information.</li>
+          </ol>
+          <strong>Please note:</strong> You will not be able to modify the selection of this box or the DOI after completing a search. If you find that either the selection of the DOI is incorrect, please delete the draft deposit and begin a new submission.
         privacy_notice:
           header: Accessible Version Generation Privacy Notice
           description: When your PDF is downloaded for the first time, an accessible version will be created to meet ADA Title II requirements

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -279,7 +279,7 @@ en:
         rights: The license you select determines how your work can be used by others. [Read more about choosing a license](https://docs.scholarsphere.psu.edu/guides/licenses/)
         contributor: If applicable, please include a brief acknowledgment of any funding sources that supported your research. This helps ensure proper attribution and increases the visibility of your funder’s contribution.
         open_access_version: >
-          The system has attempted to identify which version of the article you have uploaded. If a version could not be detected, no option will be pre-selected and you will be asked to choose manually. If you believe the detected version is incorrect, you may override it by selecting the appropriate option below. More information about the version options can be found in the <a href="https://psu.libanswers.com/faq/279953">AC02 FAQ</a>.
+          ScholarSphere attempts to identify which version of the article you have uploaded. If a version could not be detected, no option will be pre-selected and you will need to choose manually. If you believe the detected version is incorrect, you may override it by selecting the appropriate option below. More information about the version options can be found in the <a href="https://psu.libanswers.com/faq/279953">AC02 FAQ</a>.
           <br/><br/><strong>Please note:</strong> The version you select will be used to look up the publisher’s default sharing policy and complete the publishing details section including license and embargo. Selecting the correct version helps ensure accurate implementation of policy requirements.
       autocomplete_work_form:
         doi: Please enter a valid DOI (e.g. https://doi.org/10.xxxx/xxxxxx or 10.xxxx/xxxxxx)

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Api::V1::IngestController do
             rights: metadata[:rights],
             visibility: Permissions::Visibility::OPEN,
             open_access: true,
+            open_access_version: OpenAccessVersion::VersionValues::ACCEPTED,
             imported_metadata_from_rmd: true
           },
           depositor: depositor,

--- a/spec/features/dashboard/autocomplete_work_version_form_spec.rb
+++ b/spec/features/dashboard/autocomplete_work_version_form_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'Autocompleting WorkVersion metadata with data from RMD', :vcr, w
               expect(find_by_id('work_version_creators_attributes_0_display_name').value).to eq 'Anne Example Contributor'
               expect(find_by_id('work_version_creators_attributes_0_given_name').value).to eq 'Anne'
               expect(find_by_id('work_version_creators_attributes_0_surname').value).to eq 'Contributor'
-              expect(find_by_id('work_version_creators_attributes_0_email').value).to eq nil
+              expect(find_by_id('work_version_creators_attributes_0_email').value).to be_blank
               expect(page).to have_content('Unidentified').once
               expect(find_by_id('work_version_creators_attributes_1_display_name').value).to eq 'Joe Fakeman Person'
               expect(find_by_id('work_version_creators_attributes_1_given_name').value).to eq 'Joe'

--- a/spec/features/dashboard/autocomplete_work_version_form_spec.rb
+++ b/spec/features/dashboard/autocomplete_work_version_form_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe 'Autocompleting WorkVersion metadata with data from RMD', :vcr, w
   let(:metadata) { attributes_for(:work_version, :with_complete_metadata) }
 
   describe 'Submitting the Autcomplete For Open Access Works form' do
+    before do
+      @original_secret = ENV['ENABLE_OPEN_ACCESS_FEATURE']
+      ENV['ENABLE_OPEN_ACCESS_FEATURE'] = 'true'
+    end
+
+    after do
+      ENV['ENABLE_OPEN_ACCESS_FEATURE'] = @original_secret
+    end
+
     context 'when work type is not a scholarly work' do
       it 'does not render Autocomplete For Open Access Works form' do
         visit dashboard_form_work_versions_path
@@ -20,13 +29,26 @@ RSpec.describe 'Autocompleting WorkVersion metadata with data from RMD', :vcr, w
       end
     end
 
-    context 'when work type is a scholarly work' do
+    context 'when work type is a scholarly work', :js do
+      context 'when work is not an open access upload' do
+        it 'does not render Autocomplete For Open Access Works form' do
+          visit dashboard_form_work_versions_path
+
+          FeatureHelpers::DashboardForm.fill_in_minimal_work_details_for_scholarly_works_draft(metadata)
+          FeatureHelpers::DashboardForm.save_and_continue
+
+          expect(page).to have_no_content 'Autocomplete for Open Access Works'
+          expect(page).to have_no_css '#autocomplete_work_form_doi'
+        end
+      end
+
       context 'when valid DOI is submitted' do
         context 'when metadata is found' do
           before do
             visit dashboard_form_work_versions_path
 
             FeatureHelpers::DashboardForm.fill_in_minimal_work_details_for_scholarly_works_draft(metadata)
+            check 'open_access_checkbox'
             FeatureHelpers::DashboardForm.save_and_continue
 
             fill_in 'autocomplete_work_form_doi', with: 'https://doi.org/10.1038/abcdefg1234567'
@@ -45,7 +67,7 @@ RSpec.describe 'Autocompleting WorkVersion metadata with data from RMD', :vcr, w
               expect(find_by_id('work_version_publisher').value).to eq 'An Academic Journal'
               expect(find_by_id('work_version_identifier').value).to eq 'https://doi.org/10.1038/abcdefg1234567'
               expect(find_by_id('work_version_identifier').readonly?).to eq true
-              expect(find_by_id('work_version_identifier').find(:xpath, './../..').native.attribute_nodes.first.value).to eq 'mb-2'
+              expect(find_by_id('work_version_identifier').find(:xpath, './../..')[:class]).to eq 'mb-2'
               keywords = find_all('#work_version_keyword')
               expect(keywords[0].value).to eq 'A Topic'
               expect(keywords[1].value).to eq 'Another Topic'
@@ -93,6 +115,7 @@ RSpec.describe 'Autocompleting WorkVersion metadata with data from RMD', :vcr, w
             visit dashboard_form_work_versions_path
 
             FeatureHelpers::DashboardForm.fill_in_minimal_work_details_for_scholarly_works_draft(metadata)
+            check 'open_access_checkbox'
             FeatureHelpers::DashboardForm.save_and_continue
 
             fill_in 'autocomplete_work_form_doi', with: 'https://doi.org/10.1038/abcdefg1234567'
@@ -106,11 +129,12 @@ RSpec.describe 'Autocompleting WorkVersion metadata with data from RMD', :vcr, w
         end
       end
 
-      context 'when invalid DOI is submitted' do
+      context 'when invalid DOI is submitted', :js do
         it 'renders the Work Details page with a flash indicating the DOI is invalid' do
           visit dashboard_form_work_versions_path
 
           FeatureHelpers::DashboardForm.fill_in_minimal_work_details_for_scholarly_works_draft(metadata)
+          check 'open_access_checkbox'
           FeatureHelpers::DashboardForm.save_and_continue
 
           fill_in 'autocomplete_work_form_doi', with: 'abcdefghi123456'

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -2330,7 +2330,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
       context 'when no permissions are found' do
         let(:permissions) { [] }
 
-        it 'displays an error message when a version is selected and blocks publish' do
+        it 'displays no permissions found message and allows publish' do
           visit dashboard_form_publish_path(work_version)
 
           FeatureHelpers::DashboardForm.simulate_open_access_version_broadcast(work_version)
@@ -2338,11 +2338,11 @@ RSpec.describe 'Publishing a work', with_user: :user do
           choose 'Accepted Version'
 
           expect(page).to have_content(I18n.t('dashboard.works.edit.open_access_version.permissions_not_found'))
-          expect(page).to have_field('work_version_publisher_statement', with: nil, readonly: true)
-          expect(page).to have_css("input#work_version_rights_hidden[value='']", visible: :hidden)
-          expect(page).to have_field('work_version_work_attributes_embargoed_until', with: nil, readonly: true)
-          expect(page).to have_no_button('Publish')
-          expect(page).to have_content(I18n.t('dashboard.form.actions.publish.blocked_version'))
+          expect(page).to have_field('work_version_publisher_statement', with: nil)
+          expect(page).to have_no_css("input#work_version_rights_hidden[value='']")
+          expect(page).to have_field('work_version_work_attributes_embargoed_until', with: nil)
+          expect(page).to have_button('Publish')
+          expect(page).to have_no_content(I18n.t('dashboard.form.actions.publish.blocked_version'))
         end
       end
     end

--- a/spec/forms/work_deposit_pathways/scholarly_works/details_form_spec.rb
+++ b/spec/forms/work_deposit_pathways/scholarly_works/details_form_spec.rb
@@ -77,4 +77,30 @@ RSpec.describe WorkDepositPathway::ScholarlyWorks::DetailsForm, type: :model do
       )
     end
   end
+
+  describe 'autocomplete validation' do
+    context 'when the work is an open access upload' do
+      before { wv.open_access = true }
+
+      context 'when the autocomplete form has not been submitted' do
+        it 'is not valid' do
+          expect(form).not_to be_valid
+          expect(form.errors[:base]).to include I18n.t('dashboard.form.details.autocomplete_required')
+        end
+      end
+
+      context 'when the autocomplete form has been submitted' do
+        it 'is valid' do
+          wv.imported_metadata_from_rmd = true
+          expect(form).to be_valid
+        end
+      end
+    end
+
+    context 'when the work is not an open access upload' do
+      it 'is valid' do
+        expect(form).to be_valid
+      end
+    end
+  end
 end

--- a/spec/request/dashboard/form/publish_controller_spec.rb
+++ b/spec/request/dashboard/form/publish_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Dashboard::Form::PublishController, type: :request do
   end
 
   describe 'webhook on publish' do
-    let(:work_version) { create(:work_version, :able_to_be_published, open_access: open_access) }
+    let(:work_version) { create(:work_version, :able_to_be_published, open_access: open_access, open_access_version: OpenAccessVersion::VersionValues::ACCEPTED) }
     let(:open_access) { true }
     let(:user) { work_version.work.depositor.user }
     let(:request_params) do


### PR DESCRIPTION
RMD autocomplete form becomes a centralized doi submission form for the open access subpathway. The RMD form is only applicable to the open access sub pathway anyway so it makes sense to combine functionality for a better user experience. The form will still attempt to pull from RMD, but it will now save doi to identifier regardless of whether the RMD pull is successful. This form will now be required (enforced by a check that `imported_metadata_from_rmd` is not nil, ie the form has been submitted) to ensure any works going through the OA sub pathway have a DOI since auto populating permissions (the main feature of this sub pathway) cannot happen without DOI.

Note - it was a deliberate decision to leave the help text for the oa upload checkbox visible on the publish page because users coming from RMD land on the files tab & won't have seen it yet.

Fixes #1990 and #1984 

Also addresses some small issues in the OA sub pathway:
- allow publishing when no permissions are returned
- make open access upload version required when in OA sub pathway
- upload version help text was breaking when the form returned an error because versionFound was being set as a string instead of JSON