### PR TITLE
Handle open access workflow when user changes `work_type`

### DIFF
--- a/app/controllers/dashboard/form/base_controller.rb
+++ b/app/controllers/dashboard/form/base_controller.rb
@@ -128,7 +128,7 @@ module Dashboard
           param_permissions = JSON.parse(params.dig(:oaw_permissions, :versions_found) || '[]')
           permissions_found = @permissions&.all_permissions.present? || param_permissions.present?
 
-          @resource.open_access_upload &&
+          @resource.open_access_upload_active? &&
             !current_user.admin? &&
             permissions_found
         end

--- a/app/controllers/dashboard/form/files_controller.rb
+++ b/app/controllers/dashboard/form/files_controller.rb
@@ -17,7 +17,7 @@ module Dashboard
         @resource.attributes = work_version_params
         process_response(on_error: :edit) do
           send_accessibility_check_jobs
-          send_open_access_version_guesser_job if @resource.open_access_upload
+          send_open_access_version_guesser_job if @resource.open_access_upload_active?
         end
       end
 

--- a/app/controllers/dashboard/form/publish_controller.rb
+++ b/app/controllers/dashboard/form/publish_controller.rb
@@ -52,7 +52,7 @@ module Dashboard
 
         validation_context = current_user.admin? ? nil : :user_publish
         process_response(on_error: :edit, validation_context: validation_context) do
-          if publish? && @resource.open_access_upload
+          if publish? && @resource.open_access_upload_active?
             WorkPublishedWebhookJob.perform_later(@resource.work.uuid)
           end
 

--- a/app/forms/work_deposit_pathway.rb
+++ b/app/forms/work_deposit_pathway.rb
@@ -214,6 +214,7 @@ class WorkDepositPathway
 
       delegate :imported_metadata_from_rmd,
                :open_access_upload,
+               :open_access_upload_active?,
                to: :work_version, prefix: false
 
       def show_autocomplete_form?
@@ -290,8 +291,6 @@ class WorkDepositPathway
           delegate attr_name, to: :work_version, prefix: false
           delegate "#{attr_name}=", to: :work_version, prefix: false
         end
-
-        delegate :open_access_upload_active?, to: :work_version
 
         delegate :form_partial, to: :work_version
       end

--- a/app/forms/work_deposit_pathway.rb
+++ b/app/forms/work_deposit_pathway.rb
@@ -321,7 +321,7 @@ class WorkDepositPathway
         end
 
         def show_autocomplete_form?
-          open_access_upload == true && imported_metadata_from_rmd.nil?
+          work_version.open_access_upload_active? && imported_metadata_from_rmd.nil?
         end
 
         validate :autocomplete_must_be_completed

--- a/app/forms/work_deposit_pathway.rb
+++ b/app/forms/work_deposit_pathway.rb
@@ -44,7 +44,7 @@ class WorkDepositPathway
   end
 
   def allows_visibility_change?
-    !data_and_code? && !grad_culminating_experiences? && !@resource.open_access_upload
+    !data_and_code? && !grad_culminating_experiences? && !@resource.open_access_upload_active?
   end
 
   def allows_curation_request?

--- a/app/forms/work_deposit_pathway.rb
+++ b/app/forms/work_deposit_pathway.rb
@@ -291,6 +291,8 @@ class WorkDepositPathway
           delegate "#{attr_name}=", to: :work_version, prefix: false
         end
 
+        delegate :open_access_upload_active?, to: :work_version
+
         delegate :form_partial, to: :work_version
       end
     end
@@ -321,7 +323,7 @@ class WorkDepositPathway
         end
 
         def show_autocomplete_form?
-          work_version.open_access_upload_active? && imported_metadata_from_rmd.nil?
+          open_access_upload_active? && imported_metadata_from_rmd.nil?
         end
 
         validate :autocomplete_must_be_completed

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -12,7 +12,7 @@ class Work < ApplicationRecord
   fields_with_dois :doi, :latest_published_version_dois
 
   delegate :email, :display_name, to: :depositor
-  delegate :has_publisher_doi?, :open_access_upload, to: :latest_version
+  delegate :has_publisher_doi?, :open_access_upload, :open_access_upload_active?, to: :latest_version
 
   belongs_to :depositor,
              class_name: 'Actor',

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -407,6 +407,14 @@ class WorkVersion < ApplicationRecord
     file_resources&.any?(&:large_pdf?)
   end
 
