### PR TITLE
Adds JS form validation on publish button 

### DIFF
--- a/app/javascript/controllers/publishing_check_controller.js
+++ b/app/javascript/controllers/publishing_check_controller.js
@@ -56,6 +56,14 @@ export default class extends Controller {
   }
 
   openDialog (event) {
+    // Validate the full form before opening a modal dialog. When a dialog is
+    // open, the rest of the page becomes inert and browsers cannot focus
+    // invalid controls outside of the dialog.
+    const form = event.currentTarget.form
+    if (form && !form.reportValidity()) {
+      return
+    }
+
     const dialogType = event.currentTarget.dataset.dialog
     const currentTypeTargets = this.displayTargetMap[dialogType]
     // Hide all the targets that are not part of the current dialog.

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -1227,6 +1227,21 @@ RSpec.describe 'Publishing a work', with_user: :user do
   end
 
   describe 'The Publish tab' do
+    context 'when required contributor fields are blank', :js do
+      let(:work_version) { create(:work_version, :article, :able_to_be_published) }
+      let(:user) { work_version.work.depositor.user }
+
+      it 'does not open the publish dialog and keeps focus on form validation' do
+        visit dashboard_form_publish_path(work_version)
+
+        fill_in 'work_version_creators_attributes_0_given_name', with: ''
+
+        click_on I18n.t!('dashboard.form.actions.publish.button')
+
+        expect(page).to have_no_css('dialog#hidden-publish-dialog[open]')
+      end
+    end
+
     context 'when submitting the form with publication errors' do
       let(:work) { create(:work) }
       let(:user) { work.depositor.user }

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -1239,6 +1239,13 @@ RSpec.describe 'Publishing a work', with_user: :user do
         click_on I18n.t!('dashboard.form.actions.publish.button')
 
         expect(page).to have_no_css('dialog#hidden-publish-dialog[open]')
+
+        fill_in 'work_version_creators_attributes_0_given_name', with: 'Firstname'
+        fill_in 'work_version_creators_attributes_0_surname', with: 'Lastname'
+
+        click_on I18n.t!('dashboard.form.actions.publish.button')
+
+        expect(page).to have_css('dialog#hidden-publish-dialog[open]')
       end
     end
 


### PR DESCRIPTION
To direct users to incomplete parts of the form _before_ popup covers the screen.

This was a much easier fix than I predicted.  We don't have model level validations for `given_name` and `last_name` for contributors, because those names usually are a bit messy.  However, we do have front-end requirements for them, to encourage users to add them.  The problem was that the popup was blocking the frontend validation errors.


https://github.com/user-attachments/assets/1b52eacc-9dd8-4e3a-94d3-7b4d6b37e4fd

Closes #2002 



