### PR TITLE
Do not show OA checkbox if the work version is not the initial draft

### DIFF
--- a/app/views/dashboard/form/type/_work_version_fields.html.erb
+++ b/app/views/dashboard/form/type/_work_version_fields.html.erb
@@ -21,7 +21,7 @@
   <% end %>
 
   <!-- Feature Flag: remove once open access pathway is enabled -->
-  <% if ENV['ENABLE_OPEN_ACCESS_FEATURE'] == 'true' %>
+  <% if ENV['ENABLE_OPEN_ACCESS_FEATURE'] == 'true' && form.object.initial_draft? %>
     <div class="form-check"
         id="open-access-help-text"
         data-target="work-type.openAccess"
@@ -34,7 +34,8 @@
 
       <%= form.label :open_access,
                      t('dashboard.form.details.open_access_prompt'),
-                     class: 'form-check-label' %>
+                     class: 'form-check-label',
+                     for: 'open_access_checkbox' %>
     </div>
   <% end %>
   <div class="form-text text-muted" id="work-title-help-text" data-target="work-type.helpText" style="display: none;">

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -767,6 +767,27 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(page).to have_field('open_access_checkbox', type: 'checkbox', disabled: true)
       end
     end
+
+    context 'when editing a non-initial draft version', :js do
+      let(:work) { create(:work, work_type: 'article', versions_count: 2, has_draft: true) }
+
+      before do
+        @original_secret = ENV['ENABLE_OPEN_ACCESS_FEATURE']
+        ENV['ENABLE_OPEN_ACCESS_FEATURE'] = 'true'
+      end
+
+      after do
+        ENV['ENABLE_OPEN_ACCESS_FEATURE'] = @original_secret
+      end
+
+      it 'does not display the open access checkbox' do
+        expect(work_version).not_to be_initial_draft
+
+        visit dashboard_form_work_version_type_path(work_version)
+
+        expect(page).to have_no_field('open_access_checkbox', type: 'checkbox')
+      end
+    end
   end
 
   describe 'The Contributors tab', :js do


### PR DESCRIPTION
There's no reason to allow an Open Access upload for anything beyond the first version, so this will help to avoid confusion.

closes #2004 