+  def open_access_upload_eligible?
+    Work::Types.oa_scholarly_works.include?(work_type)
+  end
+
+  def open_access_upload_active?
+    open_access_upload? && open_access_upload_eligible?
+  end
+
   def has_remaining_auto_remediation_jobs?
     file_resources.exists?(['remediation_job_uuid IS NOT NULL AND remediated_version = ?', false])
   end
@@ -437,6 +445,11 @@ class WorkVersion < ApplicationRecord
       fields_to_reset.each do |field|
         send(:"#{field}=", nil)
       end
+
+      unless open_access_upload_eligible?
+        self.open_access_upload = nil
+        self.open_access_version = nil
+      end
     end
 
     def perform_update_index
@@ -456,7 +469,7 @@ class WorkVersion < ApplicationRecord
     end
 
     def open_access_version_required
-      if open_access_upload && OpenAccessVersion::VersionValues::KNOWN.exclude?(open_access_version)
+      if open_access_upload_active? && OpenAccessVersion::VersionValues::KNOWN.exclude?(open_access_version)
         errors.add(:open_access_version, :blank)
       end
     end

--- a/app/services/curation_task_client.rb
+++ b/app/services/curation_task_client.rb
@@ -14,7 +14,7 @@ class CurationTaskClient
     labels << 'Accessibility Remediation Requested' if remediation_requested
     labels << 'Needs Accessibility Review' if work_version.needs_accessibility_review
     labels << 'Large PDF' if work_version.has_large_pdf_file_resource?
-    labels << 'AC02' if work_version.open_access_upload
+    labels << 'AC02' if work_version.open_access_upload_active?
 
     record =
       {

--- a/app/views/dashboard/form/details/_scholarly_works_work_version_fields.html.erb
+++ b/app/views/dashboard/form/details/_scholarly_works_work_version_fields.html.erb
@@ -1,6 +1,6 @@
 <%= render 'dashboard/form/details/common_work_version_required_fields', form: form %>
 
-<% if @resource.open_access_upload %>
+<% if @resource.open_access_upload_active? %>
   <% form.object.publisher_statement = @permissions&.publisher_statement(@resource.open_access_version) %>
 <% end %>
 <div class="form-wrapper">

--- a/app/views/dashboard/form/publish/_fields.html.erb
+++ b/app/views/dashboard/form/publish/_fields.html.erb
@@ -1,4 +1,4 @@
-<% open_access = @resource.open_access_upload %>
+<% open_access = @resource.open_access_upload_active? %>
 <% selected_rights = open_access ? @permissions&.licence(@resource.open_access_version) : form.object.rights %>
 <% open_access_embargo_end_date = @permissions&.embargo_end_date(@resource.open_access_version) %>
 <div class="form-wrapper">

--- a/app/views/dashboard/form/publish/edit.html.erb
+++ b/app/views/dashboard/form/publish/edit.html.erb
@@ -78,7 +78,7 @@
               <%= render 'dashboard/form/files/uploaded_file_list', work_version: form.object %>
             <% end %>
 
-            <% if @resource.open_access_upload %>
+            <% if @resource.open_access_upload_active? %>
               <div class="form-wrapper form-wrapper--wide">
                 <div class="keyline keyline--left mb-3">
                   <h4><%= t '.version' %></h4>

--- a/spec/forms/work_deposit_pathway_spec.rb
+++ b/spec/forms/work_deposit_pathway_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe WorkDepositPathway do
       doi_blank?: doi_blank,
       work: work,
       file_version_memberships: [file_version_membership1, file_version_membership2],
-      open_access_upload: open_access
+      open_access_upload: open_access,
+      open_access_upload_active?: open_access
     )
   }
   let(:type) { nil }

--- a/spec/forms/work_deposit_pathways/scholarly_works/details_form_spec.rb
+++ b/spec/forms/work_deposit_pathways/scholarly_works/details_form_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe WorkDepositPathway::ScholarlyWorks::DetailsForm, type: :model do
   end
 
   describe 'autocomplete validation' do
-    context 'when the work is an open access upload' do
+    context 'when the work version is open_access_upload_active' do
       before do
         allow(wv).to receive(:open_access_upload_active?).and_return(true)
       end

--- a/spec/forms/work_deposit_pathways/scholarly_works/details_form_spec.rb
+++ b/spec/forms/work_deposit_pathways/scholarly_works/details_form_spec.rb
@@ -80,7 +80,9 @@ RSpec.describe WorkDepositPathway::ScholarlyWorks::DetailsForm, type: :model do
 
   describe 'autocomplete validation' do
     context 'when the work is an open access upload' do
