### PR TITLE
Moves webhook rmd publish callback to publish controller

### DIFF
--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -19,6 +19,7 @@ module Dashboard
         @work_version = WorkVersion.find(params[:id])
         @resource = deposit_pathway.publish_form(current_user:)
         authorize(@work_version)
+        was_published = @resource.published?
 
         @resource.attributes = work_version_params
         @submitted_permissions = oaw_permissions_params
@@ -52,6 +53,10 @@ module Dashboard
 
         validation_context = current_user.admin? ? nil : :user_publish
         process_response(on_error: :edit, validation_context: validation_context) do
+          if publish? && !was_published && @resource.published? && @resource.open_access
+            WorkPublishedWebhookJob.perform_later(@resource.work.uuid)
+          end
+
           if @resource.mint_doi_requested
             deposit_pathway.allows_mint_doi_request? ? MintDoiAsync.call(@resource.work) : flash[:error] = t('dashboard.form.publish.doi.error')
           end

--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -19,7 +19,6 @@ module Dashboard
         @work_version = WorkVersion.find(params[:id])
         @resource = deposit_pathway.publish_form(current_user:)
         authorize(@work_version)
-        was_published = @resource.published?
 
         @resource.attributes = work_version_params
         @submitted_permissions = oaw_permissions_params
@@ -53,7 +52,7 @@ module Dashboard
 
         validation_context = current_user.admin? ? nil : :user_publish
         process_response(on_error: :edit, validation_context: validation_context) do
-          if publish? && !was_published && @resource.published? && @resource.open_access
+          if publish? && @resource.open_access
             WorkPublishedWebhookJob.perform_later(@resource.work.uuid)
           end
 

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -213,8 +213,6 @@ class WorkVersion < ApplicationRecord
 
   after_update :broadcast_open_access_version_if_needed
   after_commit :perform_update_index, on: [:create, :update]
-  after_commit :enqueue_published_webhook, on: [:create, :update]
-  after_rollback :clear_publish_flag
 
   attr_accessor :force_destroy
 
@@ -224,15 +222,21 @@ class WorkVersion < ApplicationRecord
     prevent_destroy = published? && !force_destroy
     raise ArgumentError, 'cannot delete published versions' if prevent_destroy
   end
+
   aasm timestamps: true do
     state :draft, intial: true
     state :published, :withdrawn, :removed
 
     event :publish do
-      before do
-        @work_just_published = true
-      end
-      transitions from: [:draft, :withdrawn], to: :published, after: :after_publish
+      transitions from: [:draft, :withdrawn],
+                  to: :published,
+                  after: Proc.new {
+                    work.try(:update_deposit_agreement)
+                    if work.professional_doctoral_culminating_experience? || work.masters_culminating_experience? || work_type == 'instrument'
+                      set_publisher_as_scholarsphere
+                    end
+                    self.reload_on_index = true
+                  }
     end
 
     event :withdraw do
@@ -435,26 +439,6 @@ class WorkVersion < ApplicationRecord
 
     def perform_update_index
       indexing_source.call(self)
-    end
-
-    def after_publish
-      work.try(:update_deposit_agreement)
-      if work.professional_doctoral_culminating_experience? || work.masters_culminating_experience? || work_type == 'instrument'
-        set_publisher_as_scholarsphere
-      end
-      self.reload_on_index = true
-    end
-
-    def enqueue_published_webhook
-      just_published = @work_just_published
-      @work_just_published = false
-      return unless just_published && open_access
-
-      WorkPublishedWebhookJob.perform_later(work.uuid)
-    end
-
-    def clear_publish_flag
-      @work_just_published = false
     end
 
     def broadcast_open_access_version_if_needed

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -150,39 +150,6 @@ RSpec.describe WorkVersion do
     end
   end
 
-  describe 'publish event webhook' do
-    let(:work) { create(:work) }
-    let(:work_version) { create(:work_version, work: work) }
-
-    before { allow(WorkPublishedWebhookJob).to receive(:perform_later) }
-
-    context 'when the work is open access' do
-      before { work_version.update(open_access: true) }
-
-      it 'enqueues the WorkPublishedWebhookJob when published' do
-        work_version.publish!
-
-        expect(WorkPublishedWebhookJob).to have_received(:perform_later).with(work.uuid)
-      end
-    end
-
-    context 'when the work is not open access' do
-      it 'does not enqueue the webhook job' do
-        work_version.publish!
-
-        expect(WorkPublishedWebhookJob).not_to have_received(:perform_later)
-      end
-    end
-
-    context 'when the work version is updated without publishing' do
-      it 'does not enqueue the webhook job' do
-        work_version.update(title: 'no state change')
-
-        expect(WorkPublishedWebhookJob).not_to have_received(:perform_later)
-      end
-    end
-  end
-
   describe 'open access version broadcast' do
     before { allow(OpenAccessVersionChannel).to receive(:broadcast_to) }
 
