### PR TITLE
Adds `open_access` and `imported_metadata_from_rmd` params to ingest controller

### DIFF
--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -88,7 +88,7 @@ module Api::V1
             :publisher_statement,
             :doi,
             :open_access,
-            :metadata_imported_from_rmd,
+            :imported_metadata_from_rmd,
             keyword: [],
             resource_type: [],
             contributor: [],

--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -87,6 +87,8 @@ module Api::V1
             :description,
             :publisher_statement,
             :doi,
+            :open_access,
+            :metadata_imported_from_rmd,
             keyword: [],
             resource_type: [],
             contributor: [],

--- a/openapi.yml
+++ b/openapi.yml
@@ -420,6 +420,14 @@ components:
           enum:
             - open
             - authenticated
+        open_access:
+          type: "boolean"
+          description: >-
+            Whether the work is an upload for open access compliance.
+        metadata_imported_from_rmd:
+          type: "boolean"
+          description: >-
+            Whether the metadata was imported from The Researcher Metadata Database (RMD).
         embargoed_until:
           type: "string"
           format: "date"

--- a/openapi.yml
+++ b/openapi.yml
@@ -424,7 +424,7 @@ components:
           type: "boolean"
           description: >-
             Whether the work is an upload for open access compliance.
-        metadata_imported_from_rmd:
+        imported_metadata_from_rmd:
           type: "boolean"
           description: >-
             Whether the metadata was imported from The Researcher Metadata Database (RMD).

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Api::V1::IngestController do
             rights: metadata[:rights],
             visibility: Permissions::Visibility::OPEN,
             open_access: true,
-            metadata_imported_from_rmd: true
+            imported_metadata_from_rmd: true
           },
           depositor: depositor,
           content: [{ file: fixture_file_upload(File.join(fixture_paths, 'image.png')) }]
@@ -49,15 +49,9 @@ RSpec.describe Api::V1::IngestController do
         expect(response.body).to eq(
           "{\"message\":\"Work was successfully created\",\"url\":\"/resources/#{Work.last.uuid}\"}"
         )
-        expect(Api::V1::WorkCreator).to have_received(:call).with(
-          a_hash_including(
-            external_app: api_token.application,
-            metadata: a_hash_including(
-              open_access: true,
-              metadata_imported_from_rmd: true
-            )
-          )
-        )
+        a_hash_including(external_app: api_token.application)
+        expect(work_version.last.open_access).to eq(true)
+        expect(work_version.last.imported_metadata_from_rmd).to eq(true)
       end
     end
 

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -49,7 +49,9 @@ RSpec.describe Api::V1::IngestController do
         expect(response.body).to eq(
           "{\"message\":\"Work was successfully created\",\"url\":\"/resources/#{Work.last.uuid}\"}"
         )
-        a_hash_including(external_app: api_token.application)
+        expect(Api::V1::WorkCreator).to have_received(:call).with(
+          a_hash_including(external_app: api_token.application)
+        )
         expect(work_version.last.open_access).to eq(true)
         expect(work_version.last.imported_metadata_from_rmd).to eq(true)
       end

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe Api::V1::IngestController do
         expect(Api::V1::WorkCreator).to have_received(:call).with(
           a_hash_including(external_app: api_token.application)
         )
-        expect(work_version.last.open_access).to eq(true)
-        expect(work_version.last.imported_metadata_from_rmd).to eq(true)
+        expect(WorkVersion.last.open_access).to eq(true)
+        expect(WorkVersion.last.imported_metadata_from_rmd).to eq(true)
       end
     end
 

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -35,7 +35,9 @@ RSpec.describe Api::V1::IngestController do
             published_date: metadata[:published_date],
             creators: [creator],
             rights: metadata[:rights],
-            visibility: Permissions::Visibility::OPEN
+            visibility: Permissions::Visibility::OPEN,
+            open_access: true,
+            metadata_imported_from_rmd: true
           },
           depositor: depositor,
           content: [{ file: fixture_file_upload(File.join(fixture_paths, 'image.png')) }]
@@ -48,7 +50,13 @@ RSpec.describe Api::V1::IngestController do
           "{\"message\":\"Work was successfully created\",\"url\":\"/resources/#{Work.last.uuid}\"}"
         )
         expect(Api::V1::WorkCreator).to have_received(:call).with(
-          a_hash_including(external_app: api_token.application)
+          a_hash_including(
+            external_app: api_token.application,
+            metadata: a_hash_including(
+              open_access: true,
+              metadata_imported_from_rmd: true
+            )
+          )
         )
       end
     end


### PR DESCRIPTION
part of: https://github.com/psu-libraries/researcher-metadata/pull/1256 and https://github.com/psu-libraries/researcher-metadata/issues/1253

