### PR TITLE
Uncomment production smtp settings

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,6 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
   config.action_mailer.logger = nil
-  config.action_mailer.delivery_method = ENV.fetch('MAIL_DELIVERY_METHOD', 'test').to_sym
   config.action_mailer.smtp_settings = {
     address: ENV.fetch('SMTP_ADDRESS', 'localhost'),
     port: ENV.fetch('SMTP_PORT', 25),


### PR DESCRIPTION
After doing a little probing around and testing, we discovered that these are actually needed.  The only configuration not needed is the delivery_method.  So I removed that.