### PR TITLE
Disable open access workflow checkbox if open_access_upload is already set

### DIFF
--- a/app/views/dashboard/form/type/_work_version_fields.html.erb
+++ b/app/views/dashboard/form/type/_work_version_fields.html.erb
@@ -28,7 +28,11 @@
         style="display: none;">
 
       <%= form.check_box :open_access_upload,
-                         { class: 'form-check-input', id: 'open_access_upload_checkbox', disabled: local_assigns[:work_type_disabled] && !current_user.admin? },
+                         {
+                           class: 'form-check-input',
+                           id: 'open_access_upload_checkbox',
+                           disabled: (local_assigns[:work_type_disabled] && !current_user.admin?) || form.object.open_access_upload?
+                         },
                          true,
                          false %>
 

--- a/app/views/dashboard/form/type/_work_version_fields.html.erb
+++ b/app/views/dashboard/form/type/_work_version_fields.html.erb
@@ -31,7 +31,8 @@
                          {
                            class: 'form-check-input',
                            id: 'open_access_upload_checkbox',
-                           disabled: (local_assigns[:work_type_disabled] && !current_user.admin?) || form.object.open_access_upload?
+                           disabled: !current_user.admin? &&
+                             (local_assigns[:work_type_disabled] || form.object.open_access_upload?)
                          },
                          true,
                          false %>

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -768,6 +768,24 @@ RSpec.describe 'Publishing a work', with_user: :user do
       end
     end
 
+    context 'when open access upload is already true', :js do
+      before do
+        @original_secret = ENV['ENABLE_OPEN_ACCESS_FEATURE']
+        ENV['ENABLE_OPEN_ACCESS_FEATURE'] = 'true'
+        work_version.update!(open_access_upload: true)
+      end
+
+      after do
+        ENV['ENABLE_OPEN_ACCESS_FEATURE'] = @original_secret
+      end
+
+      it 'disables the open access checkbox' do
+        visit dashboard_form_work_version_type_path(work_version)
+
+        expect(page).to have_field('open_access_upload_checkbox', type: 'checkbox', disabled: true, checked: true)
+      end
+    end
+
     context 'when editing a non-initial draft version', :js do
       let(:work) { create(:work, work_type: 'article', versions_count: 2, has_draft: true) }
 

--- a/spec/features/dashboard/work_version_form_spec.rb
+++ b/spec/features/dashboard/work_version_form_spec.rb
@@ -766,6 +766,15 @@ RSpec.describe 'Publishing a work', with_user: :user do
         visit dashboard_form_work_version_type_path(work_version)
         expect(page).to have_field('open_access_upload_checkbox', type: 'checkbox', disabled: true)
       end
+
+      context 'when the user is an admin' do
+        let(:user) { create(:user, :admin) }
+
+        it 'displays the open access checkbox without disabling it' do
+          visit dashboard_form_work_version_type_path(work_version)
+          expect(page).to have_field('open_access_upload_checkbox', type: 'checkbox', disabled: false)
+        end
+      end
     end
 
     context 'when open access upload is already true', :js do
@@ -783,6 +792,16 @@ RSpec.describe 'Publishing a work', with_user: :user do
         visit dashboard_form_work_version_type_path(work_version)
 
         expect(page).to have_field('open_access_upload_checkbox', type: 'checkbox', disabled: true, checked: true)
+      end
+
+      context 'when the user is an admin' do
+        let(:user) { create(:user, :admin) }
+
+        it 'displays the open access checkbox without disabling it' do
+          visit dashboard_form_work_version_type_path(work_version)
+
+          expect(page).to have_field('open_access_upload_checkbox', type: 'checkbox', disabled: false, checked: true)
+        end
       end
     end
 


### PR DESCRIPTION
This will make sure the checkbox cannot be unchecked if the user returns to the "Work Type" page after selecting the open access workflow.