### PR TITLE
Send most recent published version that is not remediated for curation

### DIFF
--- a/app/services/curation_sync_service.rb
+++ b/app/services/curation_sync_service.rb
@@ -9,9 +9,10 @@ class CurationSyncService
     retries ||= 0
     tasks = CurationTaskClient.find_all(@work.id)
     task_uuids = tasks.pluck('ID')
+    work_version = current_version_for_curation
 
-    if able_to_curate(task_uuids)
-      CurationTaskClient.send_curation(current_version_for_curation.id, updated_version: updated_version(tasks))
+    if able_to_curate(task_uuids, work_version)
+      CurationTaskClient.send_curation(work_version.id, updated_version: updated_version(tasks, work_version))
     end
   rescue CurationTaskClient::CurationError => e
     retry if (retries += 1) < 3 && e.message.match(/5[0-9][0-9]/)
@@ -21,27 +22,24 @@ class CurationSyncService
 
   private
 
-    def able_to_curate(task_uuids)
-      task_uuids.exclude?(current_version_for_curation.uuid) &&
-        !admin_submitted?(current_version_for_curation) &&
-        current_version_for_curation.sent_for_curation_at.nil? &&
-        !current_version_for_curation.remediated_version
+    def able_to_curate(task_uuids, work_version)
+      work_version.present? &&
+        task_uuids.exclude?(work_version.uuid) &&
+        !admin_submitted?(work_version) &&
+        work_version.sent_for_curation_at.nil? &&
+        !work_version.remediated_version
     end
 
     def current_version_for_curation
       if @work.latest_version.draft_curation_requested == true
         @work.latest_version
       else
-        @work.latest_published_version
+        @work.versions.published.where(remediated_version: false).last
       end
     end
 
-    def updated_version(tasks)
-      stale_version = false
-      tasks.each do |task|
-        stale_version = true unless task.fields['ID'] == current_version_for_curation.uuid
-      end
-      stale_version
+    def updated_version(tasks, work_version)
+      tasks.any? { |task| task.fields['ID'] != work_version.uuid }
     end
 
     def admin_submitted?(work_version)

--- a/spec/services/curation_sync_service_spec.rb
+++ b/spec/services/curation_sync_service_spec.rb
@@ -118,6 +118,28 @@ RSpec.describe CurationSyncService do
 
             described_class.new(work).sync
           end
+
+          context 'when a previous version has not been sent for curation' do
+            let(:work_version4) { build(:work_version,
+                                        work: nil,
+                                        aasm_state: 'published',
+                                        draft_curation_requested: nil,
+                                        remediated_version: true,
+                                        published_at: Time.new(2024, 3, 10, 11, 30, 0))
+            }
+
+            before do
+              work.versions << work_version4
+              allow(CurationTaskClient).to receive(:find_all).with(work.id).and_return([])
+            end
+
+            it 'sends the latest non-remediated published version for curation' do
+              expect(CurationTaskClient).to receive(:send_curation).with(work_version2.id, updated_version: false)
+              expect(CurationTaskClient).not_to receive(:send_curation).with(work_version4.id)
+
+              described_class.new(work).sync
+            end
+          end
         end
 
         context 'when current version for curation has not been remediated' do

--- a/spec/services/curation_sync_service_spec.rb
+++ b/spec/services/curation_sync_service_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe CurationSyncService do
       end
 
       context 'when current version for curation has not been sent for curation' do
-        context 'when current version for curation has been remediated' do
+        context 'when the most recent published version for curation has been remediated' do
           it 'does not send for curation' do
             work_version2.update remediated_version: true
             expect(CurationTaskClient).not_to receive(:send_curation).with(work_version2.id)


### PR DESCRIPTION
When a work version is created _and_ remediated in the same day, nothing gets sent to AirTable because the most recent published version is a remediated version.  These changes make it so the most recent published version that is not remediated is sent to AirTable.