### PR TITLE
Fix memoization bug in changed work version validator

### DIFF
--- a/app/validators/changed_work_version_validator.rb
+++ b/app/validators/changed_work_version_validator.rb
@@ -17,6 +17,7 @@ class ChangedWorkVersionValidator < ActiveModel::Validator
   private
 
     def identical?
+      previous_version = find_previous_version
       return false if previous_version.nil?
 
       (work_version.file_resources == previous_version.file_resources) &&
@@ -24,7 +25,7 @@ class ChangedWorkVersionValidator < ActiveModel::Validator
         (creators_token == creators_token(previous_version))
     end
 
-    def previous_version
+    def find_previous_version
       WorkVersion.find_by(
         work_id: work_version.work_id,
         version_number: work_version.version_number - 1

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,16 +58,17 @@ Rails.application.configure do
   # Replace the default in-process and non-durable queuing backend for Active Job.
   # config.active_job.queue_adapter = :resque
 
-  config.action_mailer.perform_caching = false
-  config.action_mailer.logger = nil
-  config.action_mailer.delivery_method = ENV.fetch('MAIL_DELIVERY_METHOD', 'test').to_sym
-  config.action_mailer.smtp_settings = {
-    address: ENV.fetch('SMTP_ADDRESS', 'localhost'),
-    port: ENV.fetch('SMTP_PORT', 25),
-    user_name: ENV.fetch('SMTP_USERNAME', nil),
-    password: ENV.fetch('SMTP_PASSWORD', nil),
-    authentication: ENV.fetch('SMTP_AUTHENTICATION_TYPE', nil)
-  }
+  # Specify outgoing SMTP server.
+  # config.action_mailer.perform_caching = false
+  # config.action_mailer.logger = nil
+  # config.action_mailer.delivery_method = ENV.fetch('MAIL_DELIVERY_METHOD', 'test').to_sym
+  # config.action_mailer.smtp_settings = {
+  #   address: ENV.fetch('SMTP_ADDRESS', 'localhost'),
+  #   port: ENV.fetch('SMTP_PORT', 25),
+  #   user_name: ENV.fetch('SMTP_USERNAME', nil),
+  #   password: ENV.fetch('SMTP_PASSWORD', nil),
+  #   authentication: ENV.fetch('SMTP_AUTHENTICATION_TYPE', nil)
+  # }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
This was causing the seed command to fail.

@jrpatterson @AndrewGearhart The `bundle exec rake db:seed` command can be used to seed the uldev preview and main deployments from an empty database.  This command will also create placeholder files for the records in S3.  These records should also reindex solr as they are created, so no need to run the whole solr reindex.

I think this is pretty close to what we do with ETDA Explore.


I also added in the changes to the mailer configuration.  Replacing the environment variable setup with the out-of-the-box Rails 8 defaults.