### PR TITLE
Live update open access version

### DIFF
--- a/app/channels/open_access_version_channel.rb
+++ b/app/channels/open_access_version_channel.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class OpenAccessVersionChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from 'open_access_version_channel'
+  end
+end

--- a/app/channels/open_access_version_channel.rb
+++ b/app/channels/open_access_version_channel.rb
@@ -2,6 +2,9 @@
 
 class OpenAccessVersionChannel < ApplicationCable::Channel
   def subscribed
-    stream_from 'open_access_version_channel'
+    work_version = WorkVersion.find_by(id: params[:id])
+    return reject unless work_version
+
+    stream_for work_version
   end
 end

--- a/app/controllers/dashboard/form/files_controller.rb
+++ b/app/controllers/dashboard/form/files_controller.rb
@@ -16,7 +16,9 @@ module Dashboard
         @resource.attributes = work_version_params
         process_response(on_error: :edit) do
           send_accessibility_check_jobs
-          send_open_access_version_guesser_job if @resource.open_access
+          if @resource.open_access
+            send_open_access_version_guesser_job
+          end
         end
       end
 
@@ -43,6 +45,8 @@ module Dashboard
         end
 
         def send_open_access_version_guesser_job
+          @resource.open_access_version = nil
+          @resource.save!
           OpenAccessVersionGuesserJob.perform_later(@resource.id)
         end
     end

--- a/app/controllers/dashboard/form/files_controller.rb
+++ b/app/controllers/dashboard/form/files_controller.rb
@@ -16,9 +16,7 @@ module Dashboard
         @resource.attributes = work_version_params
         process_response(on_error: :edit) do
           send_accessibility_check_jobs
-          if @resource.open_access
-            send_open_access_version_guesser_job
-          end
+          send_open_access_version_guesser_job if @resource.open_access
         end
       end
 

--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -59,7 +59,6 @@ module Dashboard
         end
       end
 
-      # Returns the current open_access_version for the work_version as JSON.
       def open_access_version
         work_version = WorkVersion.find(params[:id])
         authorize(work_version, :edit?)

--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -59,6 +59,14 @@ module Dashboard
         end
       end
 
+      # Returns the current open_access_version for the work_version as JSON.
+      def open_access_version
+        work_version = WorkVersion.find(params[:id])
+        authorize(work_version, :edit?)
+
+        render json: { id: work_version.id, open_access_version: work_version.open_access_version }
+      end
+
       private
 
         # @note Validate the work like we're going to publish it, so we can inform the user ahead of time before they