-      before { wv.open_access_upload = true }
+      before do
+        allow(wv).to receive(:open_access_upload_active?).and_return(true)
+      end
 
       context 'when the autocomplete form has not been submitted' do
         it 'is not valid' do

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Work do
   it { is_expected.to delegate_method(:email).to(:depositor) }
   it { is_expected.to delegate_method(:display_name).to(:depositor) }
   it { is_expected.to delegate_method(:has_publisher_doi?).to(:latest_version) }
+  it { is_expected.to delegate_method(:open_access_upload).to(:latest_version) }
+  it { is_expected.to delegate_method(:open_access_upload_active?).to(:latest_version) }
 
   it_behaves_like 'a resource with permissions' do
     let(:factory_name) { :work }

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -521,6 +521,55 @@ RSpec.describe WorkVersion do
     it { is_expected.to be_latest_version }
   end
 
+  describe '#open_access_upload_active?' do
+    let(:work_version) { create(:work_version, work: build(:work, work_type: work_type), open_access_upload: open_access_upload) }
+    let(:open_access_upload) { true }
+
+    context 'when work type is open access eligible and upload is enabled' do
+      let(:work_type) { 'article' }
+
+      it 'returns true' do
+        expect(work_version.open_access_upload_active?).to be true
+      end
+    end
+
+    context 'when work type is not open access eligible and upload is enabled' do
+      let(:work_type) { 'research_paper' }
+
+      it 'returns false' do
+        expect(work_version.open_access_upload_active?).to be false
+      end
+    end
+
+    context 'when work type is open access eligible and upload is disabled' do
+      let(:work_type) { 'article' }
+      let(:open_access_upload) { false }
+
+      it 'returns false' do
+        expect(work_version.open_access_upload_active?).to be false
+      end
+    end
+  end
+
+  describe 'open access fields on work type change' do
+    let(:work_version) do
+      create(
+        :work_version,
+        work: create(:work, work_type: 'article'),
+        open_access_upload: true,
+        open_access_version: OpenAccessVersion::VersionValues::ACCEPTED
+      )
+    end
+
+    it 'clears open access fields when work type changes to a non-eligible scholarly type' do
+      work_version.assign_attributes(work_attributes: { id: work_version.work.id, work_type: 'research_paper' })
+      work_version.save!
+
+      expect(work_version.reload.open_access_upload).to be_nil
+      expect(work_version.open_access_version).to be_nil
+    end
+  end
+
   describe '#to_solr' do
     subject(:work_version) { create(:work_version, :with_files, published_date: '1999-uu-uu') }
 

--- a/spec/request/dashboard/form/files_controller_spec.rb
+++ b/spec/request/dashboard/form/files_controller_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe Dashboard::Form::FilesController, type: :request do
           expect(response).to have_http_status(:redirect)
           expect(response).to redirect_to(dashboard_form_publish_path(work_version))
           expect(OpenAccessVersionGuesserJob).not_to have_received(:perform_later)
-          expect(work_version.reload.open_access_version).to eq(OpenAccessVersion::VersionValues::ACCEPTED)
         end
       end
     end

--- a/spec/request/dashboard/form/files_controller_spec.rb
+++ b/spec/request/dashboard/form/files_controller_spec.rb
@@ -47,23 +47,23 @@ RSpec.describe Dashboard::Form::FilesController, type: :request do
         expect(OpenAccessVersionGuesserJob).to have_received(:perform_later).with(work_version.id)
         expect(work_version.reload.open_access_version).to be_nil
       end
+
+      context 'when the work type is not OA-eligible' do
+        let(:work_type) { 'research_paper' }
+
+        it 'does not enqueue open access version guessing' do
+          patch dashboard_form_files_path(work_version), params: request_params
+
+          expect(response).to have_http_status(:redirect)
+          expect(response).to redirect_to(dashboard_form_publish_path(work_version))
+          expect(OpenAccessVersionGuesserJob).not_to have_received(:perform_later)
+          expect(work_version.reload.open_access_version).to eq(OpenAccessVersion::VersionValues::ACCEPTED)
+        end
+      end
     end
 
     context 'when open access is disabled' do
       let(:open_access) { false }
-
-      it 'does not enqueue open access version guessing' do
-        patch dashboard_form_files_path(work_version), params: request_params
-
-        expect(response).to have_http_status(:redirect)
-        expect(response).to redirect_to(dashboard_form_publish_path(work_version))
-        expect(OpenAccessVersionGuesserJob).not_to have_received(:perform_later)
-        expect(work_version.reload.open_access_version).to eq(OpenAccessVersion::VersionValues::ACCEPTED)
-      end
-    end
-
-    context 'when open access is enabled but the work type is not OA-eligible' do
-      let(:work_type) { 'research_paper' }
 
       it 'does not enqueue open access version guessing' do
         patch dashboard_form_files_path(work_version), params: request_params

