### PR TITLE
1991 - makes open access checkbox ro

### DIFF
--- a/app/views/dashboard/form/type/_work_version_fields.html.erb
+++ b/app/views/dashboard/form/type/_work_version_fields.html.erb
@@ -28,7 +28,7 @@
         style="display: none;">
 
       <%= form.check_box :open_access,
-                         { class: 'form-check-input', id: 'open_access_checkbox', disabled: @resource.open_access && !current_user.admin? },
+                         { class: 'form-check-input', id: 'open_access_checkbox', disabled: local_assigns[:work_type_disabled] && !current_user.admin? },
                          true,
                          false %>
 

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -282,27 +282,6 @@ RSpec.describe 'Publishing a work', with_user: :user do
           expect(page).to have_no_field('open_access_checkbox', type: 'checkbox')
         end
       end
-
-      context 'when the work is already open access', :js do
-        before do
-          @original_secret = ENV['ENABLE_OPEN_ACCESS_FEATURE']
-          ENV['ENABLE_OPEN_ACCESS_FEATURE'] = 'true'
-        end
-
-        after do
-          ENV['ENABLE_OPEN_ACCESS_FEATURE'] = @original_secret
-        end
-
-        it 'displays the open access checkbox in readonly' do
-          visit dashboard_form_work_versions_path
-
-          FeatureHelpers::DashboardForm.fill_in_minimal_work_details_for_scholarly_works_draft(metadata)
-          check 'open_access_checkbox'
-          FeatureHelpers::DashboardForm.save_and_continue
-          click_on 'Work Type'
-          expect(page).to have_field('open_access_checkbox', type: 'checkbox', disabled: true)
-        end
-      end
     end
 
     context 'when selecting a work type that uses the data and code deposit pathway' do
@@ -697,7 +676,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
   end
 
   describe 'The Work Details tab for an existing draft work' do
-    let(:work) { create(:work, versions_count: 1) }
+    let(:work) { create(:work, work_type: 'article', versions_count: 1, has_draft: true) }
     let(:work_version) { work.versions.first }
     let(:user) { work_version.work.depositor.user }
 
@@ -769,6 +748,23 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
         expect(page).to have_current_path(dashboard_form_contributors_path('work_version', work_version))
         expect(SolrIndexingJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context 'when metadata has been imported', :js do
+      before do
+        @original_secret = ENV['ENABLE_OPEN_ACCESS_FEATURE']
+        ENV['ENABLE_OPEN_ACCESS_FEATURE'] = 'true'
+        work_version.update!(imported_metadata_from_rmd: true)
+      end
+
+      after do
+        ENV['ENABLE_OPEN_ACCESS_FEATURE'] = @original_secret
+      end
+
+      it 'displays the open access checkbox in readonly' do
+        visit dashboard_form_work_version_type_path(work_version)
+        expect(page).to have_field('open_access_checkbox', type: 'checkbox', disabled: true)
       end
     end
   end
@@ -2362,7 +2358,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
 
       it 'enables autopopulated fields and does not display open access version' do
         visit dashboard_form_publish_path(work_version)
-        expect(page).to have_field('open_access_checkbox', type: 'checkbox')
+        expect(page).to have_field('open_access_checkbox', type: 'checkbox', disabled: true)
         expect(page).to have_field('work_version_publisher_statement')
         expect(page).to have_field('work_version_rights')
         expect(page).to have_field('work_version_work_attributes_embargoed_until')


### PR DESCRIPTION
closes #1991

If the type choice is also read-only. This will always be true on the publish screen, and be true on the view screen if the work is imported from rmd.