--- a/app/javascript/controllers/open_access_version_controller.js
+++ b/app/javascript/controllers/open_access_version_controller.js
@@ -54,19 +54,19 @@ export default class extends Controller {
 
   startTimer() {
     setTimeout(() => {
-        const spinnerVisible = this.hasLoadingTarget && !this.loadingTarget.classList.contains('d-none')
-        const controlsHidden = this.hasControlsTarget && this.controlsTarget.classList.contains('d-none')
+      const spinnerVisible = this.hasLoadingTarget && !this.loadingTarget.classList.contains('d-none')
+      const controlsHidden = this.hasControlsTarget && this.controlsTarget.classList.contains('d-none')
 
-        if (spinnerVisible && controlsHidden) {
-          if (this.hasControlsTarget) this.controlsTarget.classList.remove('d-none')
-          if (this.hasLoadingTarget) this.loadingTarget.classList.add('d-none')
-        }
+      if (spinnerVisible && controlsHidden) {
+        if (this.hasControlsTarget) this.controlsTarget.classList.remove('d-none')
+        if (this.hasLoadingTarget) this.loadingTarget.classList.add('d-none')
+      }
 
-        // then unsubscribe from the channel
-        if (this.subscription && this.subscription.unsubscribe) {
-          try { this.subscription.unsubscribe() } catch (e) { void e }
-        }
-      }, 30_000)
+      // then unsubscribe from the channel
+      if (this.subscription && this.subscription.unsubscribe) {
+        try { this.subscription.unsubscribe() } catch (e) { void e }
+      }
+    }, 30_000)
   }
 
   applyOpenAccessVersion(open_access_version) {

--- a/app/javascript/controllers/open_access_version_controller.js
+++ b/app/javascript/controllers/open_access_version_controller.js
@@ -2,7 +2,7 @@ import { Controller } from 'stimulus'
 import consumer from '../channels/consumer'
 
 export default class extends Controller {
-  static targets = ['versionMessage']
+  static targets = ['versionMessage', 'loading', 'controls']
 
   connect() {
     const selectedVersion = this.element.querySelector('input[name="work_version[open_access_version]"]:checked')
@@ -60,6 +60,8 @@ export default class extends Controller {
     if (radio) {
       radio.checked = true
       this.refresh({ target: radio })
+      if (this.hasLoadingTarget) this.loadingTarget.classList.add('d-none')
+      if (this.hasControlsTarget) this.controlsTarget.classList.remove('d-none')
     }
   }
 

--- a/app/javascript/controllers/open_access_version_controller.js
+++ b/app/javascript/controllers/open_access_version_controller.js
@@ -16,21 +16,7 @@ export default class extends Controller {
     if (id) {
       this.createSubscription(id)
       this.fetchOpenAccessVersion(id)
-      this.timer = setTimeout(() => {
-        // Only show timeout message if spinner is still visible and controls are hidden
-        const spinnerVisible = this.hasLoadingTarget && !this.loadingTarget.classList.contains('d-none')
-        const controlsHidden = this.hasControlsTarget && this.controlsTarget.classList.contains('d-none')
-
-        if (spinnerVisible && controlsHidden) {
-          if (this.hasControlsTarget) this.controlsTarget.classList.remove('d-none')
-          if (this.hasLoadingTarget) this.loadingTarget.classList.add('d-none')
-
-          // then unsubscribe from the channel
-          if (this.subscription && this.subscription.unsubscribe) {
-            try { this.subscription.unsubscribe() } catch (e) { void e }
-          }
-        }
-      }, 30_000)
+      this.startTimer()
     }
   }
 
@@ -64,6 +50,23 @@ export default class extends Controller {
         this.applyOpenAccessVersion(data.open_access_version)
       })
       .catch(() => void 0)
+  }
+
+  startTimer() {
+    setTimeout(() => {
+        const spinnerVisible = this.hasLoadingTarget && !this.loadingTarget.classList.contains('d-none')
+        const controlsHidden = this.hasControlsTarget && this.controlsTarget.classList.contains('d-none')
+
+        if (spinnerVisible && controlsHidden) {
+          if (this.hasControlsTarget) this.controlsTarget.classList.remove('d-none')
+          if (this.hasLoadingTarget) this.loadingTarget.classList.add('d-none')
+        }
+
+        // then unsubscribe from the channel
+        if (this.subscription && this.subscription.unsubscribe) {
+          try { this.subscription.unsubscribe() } catch (e) { void e }
+        }
+      }, 30_000)
   }
 
   applyOpenAccessVersion(open_access_version) {

--- a/app/javascript/controllers/open_access_version_controller.js
+++ b/app/javascript/controllers/open_access_version_controller.js
@@ -2,7 +2,7 @@ import { Controller } from 'stimulus'
 import consumer from '../channels/consumer'
 
 export default class extends Controller {
-  static targets = ['versionMessage', 'loading', 'controls', 'timeoutMessage']
+  static targets = ['versionMessage', 'loading', 'controls']
 
   connect() {
     const selectedVersion = this.element.querySelector('input[name="work_version[open_access_version]"]:checked')
@@ -22,9 +22,6 @@ export default class extends Controller {
         const controlsHidden = this.hasControlsTarget && this.controlsTarget.classList.contains('d-none')
 
         if (spinnerVisible && controlsHidden) {
-          if (this.hasTimeoutMessageTarget && this.timeoutMessageTarget.classList.contains('d-none')) {
-            this.timeoutMessageTarget.classList.remove('d-none')
-          }
           if (this.hasControlsTarget) this.controlsTarget.classList.remove('d-none')
           if (this.hasLoadingTarget) this.loadingTarget.classList.add('d-none')
 

--- a/app/javascript/controllers/open_access_version_controller.js
+++ b/app/javascript/controllers/open_access_version_controller.js
@@ -30,7 +30,7 @@ export default class extends Controller {
 
           // then unsubscribe from the channel
           if (this.subscription && this.subscription.unsubscribe) {
-            try { this.subscription.unsubscribe() } catch (e) {}
+            try { this.subscription.unsubscribe() } catch (e) { void e }
           }
         }
       }, 30_000)
@@ -66,7 +66,7 @@ export default class extends Controller {
         if (!data) return
         this.applyOpenAccessVersion(data.open_access_version)
       })
-      .catch(() => {})
+      .catch(() => void 0)
   }
 
   applyOpenAccessVersion(open_access_version) {

--- a/app/javascript/controllers/open_access_version_controller.js
+++ b/app/javascript/controllers/open_access_version_controller.js
@@ -14,10 +14,9 @@ export default class extends Controller {
     const id = this.data.get('id')
 
     if (id) {
+      this.createSubscription(id)
       this.fetchOpenAccessVersion(id)
     }
-
-    this.createSubscription()
   }
 
   disconnect() {
@@ -26,9 +25,9 @@ export default class extends Controller {
     }
   }
 
-  createSubscription() {
+  createSubscription(id) {
     this.subscription = consumer.subscriptions.create(
-      { channel: 'OpenAccessVersionChannel' },
+      { channel: 'OpenAccessVersionChannel', id: id },
       {
         received: (data) => {
           const targetId = this.data.get('id')

--- a/app/javascript/controllers/open_access_version_controller.js
+++ b/app/javascript/controllers/open_access_version_controller.js
@@ -2,7 +2,7 @@ import { Controller } from 'stimulus'
 import consumer from '../channels/consumer'
 
 export default class extends Controller {
-  static targets = ['versionMessage', 'loading', 'controls']
+  static targets = ['versionMessage', 'loading', 'controls', 'timeoutMessage']
 
   connect() {
     const selectedVersion = this.element.querySelector('input[name="work_version[open_access_version]"]:checked')
@@ -17,19 +17,23 @@ export default class extends Controller {
       this.createSubscription(id)
       this.fetchOpenAccessVersion(id)
       this.timer = setTimeout(() => {
-        // if controls still hidden, reveal them and hide the loading spinner
-        if (this.hasControlsTarget && this.controlsTarget.classList.contains('d-none')) {
-          this.controlsTarget.classList.remove('d-none')
-        }
-        if (this.hasLoadingTarget && !this.loadingTarget.classList.contains('d-none')) {
-          this.loadingTarget.classList.add('d-none')
-        }
+        // Only show timeout message if spinner is still visible and controls are hidden
+        const spinnerVisible = this.hasLoadingTarget && !this.loadingTarget.classList.contains('d-none')
+        const controlsHidden = this.hasControlsTarget && this.controlsTarget.classList.contains('d-none')
 
-        // then unsubscribe from the channel
-        if (this.subscription && this.subscription.unsubscribe) {
-          try { this.subscription.unsubscribe() } catch (e) {}
+        if (spinnerVisible && controlsHidden) {
+          if (this.hasTimeoutMessageTarget && this.timeoutMessageTarget.classList.contains('d-none')) {
+            this.timeoutMessageTarget.classList.remove('d-none')
+          }
+          if (this.hasControlsTarget) this.controlsTarget.classList.remove('d-none')
+          if (this.hasLoadingTarget) this.loadingTarget.classList.add('d-none')
+
+          // then unsubscribe from the channel
+          if (this.subscription && this.subscription.unsubscribe) {
+            try { this.subscription.unsubscribe() } catch (e) {}
+          }
         }
-      }, 60_000)
+      }, 30_000)
     }
   }
 

--- a/app/javascript/controllers/open_access_version_controller.js
+++ b/app/javascript/controllers/open_access_version_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from 'stimulus'
+import consumer from '../channels/consumer'
 
 export default class extends Controller {
   static targets = ['versionMessage']
@@ -7,6 +8,49 @@ export default class extends Controller {
     const selectedVersion = this.element.querySelector('input[name="work_version[open_access_version]"]:checked')
     if (selectedVersion) {
       this.refresh({ target: selectedVersion })
+    }
+    const id = this.data.get('id')
+    if (id) {
+      fetch(`/dashboard/form/work_versions/${id}/open_access_version`, { headers: { Accept: 'application/json' } })
+        .then((response) => {
+          if (!response.ok) throw new Error('Network response was not ok')
+          return response.json()
+        })
+        .then((data) => {
+          if (!data || !data.open_access_version) return
+          const radio = this.element.querySelector(
+            `input[name="work_version[open_access_version]"][value="${data.open_access_version}"]`
+          )
+          if (radio) {
+            radio.checked = true
+            this.refresh({ target: radio })
+          }
+        })
+        .catch(() => {})
+    }
+    this.subscription = consumer.subscriptions.create(
+      { channel: 'OpenAccessVersionChannel' },
+      {
+        received: (data) => {
+          const targetId = this.data.get('id')
+          if (String(data.id) !== String(targetId)) return
+
+          const radio = this.element.querySelector(
+            `input[name="work_version[open_access_version]"][value="${data.open_access_version}"]`
+          )
+
+          if (radio) {
+            radio.checked = true
+            this.refresh({ target: radio })
+          }
+        }
+      }
+    )
+  }
+
+  disconnect() {
+    if (this.subscription && this.subscription.unsubscribe) {
+      this.subscription.unsubscribe()
     }
   }
 

--- a/app/javascript/controllers/open_access_version_controller.js
+++ b/app/javascript/controllers/open_access_version_controller.js
@@ -31,8 +31,7 @@ export default class extends Controller {
       { channel: 'OpenAccessVersionChannel', id: id },
       {
         received: (data) => {
-          const targetId = this.data.get('id')
-          if (String(data.id) !== String(targetId)) return
+          if (String(data.id) !== String(id)) return
           this.applyOpenAccessVersion(data.open_access_version)
         }
       }

--- a/app/javascript/controllers/open_access_version_controller.js
+++ b/app/javascript/controllers/open_access_version_controller.js
@@ -16,6 +16,20 @@ export default class extends Controller {
     if (id) {
       this.createSubscription(id)
       this.fetchOpenAccessVersion(id)
+      this.timer = setTimeout(() => {
+        // if controls still hidden, reveal them and hide the loading spinner
+        if (this.hasControlsTarget && this.controlsTarget.classList.contains('d-none')) {
+          this.controlsTarget.classList.remove('d-none')
+        }
+        if (this.hasLoadingTarget && !this.loadingTarget.classList.contains('d-none')) {
+          this.loadingTarget.classList.add('d-none')
+        }
+
+        // then unsubscribe from the channel
+        if (this.subscription && this.subscription.unsubscribe) {
+          try { this.subscription.unsubscribe() } catch (e) {}
+        }
+      }, 60_000)
     }
   }
 

--- a/app/javascript/controllers/open_access_version_controller.js
+++ b/app/javascript/controllers/open_access_version_controller.js
@@ -6,51 +6,60 @@ export default class extends Controller {
 
   connect() {
     const selectedVersion = this.element.querySelector('input[name="work_version[open_access_version]"]:checked')
+
     if (selectedVersion) {
       this.refresh({ target: selectedVersion })
     }
+
     const id = this.data.get('id')
+
     if (id) {
-      fetch(`/dashboard/form/work_versions/${id}/open_access_version`, { headers: { Accept: 'application/json' } })
-        .then((response) => {
-          if (!response.ok) throw new Error('Network response was not ok')
-          return response.json()
-        })
-        .then((data) => {
-          if (!data || !data.open_access_version) return
-          const radio = this.element.querySelector(
-            `input[name="work_version[open_access_version]"][value="${data.open_access_version}"]`
-          )
-          if (radio) {
-            radio.checked = true
-            this.refresh({ target: radio })
-          }
-        })
-        .catch(() => {})
+      this.fetchOpenAccessVersion(id)
     }
+
+    this.createSubscription()
+  }
+
+  disconnect() {
+    if (this.subscription && this.subscription.unsubscribe) {
+      this.subscription.unsubscribe()
+    }
+  }
+
+  createSubscription() {
     this.subscription = consumer.subscriptions.create(
       { channel: 'OpenAccessVersionChannel' },
       {
         received: (data) => {
           const targetId = this.data.get('id')
           if (String(data.id) !== String(targetId)) return
-
-          const radio = this.element.querySelector(
-            `input[name="work_version[open_access_version]"][value="${data.open_access_version}"]`
-          )
-
-          if (radio) {
-            radio.checked = true
-            this.refresh({ target: radio })
-          }
+          this.applyOpenAccessVersion(data.open_access_version)
         }
       }
     )
   }
 
-  disconnect() {
-    if (this.subscription && this.subscription.unsubscribe) {
-      this.subscription.unsubscribe()
+  fetchOpenAccessVersion(id) {
+    fetch(`/dashboard/form/work_versions/${id}/open_access_version`, { headers: { Accept: 'application/json' } })
+      .then((response) => {
+        if (!response.ok) throw new Error('Network response was not ok')
+        return response.json()
+      })
+      .then((data) => {
+        if (!data) return
+        this.applyOpenAccessVersion(data.open_access_version)
+      })
+      .catch(() => {})
+  }
+
+  applyOpenAccessVersion(open_access_version) {
+    if (!open_access_version) return
+    const radio = this.element.querySelector(
+      `input[name="work_version[open_access_version]"][value="${open_access_version}"]`
+    )
+    if (radio) {
+      radio.checked = true
+      this.refresh({ target: radio })
     }
   }
 

--- a/app/javascript/controllers/open_access_version_controller.js
+++ b/app/javascript/controllers/open_access_version_controller.js
@@ -61,7 +61,6 @@ export default class extends Controller {
         if (this.hasLoadingTarget) this.loadingTarget.classList.add('d-none')
       }
 
-      // then unsubscribe from the channel
       if (this.subscription && this.subscription.unsubscribe) {
         try { this.subscription.unsubscribe() } catch (e) { void e }
       }

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -460,8 +460,8 @@ class WorkVersion < ApplicationRecord
     def broadcast_open_access_version_if_needed
       return unless saved_change_to_open_access_version?
 
-      ActionCable.server.broadcast(
-        'open_access_version_channel',
+      OpenAccessVersionChannel.broadcast_to(
+        self,
         {
           id: id,
           open_access_version: open_access_version

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -211,6 +211,7 @@ class WorkVersion < ApplicationRecord
   validates_with ChangedWorkVersionValidator,
                  if: :published?
 
+  after_update :broadcast_open_access_version_if_needed
   after_commit :perform_update_index, on: [:create, :update]
   after_commit :enqueue_published_webhook, on: [:create, :update]
   after_rollback :clear_publish_flag
@@ -454,6 +455,18 @@ class WorkVersion < ApplicationRecord
 
     def clear_publish_flag
       @work_just_published = false
+    end
+
+    def broadcast_open_access_version_if_needed
+      return unless saved_change_to_open_access_version?
+
+      ActionCable.server.broadcast(
+        'open_access_version_channel',
+        {
+          id: id,
+          open_access_version: open_access_version
+        }
+      )
     end
 
     def strip_blanks_from_array(arr)

--- a/app/services/open_access_version/guesser.rb
+++ b/app/services/open_access_version/guesser.rb
@@ -70,6 +70,8 @@ module OpenAccessVersion
       def contains_arxiv_watermark?(pdf_reader)
         uri = pdf_reader&.objects&.[](8)&.[](:A)&.[](:URI)
         uri&.include?('arxiv.org')
+      rescue StandardError
+        false
       end
 
       def detected_filename(file_resource)

--- a/app/views/dashboard/form/publish/_open_access_version.html.erb
+++ b/app/views/dashboard/form/publish/_open_access_version.html.erb
@@ -4,10 +4,6 @@
     <span><%= t('dashboard.form.publish.edit.determining_open_access_version') %></span>
   </div>
 
-  <p data-target="open-access-version.timeoutMessage" class="form-text text-muted d-none mb-4">
-    <%= I18n.t('dashboard.form.publish.edit.open_access_version_not_determined', default: 'A version could not be determined; please select a version below.') %>
-  </p>
-
   <div data-target="open-access-version.controls" class="d-none">
     <div class="form-check mb-2">
     <%= form.radio_button :open_access_version,

--- a/app/views/dashboard/form/publish/_open_access_version.html.erb
+++ b/app/views/dashboard/form/publish/_open_access_version.html.erb
@@ -4,6 +4,10 @@
     <span><%= t('dashboard.form.publish.edit.determining_open_access_version') %></span>
   </div>
 
+  <p data-target="open-access-version.timeoutMessage" class="form-text text-muted d-none mb-4">
+    <%= I18n.t('dashboard.form.publish.edit.open_access_version_not_determined', default: 'A version could not be determined; please select a version below.') %>
+  </p>
+
   <div data-target="open-access-version.controls" class="d-none">
     <div class="form-check mb-2">
     <%= form.radio_button :open_access_version,

--- a/app/views/dashboard/form/publish/_open_access_version.html.erb
+++ b/app/views/dashboard/form/publish/_open_access_version.html.erb
@@ -1,5 +1,11 @@
 <div class="form-wrapper">
-  <div class="form-check mb-2">
+  <div data-target="open-access-version.loading" class="d-flex align-items-center mb-2">
+    <div class="spinner-border me-2 pb-2" role="status" aria-hidden="true"></div>
+    <span><%= t('dashboard.publish.edit.determining_open_access_version') %></span>
+  </div>
+
+  <div data-target="open-access-version.controls" class="d-none">
+    <div class="form-check mb-2">
     <%= form.radio_button :open_access_version,
                           OpenAccessVersion::VersionValues::ACCEPTED,
                           class: 'form-check-input',
@@ -8,16 +14,16 @@
                    value: OpenAccessVersion::VersionValues::ACCEPTED,
                    class: 'form-check-label' %>
   </div>
+    <div class="form-check mb-2">
+      <%= form.radio_button :open_access_version,
+                            OpenAccessVersion::VersionValues::PUBLISHED,
+                            class: 'form-check-input',
+                            data: { action: 'change->open-access-version#refresh' } %>
+      <%= form.label :open_access_version, 'Published Version',
+                     value: OpenAccessVersion::VersionValues::PUBLISHED,
+                     class: 'form-check-label' %>
+    </div>
 
-  <div class="form-check mb-2">
-    <%= form.radio_button :open_access_version,
-                          OpenAccessVersion::VersionValues::PUBLISHED,
-                          class: 'form-check-input',
-                          data: { action: 'change->open-access-version#refresh' } %>
-    <%= form.label :open_access_version, 'Published Version',
-                   value: OpenAccessVersion::VersionValues::PUBLISHED,
-                   class: 'form-check-label' %>
+    <span data-target="open-access-version.versionMessage" class="text-danger"></span>
   </div>
-
-  <span data-target="open-access-version.versionMessage" class="text-danger"></span>
 </div>

--- a/app/views/dashboard/form/publish/_open_access_version.html.erb
+++ b/app/views/dashboard/form/publish/_open_access_version.html.erb
@@ -1,7 +1,7 @@
 <div class="form-wrapper">
   <div data-target="open-access-version.loading" class="d-flex align-items-center mb-2">
-    <div class="spinner-border me-2 pb-2" role="status" aria-hidden="true"></div>
-    <span><%= t('dashboard.publish.edit.determining_open_access_version') %></span>
+    <div class="spinner-border m-4" role="status" aria-hidden="true"></div>
+    <span><%= t('dashboard.form.publish.edit.determining_open_access_version') %></span>
   </div>
 
   <div data-target="open-access-version.controls" class="d-none">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -586,6 +586,7 @@ en:
           files: Files
           publishing_details: Publishing Details
           version: Open Access Version
+          determining_open_access_version: "Determining open access version…"
         curation:
           header: Request Curation (Optional)
           request_description: "Recommended: Select ‘Request Curation’ below to have the ScholarSphere Curation Team review your work ensuring its findability, interoperability, accessibility, and reusability prior to publication. The curatorial review will focus on enhancing metadata quality, recommending improvements for deposit interoperability and reusability, and remediating files as necessary for accessibility. While under review, your work will remain saved as a draft. Once approved by the curator, the work will be published, and if applicable, a DOI will be minted."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,6 +133,7 @@ Rails.application.routes.draw do
         match ':id/files', to: 'files#update', via: %i[patch put], as: nil
 
         get   ':id/publish', to: 'publish#edit', as: 'publish'
+        get   ':id/open_access_version', to: 'publish#open_access_version'
         match ':id/publish', to: 'publish#update', via: %i[patch put], as: nil
 
         post ':id/autocomplete_work_forms', to: 'work_version_details#autocomplete_work_forms', as: 'autocomplete_work'

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -2280,6 +2280,10 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(page).to have_field('work_version_publisher_statement', readonly: true)
         expect(page).to have_field('work_version_rights', disabled: true)
         expect(page).to have_field('work_version_work_attributes_embargoed_until', readonly: true)
+        expect(page).to have_content(I18n.t('dashboard.form.publish.edit.determining_open_access_version'))
+
+        FeatureHelpers::DashboardForm.simulate_open_access_version_broadcast(work_version)
+
         expect(page).to have_field('work_version_open_access_version_acceptedversion')
         expect(page).to have_field('work_version_open_access_version_publishedversion')
         choose 'Published Version'
@@ -2314,6 +2318,8 @@ RSpec.describe 'Publishing a work', with_user: :user do
         it 'displays an error message when the other version is selected and blocks publish' do
           visit dashboard_form_publish_path(work_version)
 
+          FeatureHelpers::DashboardForm.simulate_open_access_version_broadcast(work_version)
+
           choose 'Accepted Version'
 
           expect(page).to have_content(I18n.t('dashboard.works.edit.open_access_version.other_version_preferred', this_version: 'accepted version', other_version: 'published version'))
@@ -2330,6 +2336,8 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         it 'displays an error message when a version is selected and blocks publish' do
           visit dashboard_form_publish_path(work_version)
+
+          FeatureHelpers::DashboardForm.simulate_open_access_version_broadcast(work_version)
 
           choose 'Accepted Version'
 
@@ -2348,6 +2356,9 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
       it 'enables autopopulated fields' do
         visit dashboard_form_publish_path(work_version)
+
+        FeatureHelpers::DashboardForm.simulate_open_access_version_broadcast(work_version)
+
         expect(page).to have_field('open_access_checkbox', type: 'checkbox')
         expect(page).to have_field('work_version_publisher_statement')
         expect(page).to have_field('work_version_rights')

--- a/spec/javascript/open_access_version_controller.test.js
+++ b/spec/javascript/open_access_version_controller.test.js
@@ -1,0 +1,176 @@
+import { Application } from 'stimulus'
+import OpenAccessVersionController from 'open_access_version_controller'
+
+let subscriptionCallbacks
+const mockUnsubscribe = jest.fn()
+
+jest.mock('../../app/javascript/channels/consumer', () => ({
+  __esModule: true,
+  default: {
+    subscriptions: {
+      create: jest.fn((_params, callbacks) => {
+        subscriptionCallbacks = callbacks
+        return { unsubscribe: mockUnsubscribe }
+      })
+    }
+  }
+}))
+
+describe('OpenAccessVersionController', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    mockUnsubscribe.mockClear()
+    subscriptionCallbacks = undefined
+
+    document.body.innerHTML = `
+      <div
+        class="tab-pane active show"
+        data-controller="open-access-version"
+        data-open-access-version-id="123"
+        data-open-access-version-accepted-version-value="acceptedVersion"
+        data-open-access-version-published-version-value="publishedVersion"
+        data-open-access-version-accepted-version-label="accepted version"
+        data-open-access-version-published-version-label="published version"
+        data-open-access-version-accepted-version-rights="CC BY"
+        data-open-access-version-published-version-rights=""
+        data-open-access-version-accepted-version-statement="Publisher statement"
+        data-open-access-version-published-version-statement=""
+        data-open-access-version-accepted-version-embargo="2026-01-01"
+        data-open-access-version-published-version-embargo=""
+        data-open-access-version-versions-found='["acceptedVersion"]'
+        data-open-access-version-not-found-message="Not found"
+        data-open-access-version-other-message="We found __OTHER__, not __THIS__"
+      >
+        <div class="form-wrapper">
+          <div data-target="open-access-version.loading" class="d-flex align-items-center mb-2">
+            <div class="spinner-border m-4" role="status" aria-hidden="true"></div>
+            <span>Determining open access version</span>
+          </div>
+
+          <div data-target="open-access-version.controls" class="d-none">
+            <div class="form-check mb-2">
+              <input
+                class="form-check-input"
+                type="radio"
+                name="work_version[open_access_version]"
+                value="acceptedVersion"
+                checked
+                data-action="change->open-access-version#refresh"
+              >
+              <label class="form-check-label">Accepted Version</label>
+            </div>
+
+            <div class="form-check mb-2">
+              <input
+                class="form-check-input"
+                type="radio"
+                name="work_version[open_access_version]"
+                value="publishedVersion"
+                data-action="change->open-access-version#refresh"
+              >
+              <label class="form-check-label">Published Version</label>
+            </div>
+
+            <span data-target="open-access-version.versionMessage" class="text-danger"></span>
+          </div>
+        </div>
+      </div>
+
+      <input id="work_version_publisher_statement">
+      <input id="work_version_work_attributes_embargoed_until">
+      <input id="work_version_rights_hidden">
+      <select id="work_version_rights">
+        <option value="CC BY">CC BY</option>
+      </select>
+    `
+
+    globalThis.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ open_access_version: 'publishedVersion' })
+      })
+    )
+
+    const application = Application.start()
+    application.register('open-access-version', OpenAccessVersionController)
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+  })
+
+  it('autofills fields based on the selected version on connect', () => {
+    const radio = document.querySelector('input[value="acceptedVersion"]')
+    radio.dispatchEvent(new Event('change', { bubbles: true }))
+
+    expect(document.getElementById('work_version_rights').value).toBe('CC BY')
+    expect(document.getElementById('work_version_rights_hidden').value).toBe('CC BY')
+    expect(document.getElementById('work_version_publisher_statement').value).toBe('Publisher statement')
+    expect(document.getElementById('work_version_work_attributes_embargoed_until').value).toBe('2026-01-01')
+  })
+
+  it('shows the version mismatch message when only the other version is found', () => {
+    const radio = document.querySelector('input[value="publishedVersion"]')
+    radio.checked = true
+    radio.dispatchEvent(new Event('change', { bubbles: true }))
+
+    jest.runOnlyPendingTimers()
+
+    const message = document.querySelector('[data-target="open-access-version.versionMessage"]')
+    expect(message.textContent).toBe('We found accepted version, not published version')
+  })
+
+  it('dispatches open-access:version-updated with versionAllowed', () => {
+    const handler = jest.fn()
+    document.addEventListener('open-access:version-updated', handler)
+
+    const radio = document.querySelector('input[value="acceptedVersion"]')
+    radio.checked = true
+    radio.dispatchEvent(new Event('change', { bubbles: true }))
+
+    jest.runOnlyPendingTimers()
+
+    expect(handler).toHaveBeenCalled()
+    expect(handler.mock.calls[0][0].detail).toEqual({ versionAllowed: true })
+  })
+
+  it('applies the open access version from the channel', () => {
+    expect(subscriptionCallbacks).toBeDefined()
+
+    subscriptionCallbacks.received({ id: '123', open_access_version: 'publishedVersion' })
+
+    const published = document.querySelector('input[value="publishedVersion"]')
+    expect(published.checked).toBe(true)
+  })
+
+  it('ignores channel updates for a different id', () => {
+    const published = document.querySelector('input[value="publishedVersion"]')
+    // ensure it's not already checked
+    published.checked = false
+    expect(published.checked).toBe(false)
+
+    subscriptionCallbacks.received({ id: '999', open_access_version: 'publishedVersion' })
+
+    expect(published.checked).toBe(false)
+  })
+
+  it('falls back to show controls and unsubscribe after 30s', () => {
+    const loading = document.querySelector('[data-target="open-access-version.loading"]')
+    const controls = document.querySelector('[data-target="open-access-version.controls"]')
+    loading.classList.remove('d-none')
+    controls.classList.add('d-none')
+
+    jest.advanceTimersByTime(30_000)
+
+    expect(controls.classList.contains('d-none')).toBe(false)
+    expect(loading.classList.contains('d-none')).toBe(true)
+    expect(mockUnsubscribe).toHaveBeenCalled()
+  })
+
+  it('fetches open access version and applies it', async () => {
+    await Promise.resolve()
+    const published = document.querySelector('input[value="publishedVersion"]')
+    expect(published.checked).toBe(true)
+  })
+})

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -183,6 +183,56 @@ RSpec.describe WorkVersion do
     end
   end
 
+  describe 'open access version broadcast' do
+    let(:cable_server) { instance_double(ActionCable::Server::Base, broadcast: true) }
+
+    before { allow(ActionCable).to receive(:server).and_return(cable_server) }
+
+    context 'when open_access_version is changed from nil' do
+      let(:work_version) { create(:work_version, open_access_version: nil) }
+
+      it 'broadcasts when open_access_version is changed to non-nil value' do
+        work_version.update!(open_access_version: OpenAccessVersion::VersionValues::PUBLISHED)
+
+        expect(cable_server).to have_received(:broadcast).with(
+          'open_access_version_channel',
+          {
+            id: work_version.id,
+            open_access_version: OpenAccessVersion::VersionValues::PUBLISHED
+          }
+        )
+      end
+
+      it 'does not broadcast when open_access_version is changed to nil' do
+        work_version.update!(open_access_version: nil)
+
+        expect(cable_server).not_to have_received(:broadcast)
+      end
+    end
+
+    context 'when open_access_version is changed from a non-nil value' do
+      let(:work_version) { create(:work_version, open_access_version: OpenAccessVersion::VersionValues::PUBLISHED) }
+
+      it 'does not broadcast when open_access_version is not changed' do
+        work_version.update!(title: 'a title change that does not affect open access version')
+
+        expect(cable_server).not_to have_received(:broadcast)
+      end
+
+      it 'broadcasts when open_access_version is updated to a different non-nil value' do
+        work_version.update!(open_access_version: OpenAccessVersion::VersionValues::ACCEPTED)
+
+        expect(cable_server).to have_received(:broadcast).with(
+          'open_access_version_channel',
+          {
+            id: work_version.id,
+            open_access_version: OpenAccessVersion::VersionValues::ACCEPTED
+          }
+        )
+      end
+    end
+  end
+
   describe 'validations' do
     subject(:work_version) { build(:work_version, work: work) }
 

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -184,9 +184,7 @@ RSpec.describe WorkVersion do
   end
 
   describe 'open access version broadcast' do
-    let(:cable_server) { instance_double(ActionCable::Server::Base, broadcast: true) }
-
-    before { allow(ActionCable).to receive(:server).and_return(cable_server) }
+    before { allow(OpenAccessVersionChannel).to receive(:broadcast_to) }
 
     context 'when open_access_version is changed from nil' do
       let(:work_version) { create(:work_version, open_access_version: nil) }
@@ -194,8 +192,8 @@ RSpec.describe WorkVersion do
       it 'broadcasts when open_access_version is changed to non-nil value' do
         work_version.update!(open_access_version: OpenAccessVersion::VersionValues::PUBLISHED)
 
-        expect(cable_server).to have_received(:broadcast).with(
-          'open_access_version_channel',
+        expect(OpenAccessVersionChannel).to have_received(:broadcast_to).with(
+          work_version,
           {
             id: work_version.id,
             open_access_version: OpenAccessVersion::VersionValues::PUBLISHED
@@ -206,7 +204,7 @@ RSpec.describe WorkVersion do
       it 'does not broadcast when open_access_version is changed to nil' do
         work_version.update!(open_access_version: nil)
 
-        expect(cable_server).not_to have_received(:broadcast)
+        expect(OpenAccessVersionChannel).not_to have_received(:broadcast_to)
       end
     end
 
@@ -216,14 +214,14 @@ RSpec.describe WorkVersion do
       it 'does not broadcast when open_access_version is not changed' do
         work_version.update!(title: 'a title change that does not affect open access version')
 
-        expect(cable_server).not_to have_received(:broadcast)
+        expect(OpenAccessVersionChannel).not_to have_received(:broadcast_to)
       end
 
       it 'broadcasts when open_access_version is updated to a different non-nil value' do
         work_version.update!(open_access_version: OpenAccessVersion::VersionValues::ACCEPTED)
 
-        expect(cable_server).to have_received(:broadcast).with(
-          'open_access_version_channel',
+        expect(OpenAccessVersionChannel).to have_received(:broadcast_to).with(
+          work_version,
           {
             id: work_version.id,
             open_access_version: OpenAccessVersion::VersionValues::ACCEPTED

--- a/spec/request/dashboard/form/files_controller_spec.rb
+++ b/spec/request/dashboard/form/files_controller_spec.rb
@@ -4,7 +4,14 @@ require 'rails_helper'
 
 RSpec.describe Dashboard::Form::FilesController, type: :request do
   describe 'PATCH /dashboard/form/work_versions/:id/files' do
-    let(:work_version) { create(:work_version, :draft, open_access: open_access) }
+    let(:work_version) do
+      create(
+        :work_version,
+        :draft,
+        open_access: open_access,
+        open_access_version: OpenAccessVersion::VersionValues::ACCEPTED
+      )
+    end
     let(:user) { work_version.depositor.user }
     let(:open_access) { true }
     let(:request_params) { { work_version: { id: work_version.id } } }
@@ -17,12 +24,13 @@ RSpec.describe Dashboard::Form::FilesController, type: :request do
     context 'when open access is enabled' do
       let(:open_access) { true }
 
-      it 'enqueues open access version guessing' do
+      it 'enqueues open access version guessing and resets open_access_version' do
         patch dashboard_form_files_path(work_version), params: request_params
 
         expect(response).to have_http_status(:redirect)
         expect(response).to redirect_to(dashboard_form_publish_path(work_version))
         expect(OpenAccessVersionGuesserJob).to have_received(:perform_later).with(work_version.id)
+        expect(work_version.reload.open_access_version).to be_nil
       end
     end
 
@@ -35,6 +43,7 @@ RSpec.describe Dashboard::Form::FilesController, type: :request do
         expect(response).to have_http_status(:redirect)
         expect(response).to redirect_to(dashboard_form_publish_path(work_version))
         expect(OpenAccessVersionGuesserJob).not_to have_received(:perform_later)
+        expect(work_version.reload.open_access_version).to eq(OpenAccessVersion::VersionValues::ACCEPTED)
       end
     end
   end

--- a/spec/request/dashboard/form/publish_controller_spec.rb
+++ b/spec/request/dashboard/form/publish_controller_spec.rb
@@ -56,4 +56,39 @@ RSpec.describe Dashboard::Form::PublishController, type: :request do
       end
     end
   end
+
+  describe 'GET /dashboard/form/work_versions/:id/open_access_version' do
+    let(:work_version) do
+      create(:work_version, open_access_version: OpenAccessVersion::VersionValues::ACCEPTED)
+    end
+
+    context 'when the user can edit the work version' do
+      let(:user) { work_version.work.depositor.user }
+
+      before { sign_in user }
+
+      it 'returns the open access version payload' do
+        get "/dashboard/form/work_versions/#{work_version.id}/open_access_version"
+
+        expect(response).to have_http_status(:ok)
+        payload = JSON.parse(response.body)
+        expect(payload).to eq(
+          'id' => work_version.id,
+          'open_access_version' => OpenAccessVersion::VersionValues::ACCEPTED
+        )
+      end
+    end
+
+    context 'when the user cannot edit the work version' do
+      let(:user) { create(:user) }
+
+      before { sign_in user }
+
+      it 'returns not found' do
+        get "/dashboard/form/work_versions/#{work_version.id}/open_access_version"
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
 end

--- a/spec/services/open_access_version/guesser_spec.rb
+++ b/spec/services/open_access_version/guesser_spec.rb
@@ -36,6 +36,33 @@ RSpec.describe OpenAccessVersion::Guesser do
     end
 
     context 'when EXIF check returns nil and no arXiv watermark is found' do
+      context 'when PDF URI metadata is missing' do
+        let(:pdf_reader) { instance_double(PDF::Reader, objects: { 8 => { A: {} } }) }
+
+        before do
+          calculator = instance_double(OpenAccessVersion::ScoreCalculator, score: 1)
+          allow(OpenAccessVersion::ScoreCalculator).to receive(:new).and_return(calculator)
+        end
+
+        it 'does not treat the file as arXiv and falls back to score calculation' do
+          expect(guesser.version).to eq(OpenAccessVersion::VersionValues::PUBLISHED)
+        end
+      end
+
+      context 'when PDF object parsing fails during arXiv watermark check' do
+        let(:pdf_reader) { instance_double(PDF::Reader) }
+
+        before do
+          allow(pdf_reader).to receive(:objects).and_raise(StandardError)
+          calculator = instance_double(OpenAccessVersion::ScoreCalculator, score: 0)
+          allow(OpenAccessVersion::ScoreCalculator).to receive(:new).and_return(calculator)
+        end
+
+        it 'rescues and continues to score-based version detection' do
+          expect(guesser.version).to eq(OpenAccessVersion::VersionValues::UNKNOWN)
+        end
+      end
+
       context 'when score is positive' do
         before do
           calculator = instance_double(OpenAccessVersion::ScoreCalculator, score: 2)

--- a/spec/support/feature_helpers/dashboard_form.rb
+++ b/spec/support/feature_helpers/dashboard_form.rb
@@ -223,7 +223,6 @@ module FeatureHelpers
     end
 
     def self.simulate_open_access_version_broadcast(work_version)
-      # Spinner shows until version is updated in db and broadcasted to page
       work_version.update(open_access_version: 'acceptedVersion')
       # Wait for broadcast to update page
       page.has_no_text?(I18n.t('dashboard.form.publish.edit.determining_open_access_version'), wait: 3)

--- a/spec/support/feature_helpers/dashboard_form.rb
+++ b/spec/support/feature_helpers/dashboard_form.rb
@@ -221,5 +221,12 @@ module FeatureHelpers
 
       page.assert_selector('.aa-dataset-1')
     end
+
+    def self.simulate_open_access_version_broadcast(work_version)
+      # Spinner shows until version is updated in db and broadcasted to page
+      work_version.update(open_access_version: 'acceptedVersion')
+      # Wait for broadcast to update page
+      page.has_no_text?(I18n.t('dashboard.form.publish.edit.determining_open_access_version'), wait: 3)
+    end
   end
 end


### PR DESCRIPTION
closes #1972 

I built this using Rails ActionCable broadcasting and then realized it doesn't work if the open access version is determined very quickly.  This is because the browser doesn't have enough time to create a websocket connection on page load before the open access version is determined.  So, I implemented a Rails endpoint that also relays the open access version.  The JS on the publish page checks this on page load _and_ sets up a websocket connection for slower open access version processing.  Technically, I could remove all the ActionCable setup now and just do JS polling, but I figure at this point its not worth it.  The ActionCable setup isn't that complicated anyway.

A spinner shows while the page waits for an open access version update:
<img width="1032" height="177" alt="Screenshot 2026-06-04 at 2 52 11 PM" src="https://github.com/user-attachments/assets/e96e996e-5929-4b02-8bcc-5f01c13c20e0" />

