### PR TITLE
Use boolean cast on publish param to handle string and boolean types

### DIFF
--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -139,7 +139,7 @@ module Api::V1
       end
 
       def publish_params
-        params.fetch(:publish, 'true') == 'true'
+        ActiveModel::Type::Boolean.new.cast(params.fetch(:publish, true))
       end
   end
 end

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -208,7 +208,16 @@ RSpec.describe Api::V1::IngestController do
       end
     end
 
-    context 'with publish: false', vcr: VCRHelpers.depositor_cassette do
+    context 'with publish:', vcr: VCRHelpers.depositor_cassette do
+      let(:publish_value) { true }
+      let(:published_response) do
+        "{\"message\":\"Work was successfully created\",\"url\":\"/resources/#{Work.last.uuid}\"}"
+      end
+      let(:draft_response) do
+        "{\"message\":\"Work was successfully created\",\"url\":\"/resources/#{Work.last.uuid}\"," +
+          "\"edit_url\":\"/dashboard/form/work_versions/#{Work.last.latest_version.id}/files\"}"
+      end
+
       before do
         post :create, params: {
           metadata: {
@@ -222,19 +231,56 @@ RSpec.describe Api::V1::IngestController do
           },
           depositor: depositor,
           content: [{ file: fixture_file_upload(File.join(fixture_paths, 'image.png')) }],
-          publish: false
+          publish: publish_value
         }
       end
 
-      it 'creates a new work without publishing' do
-        expect(response).to be_created
-        expect(response.body).to eq(
-          "{\"message\":\"Work was successfully created\",\"url\":\"/resources/#{Work.last.uuid}\"," +
-          "\"edit_url\":\"/dashboard/form/work_versions/#{Work.last.latest_version.id}/files\"}"
-        )
-        expect(Api::V1::WorkCreator).to have_received(:call).with(
-          a_hash_including(external_app: api_token.application)
-        )
+      context 'when true' do
+        let(:publish_value) { true }
+
+        it 'publishes the work' do
+          expect(response).to be_ok
+          expect(response.body).to eq(published_response)
+          expect(Api::V1::WorkCreator).to have_received(:call).with(
+            a_hash_including(external_app: api_token.application)
+          )
+        end
+      end
+
+      context "when 'true'" do
+        let(:publish_value) { 'true' }
+
+        it 'publishes the work' do
+          expect(response).to be_ok
+          expect(response.body).to eq(published_response)
+          expect(Api::V1::WorkCreator).to have_received(:call).with(
+            a_hash_including(external_app: api_token.application)
+          )
+        end
+      end
+
+      context 'when false' do
+        let(:publish_value) { false }
+
+        it 'does not publish the work' do
+          expect(response).to be_created
+          expect(response.body).to eq(draft_response)
+          expect(Api::V1::WorkCreator).to have_received(:call).with(
+            a_hash_including(external_app: api_token.application)
+          )
+        end
+      end
+
+      context "when 'false'" do
+        let(:publish_value) { 'false' }
+
+        it 'does not publish the work' do
+          expect(response).to be_created
+          expect(response.body).to eq(draft_response)
+          expect(Api::V1::WorkCreator).to have_received(:call).with(
+            a_hash_including(external_app: api_token.application)
+          )
+        end
       end
     end
 

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -208,8 +208,7 @@ RSpec.describe Api::V1::IngestController do
       end
     end
 
-    context 'with publish:', vcr: VCRHelpers.depositor_cassette do
-      let(:publish_value) { true }
+    describe 'publish parameter', vcr: VCRHelpers.depositor_cassette do
       let(:published_response) do
         "{\"message\":\"Work was successfully created\",\"url\":\"/resources/#{Work.last.uuid}\"}"
       end
@@ -230,13 +229,12 @@ RSpec.describe Api::V1::IngestController do
             visibility: Permissions::Visibility::OPEN
           },
           depositor: depositor,
-          content: [{ file: fixture_file_upload(File.join(fixture_paths, 'image.png')) }],
-          publish: publish_value
-        }
+          content: [{ file: fixture_file_upload(File.join(fixture_paths, 'image.png')) }]
+        }.merge(publish_param)
       end
 
       context 'when true' do
-        let(:publish_value) { true }
+        let(:publish_param) { { publish: true } }
 
         it 'publishes the work' do
           expect(response).to be_ok
@@ -248,7 +246,7 @@ RSpec.describe Api::V1::IngestController do
       end
 
       context "when 'true'" do
-        let(:publish_value) { 'true' }
+        let(:publish_param) { { publish: 'true' } }
 
         it 'publishes the work' do
           expect(response).to be_ok
@@ -260,7 +258,7 @@ RSpec.describe Api::V1::IngestController do
       end
 
       context 'when false' do
-        let(:publish_value) { false }
+        let(:publish_param) { { publish: false } }
 
         it 'does not publish the work' do
           expect(response).to be_created
@@ -272,11 +270,23 @@ RSpec.describe Api::V1::IngestController do
       end
 
       context "when 'false'" do
-        let(:publish_value) { 'false' }
+        let(:publish_param) { { publish: 'false' } }
 
         it 'does not publish the work' do
           expect(response).to be_created
           expect(response.body).to eq(draft_response)
+          expect(Api::V1::WorkCreator).to have_received(:call).with(
+            a_hash_including(external_app: api_token.application)
+          )
+        end
+      end
+
+      context 'without publish' do
+        let(:publish_param) { {} }
+
+        it 'publishes the work' do
+          expect(response).to be_ok
+          expect(response.body).to eq(published_response)
           expect(Api::V1::WorkCreator).to have_received(:call).with(
             a_hash_including(external_app: api_token.application)
           )


### PR DESCRIPTION
I noticed the Activity Insight Open Access Uploads were failing in RMD.  They actually weren't completely failing, they were just creating drafts instead of publishing the works.  Looks like the way the `publish` param is being handled is the issue.  When `true`, the param gets pulled out as `true` not `'true'`, so the boolean check was returning `false` instead of `true`.  These changes fix that so it can handle booleans and strings acting as booleans.