@@ -378,9 +345,9 @@ RSpec.describe WorkVersion do
 
     context 'with open_access_version' do
       it { is_expected.to allow_value(nil).for(:open_access_version) }
-      it { is_expected.to allow_value('acceptedVersion').for(:open_access_version) }
-      it { is_expected.to allow_value('publishedVersion').for(:open_access_version) }
-      it { is_expected.to allow_value('unknownVersion').for(:open_access_version) }
+      it { is_expected.to allow_value(OpenAccessVersion::VersionValues::ACCEPTED).for(:open_access_version) }
+      it { is_expected.to allow_value(OpenAccessVersion::VersionValues::PUBLISHED).for(:open_access_version) }
+      it { is_expected.to allow_value(OpenAccessVersion::VersionValues::UNKNOWN).for(:open_access_version) }
       it { is_expected.not_to allow_value('not_allowed').for(:open_access_version) }
     end
   end

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -345,9 +345,9 @@ RSpec.describe WorkVersion do
 
     context 'with open_access_version' do
       it { is_expected.to allow_value(nil).for(:open_access_version) }
-      it { is_expected.to allow_value(OpenAccessVersion::VersionValues::ACCEPTED).for(:open_access_version) }
-      it { is_expected.to allow_value(OpenAccessVersion::VersionValues::PUBLISHED).for(:open_access_version) }
-      it { is_expected.to allow_value(OpenAccessVersion::VersionValues::UNKNOWN).for(:open_access_version) }
+      it { is_expected.to allow_value('acceptedVersion').for(:open_access_version) }
+      it { is_expected.to allow_value('publishedVersion').for(:open_access_version) }
+      it { is_expected.to allow_value('unknownVersion').for(:open_access_version) }
       it { is_expected.not_to allow_value('not_allowed').for(:open_access_version) }
     end
   end

--- a/spec/request/dashboard/form/publish_controller_spec.rb
+++ b/spec/request/dashboard/form/publish_controller_spec.rb
@@ -95,6 +95,18 @@ RSpec.describe Dashboard::Form::PublishController, type: :request do
         expect(WorkPublishedWebhookJob).not_to have_received(:perform_later)
       end
     end
+
+    context 'when publish fails validation' do
+      it 'does not enqueue the webhook' do
+        invalid_params = request_params.deep_dup
+        invalid_params[:work_version][:description] = ''
+
+        patch dashboard_form_publish_path(work_version), params: invalid_params
+
+        expect(response).to have_http_status(:ok)
+        expect(WorkPublishedWebhookJob).not_to have_received(:perform_later)
+      end
+    end
   end
 
   describe 'GET /dashboard/form/work_versions/:id/open_access_version' do

--- a/spec/request/dashboard/form/publish_controller_spec.rb
+++ b/spec/request/dashboard/form/publish_controller_spec.rb
@@ -57,6 +57,46 @@ RSpec.describe Dashboard::Form::PublishController, type: :request do
     end
   end
 
+  describe 'webhook on publish' do
+    let(:work_version) { create(:work_version, :able_to_be_published, open_access: open_access) }
+    let(:open_access) { true }
+    let(:user) { work_version.work.depositor.user }
+    let(:request_params) do
+      {
+        publish: '1',
+        work_version: {
+          depositor_agreement: '1',
+          psu_community_agreement: '1',
+          accessibility_agreement: '1',
+          sensitive_info_agreement: '1'
+        }
+      }
+    end
+
+    before do
+      sign_in user
+      allow(WorkPublishedWebhookJob).to receive(:perform_later)
+    end
+
+    it 'enqueues the webhook when an open access work is published' do
+      patch dashboard_form_publish_path(work_version), params: request_params
+
+      expect(response).to have_http_status(:redirect)
+      expect(WorkPublishedWebhookJob).to have_received(:perform_later).with(work_version.work.uuid)
+    end
+
+    context 'when the work is not open access' do
+      let(:open_access) { false }
+
+      it 'does not enqueue the webhook' do
+        patch dashboard_form_publish_path(work_version), params: request_params
+
+        expect(response).to have_http_status(:redirect)
+        expect(WorkPublishedWebhookJob).not_to have_received(:perform_later)
+      end
+    end
+  end
+
   describe 'GET /dashboard/form/work_versions/:id/open_access_version' do
     let(:work_version) do
       create(:work_version, open_access_version: OpenAccessVersion::VersionValues::ACCEPTED)


### PR DESCRIPTION
In QA, the webhook callback in the model was running even when the WorkVersion was not being published.  I moved the webhook implementation to the publish controller.  This gives us more reliable behavior, even if it's only tied to GUI interactions.  This webhook does not _need_ to be tied to model commit/update callbacks, so this should work for us.