--- a/spec/request/dashboard/form/files_controller_spec.rb
+++ b/spec/request/dashboard/form/files_controller_spec.rb
@@ -21,12 +21,14 @@ RSpec.describe Dashboard::Form::FilesController, type: :request do
       create(
         :work_version,
         :draft,
+        work: build(:work, work_type: work_type),
         open_access_upload: open_access,
         open_access_version: OpenAccessVersion::VersionValues::ACCEPTED
       )
     end
     let(:user) { work_version.depositor.user }
     let(:open_access) { true }
+    let(:work_type) { 'article' }
     let(:request_params) { { work_version: { id: work_version.id } } }
 
     before do
@@ -49,6 +51,19 @@ RSpec.describe Dashboard::Form::FilesController, type: :request do
 
     context 'when open access is disabled' do
       let(:open_access) { false }
+
+      it 'does not enqueue open access version guessing' do
+        patch dashboard_form_files_path(work_version), params: request_params
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(dashboard_form_publish_path(work_version))
+        expect(OpenAccessVersionGuesserJob).not_to have_received(:perform_later)
+        expect(work_version.reload.open_access_version).to eq(OpenAccessVersion::VersionValues::ACCEPTED)
+      end
+    end
+
+    context 'when open access is enabled but the work type is not OA-eligible' do
+      let(:work_type) { 'research_paper' }
 
       it 'does not enqueue open access version guessing' do
         patch dashboard_form_files_path(work_version), params: request_params

--- a/spec/request/dashboard/form/publish_controller_spec.rb
+++ b/spec/request/dashboard/form/publish_controller_spec.rb
@@ -58,8 +58,17 @@ RSpec.describe Dashboard::Form::PublishController, type: :request do
   end
 
   describe 'webhook on publish' do
-    let(:work_version) { create(:work_version, :able_to_be_published, open_access_upload: open_access, open_access_version: OpenAccessVersion::VersionValues::ACCEPTED) }
+    let(:work_version) do
+      create(
+        :work_version,
+        :able_to_be_published,
+        work: build(:work, work_type: work_type),
+        open_access_upload: open_access,
+        open_access_version: OpenAccessVersion::VersionValues::ACCEPTED
+      )
+    end
     let(:open_access) { true }
+    let(:work_type) { 'article' }
     let(:user) { work_version.work.depositor.user }
     let(:request_params) do
       {
@@ -87,6 +96,17 @@ RSpec.describe Dashboard::Form::PublishController, type: :request do
 
     context 'when the work is not open access' do
       let(:open_access) { false }
+
+      it 'does not enqueue the webhook' do
+        patch dashboard_form_publish_path(work_version), params: request_params
+
+        expect(response).to have_http_status(:redirect)
+        expect(WorkPublishedWebhookJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context 'when open access is enabled but the work type is not OA-eligible' do
+      let(:work_type) { 'research_paper' }
 
       it 'does not enqueue the webhook' do
         patch dashboard_form_publish_path(work_version), params: request_params

--- a/spec/services/curation_task_client_spec.rb
+++ b/spec/services/curation_task_client_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe CurationTaskClient do
       let(:embargo) { nil }
       let(:labels) { ['AC02'] }
 
-      before { allow(work_version).to receive(:open_access_upload).and_return(true) }
+      before { allow(work_version).to receive(:open_access_upload_active?).and_return(true) }
 
       it 'creates a submission record in Airtable' do
         expect(Submission).to receive(:create).with(expected_record)
@@ -133,7 +133,7 @@ RSpec.describe CurationTaskClient do
       let(:embargo) { nil }
       let(:labels) { [] }
 
-      before { allow(work_version).to receive(:open_access_upload).and_return(false) }
+      before { allow(work_version).to receive(:open_access_upload_active?).and_return(false) }
 
       it 'creates a submission record in Airtable' do
         expect(Submission).to receive(:create).with(expected_record)


### PR DESCRIPTION
Context: A user changed their work type _after_ checking the Open Access checkbox and saving, making the upload an Open Access upload despite not being eligible.  This was breaking things.

Fix: Adds helper method for determining if a work version's type is eligible for the open access workflow, and using that, a helper method for determining if the open access flow should be active for a work version.  Also, reset open_access_upload and open_access_version if the user changes the work type to something that is not eligible.  This will prevent issues when users change work types.  